### PR TITLE
Fix mcp defs schema resolution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,20 @@
         "zod": "^3.23.8"
       }
     },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "15.1.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-15.1.2.tgz",
+      "integrity": "sha512-54vnqDyGsDAVM0LOIdGMnfVyCN1NlqoGnHEGpMfaDBLMvClfT4j2XbJgvfuF0Ca0kxT6Gb7xUgS5W1I14QqjiQ==",
+      "dependencies": {
+        "js-yaml": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@types/json-schema": "^7.0.15"
+      }
+    },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.11",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.11.tgz",
@@ -916,6 +930,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "peer": true
+    },
     "node_modules/@types/node": {
       "version": "24.3.0",
       "dev": true,
@@ -935,6 +955,10 @@
     },
     "node_modules/@utcp/cli": {
       "resolved": "packages/cli",
+      "link": true
+    },
+    "node_modules/@utcp/code-mode": {
+      "resolved": "packages/code-mode",
       "link": true
     },
     "node_modules/@utcp/direct-call": {
@@ -1884,8 +1908,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "license": "MIT",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -3078,10 +3103,10 @@
     },
     "packages/cli": {
       "name": "@utcp/cli",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "license": "MPL-2.0",
       "dependencies": {
-        "@utcp/sdk": "^1.0.11"
+        "@utcp/sdk": "^1.0.15"
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -3089,9 +3114,38 @@
         "typescript": "^5.0.0"
       }
     },
+    "packages/code-mode": {
+      "name": "@utcp/code-mode",
+      "version": "1.0.5",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@utcp/sdk": "^1.0.17"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "@utcp/direct-call": "^1.0.12",
+        "bun-types": "latest",
+        "typescript": "^5.0.0"
+      }
+    },
+    "packages/code-mode/node_modules/@types/node": {
+      "version": "20.19.25",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.25.tgz",
+      "integrity": "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "packages/code-mode/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true
+    },
     "packages/core": {
       "name": "@utcp/sdk",
-      "version": "1.0.14",
+      "version": "1.0.17",
       "license": "MPL-2.0",
       "dependencies": {
         "dotenv": "^17.2.1",
@@ -3104,10 +3158,10 @@
     },
     "packages/direct-call": {
       "name": "@utcp/direct-call",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "license": "MPL-2.0",
       "dependencies": {
-        "@utcp/sdk": "^1.0.11"
+        "@utcp/sdk": "^1.0.15"
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -3117,7 +3171,7 @@
     },
     "packages/dotenv-loader": {
       "name": "@utcp/dotenv-loader",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MPL-2.0",
       "dependencies": {
         "dotenv": "^17.2.1",
@@ -3128,16 +3182,16 @@
         "typescript": "^5.0.0"
       },
       "peerDependencies": {
-        "@utcp/sdk": "^1.0.8"
+        "@utcp/sdk": "^1.0.15"
       }
     },
     "packages/file": {
       "name": "@utcp/file",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MPL-2.0",
       "dependencies": {
-        "@utcp/http": "^1.0.7",
-        "@utcp/sdk": "^1.0.8",
+        "@utcp/http": "^1.0.13",
+        "@utcp/sdk": "^1.0.15",
         "js-yaml": "^4.1.0"
       },
       "devDependencies": {
@@ -3148,10 +3202,10 @@
     },
     "packages/http": {
       "name": "@utcp/http",
-      "version": "1.0.12",
+      "version": "1.0.13",
       "license": "MPL-2.0",
       "dependencies": {
-        "@utcp/sdk": "^1.0.14",
+        "@utcp/sdk": "^1.0.15",
         "axios": "^1.11.0",
         "js-yaml": "^4.1.0"
       },
@@ -3163,11 +3217,12 @@
     },
     "packages/mcp": {
       "name": "@utcp/mcp",
-      "version": "1.0.11",
+      "version": "1.0.16",
       "license": "MPL-2.0",
       "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "^15.1.2",
         "@modelcontextprotocol/sdk": "^1.17.4",
-        "@utcp/sdk": "^1.0.11",
+        "@utcp/sdk": "^1.0.15",
         "axios": "^1.11.0"
       },
       "devDependencies": {
@@ -3179,11 +3234,11 @@
     },
     "packages/text": {
       "name": "@utcp/text",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "license": "MPL-2.0",
       "dependencies": {
-        "@utcp/http": "^1.0.11",
-        "@utcp/sdk": "^1.0.11",
+        "@utcp/http": "^1.0.13",
+        "@utcp/sdk": "^1.0.15",
         "js-yaml": "^4.1.0"
       },
       "devDependencies": {

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -5,6 +5,7 @@ The `@utcp/mcp` package enables the `UtcpClient` to interact with tools defined 
 ## Features
 
 *   **Automatic Plugin Registration**: Registers automatically when imported—no manual setup required.
+*   **FastMCP 2.0+ Compatibility**: Automatically resolves JSON Schema `$defs` references, ensuring compatibility with modern MCP servers built on FastMCP 2.0+.
 *   **MCP `CallTemplate`**: Defines the configuration for connecting to one or more MCP servers (`McpCallTemplate`), including:
     *   Transport type (`stdio` or `http`)
     *   Optional OAuth2 authentication for HTTP-based servers
@@ -215,6 +216,25 @@ MCP servers can expose resources (files, data sources, etc.) alongside tools. To
   register_resources_as_tools: true  // Exposes server resources as tools
 }
 ```
+
+## FastMCP Compatibility
+
+Starting with version 1.0.17, this plugin automatically handles JSON Schema `$defs` references used by FastMCP 2.0+ servers. This resolves the issue where tool discovery would fail with:
+
+```
+MissingRefError: can't resolve reference #/$defs/...
+```
+
+**How it works:**
+- When tools are discovered from MCP servers, their input and output schemas are automatically dereferenced
+- `$defs` references are resolved and inlined into the schema
+- This process is transparent and requires no configuration changes
+- If dereferencing fails for any reason, the original schema is used as a fallback
+
+This ensures seamless integration with:
+- `basic-memory` and other FastMCP-based servers
+- Any MCP server using modern JSON Schema draft-2020-12 features
+- Legacy MCP servers (which continue to work as before)
 
 ## Tool Naming Convention
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -44,6 +44,7 @@
     "build": "tsup"
   },
   "dependencies": {
+    "@apidevtools/json-schema-ref-parser": "^15.1.2",
     "@modelcontextprotocol/sdk": "^1.17.4",
     "@utcp/sdk": "^1.0.15",
     "axios": "^1.11.0"


### PR DESCRIPTION
Referencing issue https://github.com/universal-tool-calling-protocol/code-mode/issues/10


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix JSON Schema resolution for MCP tool discovery by dereferencing $refs and $defs. Restores compatibility with FastMCP 2.0+ servers and removes MissingRefError during tool listing.

- **Bug Fixes**
  - Dereference input/output schemas during tool discovery to inline $refs/$defs (FastMCP 2.0+). Prevents "MissingRefError: can't resolve reference #/$defs/...". Falls back to the original schema on failure and remains backward compatible.

- **Dependencies**
  - Add @apidevtools/json-schema-ref-parser.

<sup>Written for commit ddc02a53e2f4e18e504eea208ae1882f081142d3. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

