### PR TITLE
fix(mcp): use configured timeout instead of hardcoded 15s

### DIFF
--- a/packages/mcp/src/mcp_call_template.ts
+++ b/packages/mcp/src/mcp_call_template.ts
@@ -22,6 +22,7 @@ export interface McpStdioServer {
   args: string[];
   cwd?: string;
   env: Record<string, string>;
+  timeout: number;
 }
 
 /**
@@ -33,6 +34,7 @@ export const McpStdioServerSchema: z.ZodType<McpStdioServer> = z.object({
   args: z.array(z.string()).optional().default([]).describe('Arguments to pass to the command.'),
   cwd: z.string().optional().describe('Working directory for the command.'),
   env: z.record(z.string(), z.string()).optional().default({}).describe('Environment variables for the command.'),
+  timeout: z.number().optional().default(30).describe('Timeout for MCP operations in seconds.'),
 }) as z.ZodType<McpStdioServer>;
 
 


### PR DESCRIPTION
## Summary

The `timeout` field was defined in `McpHttpServerSchema` but never actually used in the implementation. `_withSession()` had a hardcoded 15000ms (15s) timeout which caused issues with slow MCP servers (e.g., LLM providers like PAL via OpenRouter that need 30-60s+ for responses).

## Changes

- Add `timeout` field to `McpStdioServerSchema` for consistency with HTTP servers
- Use `serverConfig.timeout` in `_withSession()` instead of hardcoded 15s
- Default timeout increased from 15s to 30s to match the existing schema default

## Before

```typescript
// Hardcoded 15s timeout, ignoring config
new Promise<T>((_, reject) => setTimeout(() => reject(...), 15000))
```

## After

```typescript
const timeoutMs = (serverConfig.timeout ?? 30) * 1000;
new Promise<T>((_, reject) => setTimeout(() => reject(...), timeoutMs))
```

## Usage

Users can now configure timeout per-server in their `.utcp_config.json`:

```json
{
  "manual_call_templates": [{
    "name": "pal",
    "call_template_type": "mcp",
    "config": {
      "mcpServers": {
        "pal": {
          "transport": "stdio",
          "command": "...",
          "timeout": 120
        }
      }
    }
  }]
}
```

## Related Issues

Fixes https://github.com/universal-tool-calling-protocol/code-mode/issues/20



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the configured MCP timeout instead of a hardcoded 15s to avoid premature failures with slow MCP servers. Default is 30s; set per-server timeouts in .utcp_config.json (fixes code-mode #20).

- **Bug Fixes**
  - Respect serverConfig.timeout in _withSession() (including retry path).
  - Add timeout to McpStdioServerSchema for parity with HTTP servers.

<sup>Written for commit 9a3a7a5bdba5e3a0f80a21f21600d94132a3dd2d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



