### PR TITLE
Dev

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "typescript-utcp",
@@ -41,14 +42,15 @@
     },
     "packages/direct-call": {
       "name": "@utcp/direct-call",
-      "version": "1.1.0",
-      "dependencies": {
-        "@utcp/sdk": "^1.1.0",
-      },
+      "version": "1.1.1",
       "devDependencies": {
         "@types/bun": "latest",
+        "@utcp/sdk": "^1.1.0",
         "bun-types": "latest",
         "typescript": "^5.0.0",
+      },
+      "peerDependencies": {
+        "@utcp/sdk": "^1.1.0",
       },
     },
     "packages/dotenv-loader": {
@@ -82,7 +84,7 @@
     },
     "packages/http": {
       "name": "@utcp/http",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "dependencies": {
         "@utcp/sdk": "^1.0.6",
         "axios": "^1.11.0",
@@ -96,7 +98,7 @@
     },
     "packages/mcp": {
       "name": "@utcp/mcp",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^15.1.2",
         "@modelcontextprotocol/sdk": "^1.17.4",
@@ -631,9 +633,9 @@
 
     "@utcp/cli/bun-types": ["bun-types@1.3.0", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-u8X0thhx+yJ0KmkxuEo9HAtdfgCBaM/aI9K90VQcQioAmkVp3SG3FkwWGibUFz3WdXAdcsqOcbU40lK7tbHdkQ=="],
 
-    "@utcp/direct-call/@types/bun": ["@types/bun@1.3.6", "", { "dependencies": { "bun-types": "1.3.6" } }, "sha512-uWCv6FO/8LcpREhenN1d1b6fcspAB+cefwD7uti8C8VffIv0Um08TKMn98FynpTiU38+y2dUO55T11NgDt8VAA=="],
+    "@utcp/direct-call/@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
-    "@utcp/direct-call/bun-types": ["bun-types@1.3.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-OlFwHcnNV99r//9v5IIOgQ9Uk37gZqrNMCcqEaExdkVq3Avwqok1bJFmvGMCkCE0FqzdY8VMOZpfpR3lwI+CsQ=="],
+    "@utcp/direct-call/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
     "@utcp/dotenv-loader/bun-types": ["bun-types@1.3.1", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-NMrcy7smratanWJ2mMXdpatalovtxVggkj11bScuWuiOoXTiKIu2eVS1/7qbyI/4yHedtsn175n4Sm4JcdHLXw=="],
 
@@ -645,7 +647,7 @@
 
     "@utcp/mcp/bun-types": ["bun-types@1.3.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-z3Xwlg7j2l9JY27x5Qn3Wlyos8YAp0kKRlrePAOjgjMGS5IG6E7Jnlx736vH9UVI4wUICwwhC9anYL++XeOgTQ=="],
 
-    "@utcp/sdk/bun-types": ["bun-types@1.3.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-OlFwHcnNV99r//9v5IIOgQ9Uk37gZqrNMCcqEaExdkVq3Avwqok1bJFmvGMCkCE0FqzdY8VMOZpfpR3lwI+CsQ=="],
+    "@utcp/sdk/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
     "@utcp/text/bun-types": ["bun-types@1.3.1", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-NMrcy7smratanWJ2mMXdpatalovtxVggkj11bScuWuiOoXTiKIu2eVS1/7qbyI/4yHedtsn175n4Sm4JcdHLXw=="],
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@utcp/mcp",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Model Context Protocol integration for UTCP",
   "main": "dist/index.cjs",
   "module": "dist/index.js",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Respect per-server timeouts by forwarding `serverConfig.timeout` to MCP SDK `listTools` and `callTool` calls, preventing the SDK’s 60s default from firing first. Adds a helper to compute timeouts in ms with a 30s default.

- **Bug Fixes**
  - Pass `{ timeout: <ms> }` to `listTools` and `callTool` based on `serverConfig.timeout` (defaults to 30s).
  - Test verifies a 90s config is forwarded as `90_000` ms to both calls.

- **Dependencies**
  - Bump `@utcp/mcp` to `1.1.2`.

<sup>Written for commit 012d3fd0127ca84e018f930f75ba3197d6eaf12f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

