### PR TITLE
Update MCP Plugin

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@utcp/mcp",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "Model Context Protocol integration for UTCP",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/packages/mcp/src/mcp_communication_protocol.ts
+++ b/packages/mcp/src/mcp_communication_protocol.ts
@@ -99,7 +99,7 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
       };
 
       transport = new StdioClientTransport({
-        command: isWindows ? 'cmd.exe' : '/bin/sh',
+        command: isWindows ? 'cmd.exe' : 'sh',
         args: isWindows ? ['/c', commandString] : ['-c', commandString],
         cwd: stdioConfig.cwd,
         env: combinedEnv,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes Linux shell invocation in the MCP stdio transport and namespaces tool names to avoid collisions. Updates @utcp/mcp to v1.0.14.

- **Bug Fixes**
  - Use "sh" instead of "/bin/sh" on non-Windows systems for better compatibility.

- **Migration**
  - If you reference tool names, update to the new format: <template>.<server>.<tool>.

<sup>Written for commit 89b3b6259100a6d043133f9ff9af3f33087ebe90. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

