### PR TITLE
Dev

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@utcp/cli",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "CLI utilities for UTCP",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@utcp/cli",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "CLI utilities for UTCP",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/packages/cli/src/cli_call_template.ts
+++ b/packages/cli/src/cli_call_template.ts
@@ -6,15 +6,41 @@ import { Serializer } from '@utcp/sdk';
 /**
  * REQUIRED
  * Configuration for a single command step in a CLI execution flow.
- * 
+ *
  * Attributes:
  *     command: The command string to execute. Can contain UTCP_ARG_argname_UTCP_END
  *         placeholders that will be replaced with values from tool_args. Can also
  *         reference previous command outputs using $CMD_0_OUTPUT, $CMD_1_OUTPUT, etc.
+ *
+ *         Placeholders are NOT inlined as text. Instead the protocol
+ *         emits a context-aware shell variable reference (`"$VAR"` /
+ *         `${VAR}` / `$env:VAR`) and ships the actual `tool_args` value
+ *         to the subprocess via an environment variable, so the shell
+ *         expands the value AFTER it has parsed the script. Attacker-
+ *         controlled bytes therefore cannot inject commands or escape
+ *         any quoting context.
+ *
+ *         A placeholder always substitutes a **single logical value**
+ *         (never a list of shell words) -- the substituted value cannot
+ *         be reinterpreted as additional shell syntax. Several
+ *         placeholders may appear within the same quoted region (e.g.
+ *         `"https://api/UTCP_ARG_id_UTCP_END/UTCP_ARG_action_UTCP_END"`)
+ *         and they compose with the surrounding literal text into one
+ *         shell argument. Tools that previously relied on a single
+ *         placeholder splitting into multiple flags (e.g.
+ *         `UTCP_ARG_flags_UTCP_END` -> `--verbose --debug`) must now
+ *         use one placeholder per intended flag. This change ships
+ *         with @utcp/cli 1.1.1.
+ *
+ *         PowerShell limitation: a placeholder appearing inside a
+ *         single-quoted PowerShell string (`'...'`) will throw at
+ *         script-build time -- PowerShell does not expand variables
+ *         inside single quotes, and rewriting the surrounding token
+ *         is too brittle. Use a double-quoted string ("...") instead.
  *     append_to_final_output: Whether this command's output should be included
  *         in the final result. If not specified, defaults to False for all
  *         commands except the last one.
- * 
+ *
  * Examples:
  *     Basic command step:
  *     ```json
@@ -23,7 +49,7 @@ import { Serializer } from '@utcp/sdk';
  *       "append_to_final_output": true
  *     }
  *     ```
- *     
+ *
  *     Command with argument placeholders and output reference:
  *     ```json
  *     {
@@ -34,7 +60,12 @@ import { Serializer } from '@utcp/sdk';
  */
 export interface CommandStep {
   /**
-   * Command string to execute, may contain UTCP_ARG_argname_UTCP_END placeholders
+   * Command string to execute, may contain UTCP_ARG_argname_UTCP_END
+   * placeholders. Each placeholder substitutes a single value via a
+   * shell-variable reference whose form is chosen for the surrounding
+   * quote context; substituted values cannot be reinterpreted as
+   * additional shell syntax. Several placeholders may appear in the
+   * same quoted region and compose into one argument.
    */
   command: string;
   /**
@@ -47,7 +78,16 @@ export interface CommandStep {
  * Zod schema for CommandStep.
  */
 export const CommandStepSchema: z.ZodType<CommandStep> = z.object({
-  command: z.string().describe('Command string to execute, may contain UTCP_ARG_argname_UTCP_END placeholders'),
+  command: z
+    .string()
+    .describe(
+      'Command string to execute, may contain UTCP_ARG_argname_UTCP_END ' +
+        'placeholders. Each placeholder substitutes a single value via a ' +
+        'shell-variable reference chosen for its surrounding quote ' +
+        'context; substituted values cannot be reinterpreted as ' +
+        'additional shell syntax. Several placeholders may appear in ' +
+        'the same quoted region and compose into one argument.',
+    ),
   append_to_final_output: z.boolean().nullable().optional().describe('Whether to include this command\'s output in final result. Defaults to False for all except last command'),
 }).strict() as z.ZodType<CommandStep>;
 
@@ -74,14 +114,71 @@ export const CommandStepSchema: z.ZodType<CommandStep> = z.object({
  * 
  * Example: `echo "Previous result: $CMD_0_OUTPUT"`
  *
+ * **Argument Substitution (@utcp/cli >= 1.1.1):**
+ * `UTCP_ARG_argname_UTCP_END` placeholders are replaced with a
+ * context-aware shell variable reference (`"$VAR"` outside quotes,
+ * `${VAR}` inside double quotes, an adjacent-quote concat trick inside
+ * single-quoted bash). The actual `tool_args` value is shipped to the
+ * subprocess via a fresh, per-invocation env var; the shell expands it
+ * at runtime AFTER it has parsed the script, so attacker-controlled
+ * bytes cannot inject commands or escape any quoting context.
+ *
+ * A placeholder always substitutes a single logical value (never a
+ * list of shell words). Several placeholders may appear in one quoted
+ * region and compose with the surrounding text into one argument
+ * (e.g. `"https://api/UTCP_ARG_id_UTCP_END/UTCP_ARG_action_UTCP_END"`).
+ * If a tool needs multiple separate flags, use one placeholder per
+ * flag in bare position. PowerShell single-quoted strings cannot
+ * expand variables, so a placeholder inside `'...'` on Windows raises
+ * a build-time error; use a double-quoted string instead.
+ *
+ * **Subprocess Environment (@utcp/cli >= 1.1.1):**
+ * The CLI subprocess no longer inherits the full host environment.
+ * Inheritance is controlled by `inherit_env_vars`:
+ *   - Omitted / `null`: a built-in default allowlist of host variables
+ *     is passed through (e.g. `PATH`, `PATHEXT`, `SYSTEMROOT`, `HOME`,
+ *     `LANG`) so shells and binaries can be located normally.
+ *   - `[]`: strict mode -- nothing from the host environment is
+ *     inherited; only `env_vars` is propagated.
+ *   - `["FOO", "BAR"]`: exactly those host variables are passed
+ *     through. The default allowlist is NOT merged in, so callers that
+ *     still need `PATH` must list it explicitly.
+ * `env_vars` is always applied on top and overrides any inherited
+ * value. Values in `env_vars` may be plain strings or `${VARNAME}`
+ * style placeholders resolved by the UTCP client's variable
+ * substitutor (note: those placeholders are resolved against the UTCP
+ * client's variable sources, not against the host shell -- to forward
+ * a host variable by name use `inherit_env_vars`). This closes the
+ * secret-exfiltration vector.
+ *
  * Attributes:
  *     call_template_type: The type of the call template. Must be "cli".
  *     commands: A list of CommandStep objects defining the commands to execute
  *         in order. Each command can contain UTCP_ARG_argname_UTCP_END placeholders
  *         that will be replaced with values from tool_args during execution.
+ *         Placeholders are shell-quoted and therefore expand to exactly
+ *         one shell token (see class docstring).
  *     env_vars: A dictionary of environment variables to set for the command's
  *         execution context. Values can be static strings or placeholders for
- *         variables from the UTCP client's variable substitutor.
+ *         variables from the UTCP client's variable substitutor. Always
+ *         propagated; overrides anything inherited from the host.
+ *     inherit_env_vars: Controls which host environment variables are
+ *         passed through to the subprocess.
+ *           - `undefined` / `null` (default): the built-in default
+ *             allowlist (`PATH`, `HOME`, `LANG` on Unix; `PATH`,
+ *             `PATHEXT`, `SYSTEMROOT`, `USERPROFILE`, etc. on Windows)
+ *             is inherited so shells and binaries work without extra
+ *             configuration.
+ *           - `[]`: strict mode -- no host variables are inherited at
+ *             all. Only `env_vars` reaches the subprocess.
+ *           - `["FOO", "BAR"]`: exactly those host variables are
+ *             inherited. The default allowlist is replaced, not
+ *             extended, so include `PATH` (and any other required
+ *             shell vars) yourself if needed.
+ *         Variables named here that are not set on the host are
+ *         silently skipped. Use this to expose specific host secrets
+ *         such as `OPENAI_API_KEY`, `AWS_PROFILE`, or `NODE_PATH`
+ *         without putting their values in the call template.
  *     working_dir: The working directory from which to run the commands. If not
  *         provided, it defaults to the current process's working directory.
  *     auth: Authentication details. Not applicable to the CLI protocol, so it
@@ -160,6 +257,7 @@ export interface CliCallTemplate extends CallTemplate {
   call_template_type: 'cli';
   commands: CommandStep[];
   env_vars?: Record<string, string> | null;
+  inherit_env_vars?: string[] | null;
   working_dir?: string | null;
   auth?: undefined;
   allowed_communication_protocols?: string[];
@@ -171,8 +269,34 @@ export interface CliCallTemplate extends CallTemplate {
 export const CliCallTemplateSchema: z.ZodType<CliCallTemplate> = z.object({
   name: z.string().optional(),
   call_template_type: z.literal('cli'),
-  commands: z.array(CommandStepSchema).describe('List of commands to execute in order. Each command can contain UTCP_ARG_argname_UTCP_END placeholders.'),
-  env_vars: z.record(z.string(), z.string()).nullable().optional().describe('Environment variables to set when executing the commands'),
+  commands: z
+    .array(CommandStepSchema)
+    .describe(
+      'List of commands to execute in order. Each command can contain ' +
+        'UTCP_ARG_argname_UTCP_END placeholders, which are shell-quoted ' +
+        'on substitution and therefore expand to exactly one shell token.',
+    ),
+  env_vars: z
+    .record(z.string(), z.string())
+    .nullable()
+    .optional()
+    .describe(
+      'Environment variables to set when executing the commands. Always ' +
+        'propagated to the subprocess and override values inherited from ' +
+        'the host.',
+    ),
+  inherit_env_vars: z
+    .array(z.string())
+    .nullable()
+    .optional()
+    .describe(
+      'Controls host environment inheritance. undefined/null (default) ' +
+        'inherits a built-in safe allowlist (PATH, HOME / PATHEXT, ' +
+        'SYSTEMROOT, etc.). [] disables host inheritance entirely. A ' +
+        'list of names replaces the default allowlist with exactly those ' +
+        'variables, so include PATH explicitly if your tool needs it. ' +
+        'Names not set on the host are skipped silently.',
+    ),
   working_dir: z.string().nullable().optional().describe('Working directory for command execution'),
   auth: z.undefined().optional(),
   allowed_communication_protocols: z.array(z.string()).optional().describe('Optional list of allowed communication protocol types for tools within this manual.'),
@@ -200,6 +324,7 @@ export class CliCallTemplateSerializer extends Serializer<CliCallTemplate> {
       call_template_type: obj.call_template_type,
       commands: obj.commands,
       env_vars: obj.env_vars,
+      inherit_env_vars: obj.inherit_env_vars,
       working_dir: obj.working_dir,
       auth: obj.auth,
       allowed_communication_protocols: obj.allowed_communication_protocols,

--- a/packages/cli/src/cli_communication_protocol.ts
+++ b/packages/cli/src/cli_communication_protocol.ts
@@ -248,8 +248,12 @@ export class CliCommunicationProtocol implements CommunicationProtocol {
    *                                                as a single token)
    *
    *   powershell (Windows):
-   *     - bare:                   `$env:VAR`
-   *     - inside double quotes:   `$env:VAR`      (PS expands inside dq)
+   *     - bare:                   `${env:VAR}`
+   *     - inside double quotes:   `${env:VAR}`    (PS expands inside dq;
+   *                                                braced form prevents
+   *                                                suffix characters
+   *                                                from being consumed
+   *                                                into the var name)
    *     - inside single quotes:   error -- PS does not expand inside
    *                                        single-quoted strings, so
    *                                        we cannot safely substitute
@@ -403,7 +407,15 @@ export class CliCommunicationProtocol implements CommunicationProtocol {
         const v = collect(m[1]);
         // Both bare and dq accept `$env:VAR` -- PowerShell expands it
         // inside double-quoted strings.
-        out.push(`$env:${v}`);
+        // Use the braced form `${env:VAR}` rather than `$env:VAR` so
+        // the variable name is explicitly delimited. The bare form lets
+        // PowerShell's lexer keep consuming alphanumerics + `_` until
+        // it hits a non-identifier char, which would silently swallow
+        // any suffix text in the template (e.g. template
+        // `"URL=UTCP_ARG_id_UTCP_END123"` would substitute as
+        // `"URL=$env:__UTCP_ARG_<nonce>_id123"` and resolve an env var
+        // that does not exist). Braces close that boundary cleanly.
+        out.push(`\${env:${v}}`);
         i += m[0].length;
         continue;
       }

--- a/packages/cli/src/cli_communication_protocol.ts
+++ b/packages/cli/src/cli_communication_protocol.ts
@@ -82,8 +82,15 @@ export class CliCommunicationProtocol implements CommunicationProtocol {
     'PATH', 'PATHEXT', 'SYSTEMROOT', 'SYSTEMDRIVE', 'WINDIR', 'COMSPEC',
     'TEMP', 'TMP', 'USERPROFILE', 'USERNAME', 'USERDOMAIN', 'COMPUTERNAME',
     'HOMEDRIVE', 'HOMEPATH', 'APPDATA', 'LOCALAPPDATA', 'PROGRAMDATA',
+    'ALLUSERSPROFILE', 'PUBLIC',
     'PROGRAMFILES', 'PROGRAMFILES(X86)', 'PROGRAMW6432', 'OS',
-    'PROCESSOR_ARCHITECTURE', 'NUMBER_OF_PROCESSORS',
+    'PROCESSOR_ARCHITECTURE', 'PROCESSOR_IDENTIFIER',
+    'PROCESSOR_LEVEL', 'PROCESSOR_REVISION', 'NUMBER_OF_PROCESSORS',
+    // PowerShell + login session bits. Without PSMODULEPATH in
+    // particular, powershell.exe has to enumerate module roots from
+    // scratch on first use, which can cost 5-15s on CI runners and
+    // silently push the discovery flow past its timeout.
+    'PSMODULEPATH', 'LOGONSERVER', 'SESSIONNAME', 'USERDNSDOMAIN',
   ];
 
   private _default_inherited_keys(): readonly string[] {
@@ -597,7 +604,11 @@ export class CliCommunicationProtocol implements CommunicationProtocol {
       const { stdout, stderr, exitCode } = await this._executeShellScript(shellScript, {
         cwd: cliCallTemplate.working_dir || undefined,
         env,
-      }, 30000);
+        // 60s, not 30s: Windows PowerShell startup on CI runners can
+        // be slow (especially the first time in a session, before
+        // module path caches warm up). Discovery runs once per
+        // manual, so a generous ceiling here is cheap.
+      }, 60000);
 
       // Get output based on exit code
       const output = exitCode === 0 ? stdout : stderr;

--- a/packages/cli/src/cli_communication_protocol.ts
+++ b/packages/cli/src/cli_communication_protocol.ts
@@ -28,6 +28,7 @@ import { CliCallTemplate, CliCallTemplateSchema, CommandStep } from './cli_call_
 import { spawn, ChildProcess } from 'child_process';
 import { clearTimeout } from 'timers';
 import { Readable } from 'stream';
+import { randomBytes } from 'crypto';
 
 /**
  * REQUIRED
@@ -55,19 +56,90 @@ export class CliCommunicationProtocol implements CommunicationProtocol {
   }
 
   /**
+   * Default set of host environment variables propagated to the CLI
+   * subprocess when `CliCallTemplate.inherit_env_vars` is not provided
+   * (i.e. undefined / null). Locating binaries (`PATH` / `PATHEXT`),
+   * basic shell + locale state, and Windows runtime paths are needed for
+   * almost any tool to start. Anything else (cloud creds, API keys,
+   * internal tokens) must be opted in by listing the variable name in
+   * `inherit_env_vars`, or its value provided in `env_vars`.
+   *
+   * If `inherit_env_vars === []`, the caller is opting into strict mode
+   * and NOTHING is inherited from the host -- only `env_vars` reaches
+   * the subprocess.
+   *
+   * Backs GHSA-r8j5-8747-88cm (sister advisory of python-utcp's
+   * GHSA-5v57-8rxj-3p2r): the previous implementation handed the full
+   * `process.env` to the subprocess, which combined with the command
+   * injection in `_substitute_utcp_args` let an attacker exfiltrate
+   * every secret in the host process.
+   */
+  private static readonly _DEFAULT_INHERITED_KEYS_UNIX: readonly string[] = [
+    'PATH', 'HOME', 'LANG', 'LC_ALL', 'LC_CTYPE', 'USER', 'LOGNAME',
+    'SHELL', 'TZ', 'TERM',
+  ];
+  private static readonly _DEFAULT_INHERITED_KEYS_WINDOWS: readonly string[] = [
+    'PATH', 'PATHEXT', 'SYSTEMROOT', 'SYSTEMDRIVE', 'WINDIR', 'COMSPEC',
+    'TEMP', 'TMP', 'USERPROFILE', 'USERNAME', 'USERDOMAIN', 'COMPUTERNAME',
+    'HOMEDRIVE', 'HOMEPATH', 'APPDATA', 'LOCALAPPDATA', 'PROGRAMDATA',
+    'PROGRAMFILES', 'PROGRAMFILES(X86)', 'PROGRAMW6432', 'OS',
+    'PROCESSOR_ARCHITECTURE', 'NUMBER_OF_PROCESSORS',
+  ];
+
+  private _default_inherited_keys(): readonly string[] {
+    return process.platform === 'win32'
+      ? CliCommunicationProtocol._DEFAULT_INHERITED_KEYS_WINDOWS
+      : CliCommunicationProtocol._DEFAULT_INHERITED_KEYS_UNIX;
+  }
+
+  /**
    * Prepare environment variables for command execution.
-   * 
+   *
+   * Composes the subprocess environment with one layer of host
+   * inheritance (controlled by `provider.inherit_env_vars`) plus
+   * `provider.env_vars` on top:
+   *
+   *   - `inherit_env_vars` undefined / null (default): pass through the
+   *     built-in default allowlist of host vars (`PATH`, `HOME` /
+   *     `PATHEXT`, `SYSTEMROOT`, etc.) so normal shells and binaries
+   *     work without extra wiring.
+   *   - `inherit_env_vars === []`: strict mode. Nothing from the host
+   *     environment reaches the subprocess -- only `env_vars`.
+   *   - `inherit_env_vars === [...]`: pass through exactly the named
+   *     host variables. The default allowlist is NOT merged in, so
+   *     callers who still want `PATH` must include it explicitly.
+   *
+   * `env_vars` is always applied last and overrides anything inherited
+   * from the host.
+   *
    * @param provider The CLI provider
    * @returns Environment variables dictionary
    */
   private _prepare_environment(provider: CliCallTemplate): Record<string, string> {
-    const env = { ...process.env } as Record<string, string>;
-    
-    // Add custom environment variables if provided
-    if (provider.env_vars) {
-      Object.assign(env, provider.env_vars);
+    const inheritedKeys: readonly string[] =
+      provider.inherit_env_vars === undefined || provider.inherit_env_vars === null
+        ? this._default_inherited_keys()
+        : provider.inherit_env_vars;
+
+    const env: Record<string, string> = {};
+    for (const key of inheritedKeys) {
+      const value = process.env[key];
+      if (value !== undefined) {
+        env[key] = value;
+      }
     }
-    
+
+    // Caller-supplied variables override anything inherited from the
+    // host. Skip undefined values so they don't appear as the literal
+    // string "undefined" in the subprocess.
+    if (provider.env_vars) {
+      for (const [k, v] of Object.entries(provider.env_vars)) {
+        if (v !== undefined && v !== null) {
+          env[k] = String(v);
+        }
+      }
+    }
+
     return env;
   }
 
@@ -83,12 +155,14 @@ export class CliCommunicationProtocol implements CommunicationProtocol {
     let childProcess: ChildProcess | undefined;
 
     try {
-      const currentProcessEnv = typeof process !== 'undefined' ? process.env : {};
-      const mergedEnv = { ...currentProcessEnv, ...options.env };
-
+      // IMPORTANT: do NOT merge `process.env` here. `_prepare_environment`
+      // is responsible for assembling the subprocess environment with the
+      // proper allowlist + caller-supplied overrides. Re-adding the full
+      // host environment at this layer would silently undo the
+      // restriction and re-introduce GHSA-r8j5-8747-88cm-style leaks.
       childProcess = spawn(shell, args, {
         cwd: options.cwd,
-        env: mergedEnv,
+        env: options.env,
         stdio: ['ignore', 'pipe', 'pipe'],
       });
 
@@ -130,35 +204,284 @@ export class CliCommunicationProtocol implements CommunicationProtocol {
   }
 
   /**
-   * Substitute UTCP_ARG placeholders in command string with tool arguments.
-   * 
-   * @param command Command string containing UTCP_ARG_argname_UTCP_END placeholders
-   * @param toolArgs Dictionary of argument names and values
-   * @returns Command string with placeholders replaced by actual values
+   * Generate an unguessable nonce that namespaces the env vars used for
+   * argument substitution within a single tool invocation. Prevents a
+   * template author from being able to write a literal
+   * `${__UTCP_ARG_<nonce>_<name>}` reference that collides with our
+   * substitution slot, which would re-introduce
+   * unquoted-variable-expansion injection.
    */
-  private _substitute_utcp_args(command: string, toolArgs: Record<string, any>): string {
-    const pattern = /UTCP_ARG_([a-zA-Z0-9_]+?)_UTCP_END/g;
-    return command.replace(pattern, (match, argName) => {
-      if (argName in toolArgs) {
-        // Return the raw value. The shell will handle it correctly when it's inside quotes
-        // in the final command (e.g., echo "Initial message: Workflow Argument").
-        return String(toolArgs[argName]);
+  private static _make_nonce(): string {
+    return randomBytes(8).toString('hex');
+  }
+
+  /**
+   * Compute the env-var name that carries one substituted tool_arg
+   * value into the subprocess. The nonce is fresh per invocation so
+   * `${__UTCP_ARG_<nonce>_<name>}` literals cannot exist in templates
+   * authored before invocation time.
+   */
+  private static _env_var_name(nonce: string, argName: string): string {
+    return `__UTCP_ARG_${nonce}_${argName}`;
+  }
+
+  /**
+   * Substitute `UTCP_ARG_<name>_UTCP_END` placeholders in a command
+   * string by emitting context-appropriate shell variable references
+   * and recording the actual values as env vars on the returned object.
+   * The caller wires those env vars into the subprocess (alongside the
+   * call template's `env_vars` and host-inheritance allowlist) so the
+   * shell expands them at runtime, AFTER it has already parsed the
+   * script. As a result, attacker-controlled `toolArgs` never get
+   * spliced into the script source and therefore cannot inject
+   * commands or escape any quoting context.
+   *
+   * Quote-state tracking ensures the emitted reference is correct for
+   * its surrounding context:
+   *
+   *   bash (Unix):
+   *     - bare:                   `"$VAR"`        (quoted: no word splitting)
+   *     - inside double quotes:   `${VAR}`        (bash expands inside dq)
+   *     - inside single quotes:   `'"$VAR"'`      (close sq, dq with var,
+   *                                                reopen sq -- bash treats
+   *                                                adjacent quoted regions
+   *                                                as a single token)
+   *
+   *   powershell (Windows):
+   *     - bare:                   `$env:VAR`
+   *     - inside double quotes:   `$env:VAR`      (PS expands inside dq)
+   *     - inside single quotes:   error -- PS does not expand inside
+   *                                        single-quoted strings, so
+   *                                        we cannot safely substitute
+   *                                        without rewriting the entire
+   *                                        surrounding token. Author
+   *                                        must use a double-quoted
+   *                                        string.
+   *
+   * Backs the sister advisory of python-utcp's GHSA-33p6-5jxp-p3x4.
+   * An earlier fix that did inline `shlex.quote`-style substitution was
+   * still vulnerable when the placeholder sat inside a surrounding `"`
+   * region: e.g. template `curl "https://api/UTCP_ARG_id_UTCP_END"`
+   * with `id = '"; rm -rf /; "'` produced
+   * `curl "https://api/'"; rm -rf /; "'"`, where bash's parser closed
+   * the outer dq early and ran the injected commands.
+   *
+   * @param command  Command string containing UTCP_ARG_<name>_UTCP_END placeholders
+   * @param toolArgs Dictionary of argument names and values
+   * @param nonce    Per-invocation nonce used to namespace generated env vars
+   * @returns        { command, env } where `command` is safe to embed in a
+   *                 shell script and `env` is the additional env vars the
+   *                 subprocess must receive for the references to expand.
+   */
+  private _substitute_utcp_args(
+    command: string,
+    toolArgs: Record<string, any>,
+    nonce: string,
+  ): { command: string; env: Record<string, string> } {
+    return process.platform === 'win32'
+      ? this._substitute_powershell(command, toolArgs, nonce)
+      : this._substitute_bash(command, toolArgs, nonce);
+  }
+
+  private _substitute_bash(
+    command: string,
+    toolArgs: Record<string, any>,
+    nonce: string,
+  ): { command: string; env: Record<string, string> } {
+    const env: Record<string, string> = {};
+    const out: string[] = [];
+    const phRe = /^UTCP_ARG_([a-zA-Z0-9_]+?)_UTCP_END/;
+    let state: 'normal' | 'dq' | 'sq' = 'normal';
+    let i = 0;
+
+    const collect = (name: string): string => {
+      const v = CliCommunicationProtocol._env_var_name(nonce, name);
+      if (name in toolArgs) {
+        env[v] = String(toolArgs[name]);
+      } else {
+        this._log_error(`Missing argument '${name}' for placeholder in command: ${command}`);
+        env[v] = `MISSING_ARG_${name}`;
       }
-      this._log_error(`Missing argument '${argName}' for placeholder in command: ${command}`);
-      return `MISSING_ARG_${argName}`;
-    });
+      return v;
+    };
+
+    while (i < command.length) {
+      const m = command.slice(i).match(phRe);
+      if (m) {
+        const v = collect(m[1]);
+        if (state === 'normal') {
+          out.push(`"$${v}"`);
+        } else if (state === 'dq') {
+          out.push(`\${${v}}`);
+        } else {
+          // sq: break out, dq the var, reopen sq. Adjacent quoted
+          // regions concatenate into one token.
+          out.push(`'"$${v}"'`);
+        }
+        i += m[0].length;
+        continue;
+      }
+
+      const ch = command[i];
+      if (state === 'normal') {
+        if (ch === "'") {
+          state = 'sq';
+          out.push(ch);
+        } else if (ch === '"') {
+          state = 'dq';
+          out.push(ch);
+        } else if (ch === '\\' && i + 1 < command.length) {
+          out.push(ch);
+          out.push(command[i + 1]);
+          i += 2;
+          continue;
+        } else {
+          out.push(ch);
+        }
+      } else if (state === 'dq') {
+        if (ch === '\\' && i + 1 < command.length && '"\\$`\n'.includes(command[i + 1])) {
+          out.push(ch);
+          out.push(command[i + 1]);
+          i += 2;
+          continue;
+        }
+        if (ch === '"') {
+          state = 'normal';
+          out.push(ch);
+        } else {
+          out.push(ch);
+        }
+      } else {
+        // sq: only `'` ends the string. No expansion, no escapes.
+        if (ch === "'") {
+          state = 'normal';
+          out.push(ch);
+        } else {
+          out.push(ch);
+        }
+      }
+      i++;
+    }
+
+    return { command: out.join(''), env };
+  }
+
+  private _substitute_powershell(
+    command: string,
+    toolArgs: Record<string, any>,
+    nonce: string,
+  ): { command: string; env: Record<string, string> } {
+    const env: Record<string, string> = {};
+    const out: string[] = [];
+    const phRe = /^UTCP_ARG_([a-zA-Z0-9_]+?)_UTCP_END/;
+    let state: 'normal' | 'dq' | 'sq' = 'normal';
+    let i = 0;
+
+    const collect = (name: string): string => {
+      const v = CliCommunicationProtocol._env_var_name(nonce, name);
+      if (name in toolArgs) {
+        env[v] = String(toolArgs[name]);
+      } else {
+        this._log_error(`Missing argument '${name}' for placeholder in command: ${command}`);
+        env[v] = `MISSING_ARG_${name}`;
+      }
+      return v;
+    };
+
+    while (i < command.length) {
+      const m = command.slice(i).match(phRe);
+      if (m) {
+        if (state === 'sq') {
+          throw new Error(
+            `Placeholder UTCP_ARG_${m[1]}_UTCP_END appears inside a ` +
+              `PowerShell single-quoted string in command: ${command}\n` +
+              `PowerShell does not expand variables inside single quotes, ` +
+              `so this cannot be substituted safely. Use a double-quoted ` +
+              `string ("...") around the placeholder instead.`,
+          );
+        }
+        const v = collect(m[1]);
+        // Both bare and dq accept `$env:VAR` -- PowerShell expands it
+        // inside double-quoted strings.
+        out.push(`$env:${v}`);
+        i += m[0].length;
+        continue;
+      }
+
+      const ch = command[i];
+      if (state === 'normal') {
+        if (ch === "'") {
+          state = 'sq';
+          out.push(ch);
+        } else if (ch === '"') {
+          state = 'dq';
+          out.push(ch);
+        } else if (ch === '`' && i + 1 < command.length) {
+          out.push(ch);
+          out.push(command[i + 1]);
+          i += 2;
+          continue;
+        } else {
+          out.push(ch);
+        }
+      } else if (state === 'dq') {
+        if (ch === '`' && i + 1 < command.length) {
+          out.push(ch);
+          out.push(command[i + 1]);
+          i += 2;
+          continue;
+        }
+        if (ch === '"') {
+          state = 'normal';
+          out.push(ch);
+        } else {
+          out.push(ch);
+        }
+      } else {
+        // PS sq: `''` is an escaped single quote inside the literal.
+        if (ch === "'" && i + 1 < command.length && command[i + 1] === "'") {
+          out.push(ch);
+          out.push(command[i + 1]);
+          i += 2;
+          continue;
+        }
+        if (ch === "'") {
+          state = 'normal';
+          out.push(ch);
+        } else {
+          out.push(ch);
+        }
+      }
+      i++;
+    }
+
+    return { command: out.join(''), env };
   }
   
   /**
    * Build a combined shell script from multiple commands.
-   * 
+   *
+   * Returns both the script and the env-var contributions accumulated
+   * across all command steps. Callers must merge these env vars into
+   * the subprocess environment so the placeholder references the
+   * script writes (`$VAR` / `${VAR}` / `$env:VAR`) actually resolve to
+   * the original tool_arg values at runtime.
+   *
    * @param commands List of CommandStep objects to combine
    * @param toolArgs Tool arguments for placeholder substitution
-   * @returns Shell script string that executes all commands in sequence
+   * @returns        { script, env } — script is the shell script source,
+   *                 env is the additional UTCP_ARG_* env vars to inject.
    */
-  private _build_combined_shell_script(commands: CommandStep[], toolArgs: Record<string, any>): string {
+  private _build_combined_shell_script(
+    commands: CommandStep[],
+    toolArgs: Record<string, any>,
+  ): { script: string; env: Record<string, string> } {
     const isWindows = process.platform === 'win32';
     const scriptLines: string[] = [];
+    const accumulatedEnv: Record<string, string> = {};
+    // One nonce per script -- shared across all command steps so the
+    // env-var contributions land in a consistent namespace.
+    const nonce = CliCommunicationProtocol._make_nonce();
 
     // Add error handling and setup
     if (isWindows) {
@@ -175,11 +498,17 @@ export class CliCommunicationProtocol implements CommunicationProtocol {
     // Execute each command and store output in variables
     for (let i = 0; i < commands.length; i++) {
       const commandStep = commands[i];
-      // Substitute UTCP_ARG placeholders
-      const substitutedCommand = this._substitute_utcp_args(commandStep.command, toolArgs);
-      
+      // Substitute UTCP_ARG placeholders -- emits shell-variable
+      // references, contributes the actual values via env.
+      const { command: substitutedCommand, env: stepEnv } = this._substitute_utcp_args(
+        commandStep.command,
+        toolArgs,
+        nonce,
+      );
+      Object.assign(accumulatedEnv, stepEnv);
+
       const varName = `CMD_${i}_OUTPUT`;
-      
+
       if (isWindows) {
         // PowerShell - capture command output in variable
         scriptLines.push(`\$${varName} = ${substitutedCommand} 2>&1 | Out-String`);
@@ -194,12 +523,12 @@ export class CliCommunicationProtocol implements CommunicationProtocol {
       const commandStep = commands[i];
       const isLastCommand = i === commands.length - 1;
       let shouldAppend = commandStep.append_to_final_output;
-      
+
       if (shouldAppend === null || shouldAppend === undefined) {
         // Default: only append the last command's output
         shouldAppend = isLastCommand;
       }
-      
+
       if (shouldAppend) {
         const varName = `CMD_${i}_OUTPUT`;
         if (isWindows) {
@@ -212,7 +541,7 @@ export class CliCommunicationProtocol implements CommunicationProtocol {
       }
     }
 
-    return scriptLines.join('\n');
+    return { script: scriptLines.join('\n'), env: accumulatedEnv };
   }
 
   /**
@@ -241,9 +570,16 @@ export class CliCommunicationProtocol implements CommunicationProtocol {
 
     try {
       // Execute commands using the same approach as call_tool but with no arguments
-      const env = this._prepare_environment(cliCallTemplate);
-      const shellScript = this._build_combined_shell_script(cliCallTemplate.commands, {});
-      
+      const baseEnv = this._prepare_environment(cliCallTemplate);
+      const { script: shellScript, env: argEnv } = this._build_combined_shell_script(
+        cliCallTemplate.commands,
+        {},
+      );
+      // Per-call UTCP_ARG_* env vars carry placeholder values; layer them
+      // on top of the inherited+caller-supplied env so the references
+      // emitted into the script actually resolve.
+      const env = { ...baseEnv, ...argEnv };
+
       this._log_info(`Executing shell script for tool discovery from provider '${manualCallTemplate.name}'`);
 
       const { stdout, stderr, exitCode } = await this._executeShellScript(shellScript, {
@@ -337,13 +673,19 @@ export class CliCommunicationProtocol implements CommunicationProtocol {
     this._log_info(`Executing CLI tool '${toolName}' with ${cliCallTemplate.commands.length} command(s) in single subprocess`);
     
     try {
-      const env = this._prepare_environment(cliCallTemplate);
-      
-      // Build combined shell script with output capture
-      const shellScript = this._build_combined_shell_script(cliCallTemplate.commands, toolArgs);
-      
+      const baseEnv = this._prepare_environment(cliCallTemplate);
+
+      // Build combined shell script with output capture. The script's
+      // placeholders are emitted as `$VAR` / `${VAR}` / `$env:VAR`
+      // references; the actual tool_arg values come back as `argEnv`.
+      const { script: shellScript, env: argEnv } = this._build_combined_shell_script(
+        cliCallTemplate.commands,
+        toolArgs,
+      );
+      const env = { ...baseEnv, ...argEnv };
+
       this._log_info('Executing combined shell script');
-      
+
       // Execute the combined script in a single subprocess
       const { stdout, stderr, exitCode } = await this._executeShellScript(shellScript, {
         cwd: cliCallTemplate.working_dir || undefined,

--- a/packages/cli/tests/cli_communication_protocol.test.ts
+++ b/packages/cli/tests/cli_communication_protocol.test.ts
@@ -100,9 +100,8 @@ describe('CliCommunicationProtocol (Multi-Command)', () => {
         { command: 'echo "Received: $CMD_0_OUTPUT"' },
       ],
     });
-    
+
     const result = await cliProtocol.callTool(mockClient, 'test.args', { message: 'Workflow Argument' }, callTemplate);
-    // The argument is substituted directly without extra quoting
     expect(result.trim()).toContain('Received: Initial message: Workflow Argument');
   });
   

--- a/packages/cli/tests/security.test.ts
+++ b/packages/cli/tests/security.test.ts
@@ -1,0 +1,569 @@
+// packages/cli/tests/security.test.ts
+//
+// Pin the fixes for the CLI protocol's two historical vulnerabilities:
+//
+//   - Command injection via unsanitized `tool_args` substitution in
+//     `_substitute_utcp_args` (mirror of python-utcp's
+//     GHSA-33p6-5jxp-p3x4).
+//   - Full host environment leaked into the CLI subprocess via
+//     `_prepare_environment` + `_executeShellScript`'s extra
+//     `process.env` re-merge (mirror of python-utcp's
+//     GHSA-5v57-8rxj-3p2r).
+//
+// As of @utcp/cli 1.1.1+, substitution is context-aware: it tracks the
+// surrounding quote state in the template and emits a shell variable
+// reference (`$VAR` / `${VAR}` / `$env:VAR`) for each placeholder, then
+// carries the actual values to the subprocess via env vars. The shell
+// expands them at runtime, AFTER parsing, so attacker-controlled bytes
+// never enter the parser. Each invocation uses a fresh nonce so a
+// template author cannot collide with our injection slot.
+
+import { test, expect, describe, beforeEach, afterEach } from 'bun:test';
+import { CliCommunicationProtocol } from '../src/cli_communication_protocol';
+import { CliCallTemplate, CliCallTemplateSchema, CliCallTemplateSerializer } from '../src/cli_call_template';
+import { IUtcpClient } from '@utcp/sdk';
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs/promises';
+
+const mockClient = { root_dir: process.cwd() } as IUtcpClient;
+
+// The protocol exposes these as private. Cast through `any` once so
+// tests can drive them as unit-level helpers.
+type Privates = {
+  _substitute_utcp_args(
+    command: string,
+    toolArgs: Record<string, any>,
+    nonce: string,
+  ): { command: string; env: Record<string, string> };
+  _prepare_environment(provider: CliCallTemplate): Record<string, string>;
+  _default_inherited_keys(): readonly string[];
+};
+const proto = new CliCommunicationProtocol() as unknown as CliCommunicationProtocol & Privates;
+const NONCE = 'TESTNONCE';
+const expectedVar = (name: string) => `__UTCP_ARG_${NONCE}_${name}`;
+
+const isWindows = process.platform === 'win32';
+
+
+// ---------------------------------------------------------------------------
+// Argument substitution must:
+//   1. NOT splice attacker-controlled bytes into the parsed script.
+//   2. Emit a reference whose form matches the surrounding quote context.
+//   3. Carry the raw value via the returned env contribution.
+// ---------------------------------------------------------------------------
+
+describe('_substitute_utcp_args context-aware emission', () => {
+  if (isWindows) {
+    test('PowerShell: bare placeholder emits $env:VAR', () => {
+      const { command, env } = proto._substitute_utcp_args(
+        'mytool UTCP_ARG_x_UTCP_END',
+        { x: 'a b' },
+        NONCE,
+      );
+      expect(command).toBe(`mytool $env:${expectedVar('x')}`);
+      expect(env[expectedVar('x')]).toBe('a b');
+    });
+
+    test('PowerShell: placeholder inside double-quoted string emits $env:VAR (PS expands inside dq)', () => {
+      const { command, env } = proto._substitute_utcp_args(
+        'Write-Output "Hi UTCP_ARG_x_UTCP_END!"',
+        { x: 'a; rm /' },
+        NONCE,
+      );
+      expect(command).toBe(`Write-Output "Hi $env:${expectedVar('x')}!"`);
+      expect(env[expectedVar('x')]).toBe('a; rm /');
+    });
+
+    test('PowerShell: placeholder inside single-quoted string throws with clear message', () => {
+      expect(() =>
+        proto._substitute_utcp_args(
+          "Write-Output 'Hi UTCP_ARG_x_UTCP_END'",
+          { x: 'a' },
+          NONCE,
+        ),
+      ).toThrow(/single-quoted/);
+    });
+
+    test('PowerShell: PS-style escaped backtick inside dq is preserved', () => {
+      const { command } = proto._substitute_utcp_args(
+        'Write-Output "pre `"x`" UTCP_ARG_a_UTCP_END"',
+        { a: 'v' },
+        NONCE,
+      );
+      // The dq state must still be active when the placeholder is hit.
+      expect(command).toBe(`Write-Output "pre \`"x\`" $env:${expectedVar('a')}"`);
+    });
+  } else {
+    test('bash: bare placeholder emits "$VAR" (quoted to prevent word-splitting)', () => {
+      const { command, env } = proto._substitute_utcp_args(
+        'mytool UTCP_ARG_x_UTCP_END',
+        { x: 'a b' },
+        NONCE,
+      );
+      expect(command).toBe(`mytool "$${expectedVar('x')}"`);
+      expect(env[expectedVar('x')]).toBe('a b');
+    });
+
+    test('bash: placeholder inside double-quoted string emits ${VAR}', () => {
+      const { command, env } = proto._substitute_utcp_args(
+        'echo "Hi UTCP_ARG_x_UTCP_END!"',
+        { x: 'a; rm /' },
+        NONCE,
+      );
+      expect(command).toBe(`echo "Hi \${${expectedVar('x')}}!"`);
+      expect(env[expectedVar('x')]).toBe('a; rm /');
+    });
+
+    test('bash: placeholder inside single-quoted string emits break-out form', () => {
+      const { command, env } = proto._substitute_utcp_args(
+        "echo 'Hi UTCP_ARG_x_UTCP_END!'",
+        { x: 'a; rm /' },
+        NONCE,
+      );
+      // Bash adjacent-quote concat: 'Hi '"$VAR"'!' -> single token 'Hi <value>!'.
+      expect(command).toBe(`echo 'Hi '"$${expectedVar('x')}"'!'`);
+      expect(env[expectedVar('x')]).toBe('a; rm /');
+    });
+
+    test('bash: backslash escape inside double quotes does not flip state', () => {
+      // `echo "esc\" UTCP_ARG_a_UTCP_END"` -- the \" is escaped, dq remains
+      // open, so the placeholder must emit the dq form (${VAR}).
+      const { command } = proto._substitute_utcp_args(
+        'echo "esc\\" UTCP_ARG_a_UTCP_END"',
+        { a: 'v' },
+        NONCE,
+      );
+      expect(command).toBe(`echo "esc\\" \${${expectedVar('a')}}"`);
+    });
+  }
+
+  test('multiple placeholders share the same nonce namespace', () => {
+    const { command, env } = proto._substitute_utcp_args(
+      'cmd UTCP_ARG_a_UTCP_END UTCP_ARG_b_UTCP_END',
+      { a: '1', b: '2' },
+      NONCE,
+    );
+    expect(env[expectedVar('a')]).toBe('1');
+    expect(env[expectedVar('b')]).toBe('2');
+    expect(command).not.toMatch(/UTCP_ARG_[a-zA-Z0-9_]+_UTCP_END/);
+  });
+
+  test('missing arg is recorded as MISSING_ARG_<name> via env', () => {
+    const { command, env } = proto._substitute_utcp_args(
+      'cmd UTCP_ARG_x_UTCP_END',
+      {},
+      NONCE,
+    );
+    expect(env[expectedVar('x')]).toBe('MISSING_ARG_x');
+    expect(command).not.toMatch(/UTCP_ARG_x_UTCP_END/);
+  });
+
+  test('attacker bytes never appear in the substituted command', () => {
+    // The headline guarantee: even with payloads designed to break
+    // every quote context, the SCRIPT contains only our reference and
+    // the surrounding template chars. The bytes go into env.
+    const payload = '"; rm -rf /; "';
+    if (isWindows) {
+      // PS dq form (sq throws, bare doesn't surround so doesn't apply)
+      const { command, env } = proto._substitute_utcp_args(
+        'Write-Output "URL=UTCP_ARG_id_UTCP_END"',
+        { id: payload },
+        NONCE,
+      );
+      expect(command).not.toContain('"; rm -rf /;');
+      expect(command).not.toContain(';');
+      expect(env[expectedVar('id')]).toBe(payload);
+    } else {
+      for (const tpl of [
+        'curl UTCP_ARG_id_UTCP_END',
+        'curl "https://api/UTCP_ARG_id_UTCP_END"',
+        "curl 'https://api/UTCP_ARG_id_UTCP_END'",
+      ]) {
+        const { command, env } = proto._substitute_utcp_args(tpl, { id: payload }, NONCE);
+        expect(command).not.toContain('rm -rf');
+        expect(command).not.toContain(';');
+        expect(env[expectedVar('id')]).toBe(payload);
+      }
+    }
+  });
+
+  test('nonce changes between invocations (non-deterministic env var name)', () => {
+    // Drive the public path twice; the script must use different
+    // env-var names each run so a template author can never pre-write
+    // a literal `${__UTCP_ARG_<nonce>_x}` reference that collides.
+    // We can't read the nonce from outside, but we can observe that
+    // two runs with the same template+args produce different scripts.
+    const tpl: CliCallTemplate = CliCallTemplateSchema.parse({
+      call_template_type: 'cli',
+      commands: [{ command: 'echo UTCP_ARG_x_UTCP_END' }],
+    });
+    const build = (proto as any)._build_combined_shell_script.bind(proto);
+    const a = build(tpl.commands, { x: 'v' });
+    const b = build(tpl.commands, { x: 'v' });
+    expect(Object.keys(a.env)[0]).not.toBe(Object.keys(b.env)[0]);
+  });
+});
+
+
+// ---------------------------------------------------------------------------
+// Subprocess environment must NOT include arbitrary host vars.
+// ---------------------------------------------------------------------------
+
+describe('_prepare_environment', () => {
+  const SECRET_KEYS = [
+    'OPENAI_API_KEY',
+    'ANTHROPIC_API_KEY',
+    'AWS_SECRET_ACCESS_KEY',
+    'AWS_ACCESS_KEY_ID',
+    'AZURE_CLIENT_SECRET',
+    'GITHUB_TOKEN',
+    'DATABASE_URL',
+    'SLACK_TOKEN',
+    'UTCP_TEST_FAKE_SECRET',
+  ];
+
+  const saved: Record<string, string | undefined> = {};
+  beforeEach(() => {
+    for (const k of SECRET_KEYS) {
+      saved[k] = process.env[k];
+      process.env[k] = `super-secret-${k}`;
+    }
+  });
+  afterEach(() => {
+    for (const k of SECRET_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k]!;
+    }
+  });
+
+  test('default (inherit_env_vars omitted) does not include arbitrary secrets', () => {
+    const provider = CliCallTemplateSchema.parse({
+      call_template_type: 'cli',
+      commands: [{ command: 'echo hi' }],
+    });
+    const env = proto._prepare_environment(provider);
+    for (const k of SECRET_KEYS) {
+      expect(env[k]).toBeUndefined();
+    }
+  });
+
+  test('default propagates PATH and a home-directory variable', () => {
+    process.env.PATH = process.env.PATH ?? '/usr/bin';
+    if (isWindows) {
+      process.env.USERPROFILE = process.env.USERPROFILE ?? 'C:\\Users\\x';
+    } else {
+      process.env.HOME = process.env.HOME ?? '/home/x';
+    }
+    const provider = CliCallTemplateSchema.parse({
+      call_template_type: 'cli',
+      commands: [{ command: 'echo hi' }],
+    });
+    const env = proto._prepare_environment(provider);
+    expect(env.PATH).toBeDefined();
+    expect(isWindows ? env.USERPROFILE : env.HOME).toBeDefined();
+  });
+
+  test('explicit null matches default (does not flip to strict mode)', () => {
+    const omitted = CliCallTemplateSchema.parse({
+      call_template_type: 'cli',
+      commands: [{ command: 'echo hi' }],
+    });
+    const explicit = CliCallTemplateSchema.parse({
+      call_template_type: 'cli',
+      commands: [{ command: 'echo hi' }],
+      inherit_env_vars: null,
+    });
+    expect(proto._prepare_environment(omitted)).toEqual(
+      proto._prepare_environment(explicit),
+    );
+  });
+
+  test('inherit_env_vars: [] is strict mode (nothing inherited)', () => {
+    process.env.PATH = '/usr/bin';
+    const provider = CliCallTemplateSchema.parse({
+      call_template_type: 'cli',
+      commands: [{ command: 'echo hi' }],
+      inherit_env_vars: [],
+    });
+    const env = proto._prepare_environment(provider);
+    expect(env).toEqual({});
+  });
+
+  test('inherit_env_vars: [] + env_vars yields only env_vars', () => {
+    process.env.PATH = '/usr/bin';
+    const provider = CliCallTemplateSchema.parse({
+      call_template_type: 'cli',
+      commands: [{ command: 'echo hi' }],
+      inherit_env_vars: [],
+      env_vars: { FOO: 'bar' },
+    });
+    const env = proto._prepare_environment(provider);
+    expect(env).toEqual({ FOO: 'bar' });
+  });
+
+  test('inherit_env_vars: explicit list replaces default allowlist', () => {
+    process.env.PATH = '/usr/bin';
+    process.env.UTCP_TEST_FAKE_SECRET = 'sk-x';
+    const provider = CliCallTemplateSchema.parse({
+      call_template_type: 'cli',
+      commands: [{ command: 'echo hi' }],
+      inherit_env_vars: ['UTCP_TEST_FAKE_SECRET'],
+    });
+    const env = proto._prepare_environment(provider);
+    expect(env).toEqual({ UTCP_TEST_FAKE_SECRET: 'sk-x' });
+  });
+
+  test('inherit_env_vars: unset names are skipped silently', () => {
+    delete process.env.UTCP_TEST_DOES_NOT_EXIST;
+    const provider = CliCallTemplateSchema.parse({
+      call_template_type: 'cli',
+      commands: [{ command: 'echo hi' }],
+      inherit_env_vars: ['UTCP_TEST_DOES_NOT_EXIST'],
+    });
+    const env = proto._prepare_environment(provider);
+    expect(env.UTCP_TEST_DOES_NOT_EXIST).toBeUndefined();
+  });
+
+  test('env_vars override values inherited from the host', () => {
+    process.env.PATH = '/usr/bin';
+    const provider = CliCallTemplateSchema.parse({
+      call_template_type: 'cli',
+      commands: [{ command: 'echo hi' }],
+      env_vars: { PATH: '/custom/bin' },
+    });
+    const env = proto._prepare_environment(provider);
+    expect(env.PATH).toBe('/custom/bin');
+  });
+
+  test('env_vars override inherit_env_vars too', () => {
+    process.env.UTCP_TEST_FAKE_SECRET = 'host-value';
+    const provider = CliCallTemplateSchema.parse({
+      call_template_type: 'cli',
+      commands: [{ command: 'echo hi' }],
+      inherit_env_vars: ['UTCP_TEST_FAKE_SECRET'],
+      env_vars: { UTCP_TEST_FAKE_SECRET: 'explicit-override' },
+    });
+    const env = proto._prepare_environment(provider);
+    expect(env.UTCP_TEST_FAKE_SECRET).toBe('explicit-override');
+  });
+
+  test('duplicate names in inherit_env_vars are idempotent', () => {
+    process.env.UTCP_TEST_FAKE_SECRET = '1';
+    const provider = CliCallTemplateSchema.parse({
+      call_template_type: 'cli',
+      commands: [{ command: 'echo hi' }],
+      inherit_env_vars: [
+        'UTCP_TEST_FAKE_SECRET',
+        'UTCP_TEST_FAKE_SECRET',
+        'UTCP_TEST_FAKE_SECRET',
+      ],
+    });
+    const env = proto._prepare_environment(provider);
+    expect(env).toEqual({ UTCP_TEST_FAKE_SECRET: '1' });
+  });
+
+  test('explicit list does not pull other defaults along', () => {
+    process.env.PATH = '/usr/bin';
+    if (!isWindows) process.env.HOME = '/home/x';
+    const provider = CliCallTemplateSchema.parse({
+      call_template_type: 'cli',
+      commands: [{ command: 'echo hi' }],
+      inherit_env_vars: ['PATH'],
+    });
+    const env = proto._prepare_environment(provider);
+    expect(env).toEqual({ PATH: '/usr/bin' });
+  });
+});
+
+
+// ---------------------------------------------------------------------------
+// Pydantic-equivalent: schema round-trip preserves null/[]/[...] tri-state.
+// ---------------------------------------------------------------------------
+
+describe('CliCallTemplate serialization preserves inherit_env_vars tri-state', () => {
+  const ser = new CliCallTemplateSerializer();
+
+  test('omitted field stays omitted-ish (not silently coerced to [])', () => {
+    const tpl = CliCallTemplateSchema.parse({
+      call_template_type: 'cli',
+      commands: [{ command: 'x' }],
+    });
+    const d = ser.toDict(tpl);
+    expect(d.inherit_env_vars === undefined || d.inherit_env_vars === null).toBe(true);
+    const round = ser.validateDict(d);
+    expect(round.inherit_env_vars === undefined || round.inherit_env_vars === null).toBe(true);
+  });
+
+  test('empty array survives round-trip', () => {
+    const tpl = CliCallTemplateSchema.parse({
+      call_template_type: 'cli',
+      commands: [{ command: 'x' }],
+      inherit_env_vars: [],
+    });
+    const d = ser.toDict(tpl);
+    expect(d.inherit_env_vars).toEqual([]);
+    const round = ser.validateDict(d);
+    expect(round.inherit_env_vars).toEqual([]);
+  });
+
+  test('list of names survives round-trip', () => {
+    const tpl = CliCallTemplateSchema.parse({
+      call_template_type: 'cli',
+      commands: [{ command: 'x' }],
+      inherit_env_vars: ['PATH', 'OPENAI_API_KEY'],
+    });
+    const d = ser.toDict(tpl);
+    expect(d.inherit_env_vars).toEqual(['PATH', 'OPENAI_API_KEY']);
+    const round = ser.validateDict(d);
+    expect(round.inherit_env_vars).toEqual(['PATH', 'OPENAI_API_KEY']);
+  });
+});
+
+
+// ---------------------------------------------------------------------------
+// End-to-end (Unix only -- bash payload assumptions). The headline
+// regression we want to lock down: a placeholder INSIDE surrounding
+// double quotes must not allow injection.
+// ---------------------------------------------------------------------------
+
+describe('end-to-end injection canaries (Unix only)', () => {
+  if (isWindows) {
+    test.skip('skipped on Windows (bash payload assumptions)', () => {});
+    return;
+  }
+
+  test('attacker tool_arg cannot inject when placeholder is BARE', async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'utcp-cli-sec-'));
+    try {
+      const canary = path.join(tmp, 'pwned-bare');
+      const tpl = CliCallTemplateSchema.parse({
+        call_template_type: 'cli',
+        commands: [{ command: 'echo UTCP_ARG_v_UTCP_END' }],
+        working_dir: tmp,
+      });
+      const result = await new CliCommunicationProtocol().callTool(
+        mockClient,
+        'echo_arg',
+        { v: `benign; touch ${canary}` },
+        tpl,
+      );
+
+      let canaryExists = false;
+      try { await fs.access(canary); canaryExists = true; } catch {}
+      expect(canaryExists).toBe(false);
+      expect(String(result)).toContain('benign; touch');
+    } finally {
+      await fs.rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('attacker tool_arg cannot inject when placeholder is INSIDE DOUBLE QUOTES', async () => {
+    // The exact 1.1.1-bypass scenario: shlex.quote substitution would
+    // splice `'"; rm /; "'` into a surrounding `"..."` and let the
+    // attacker close the dq.
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'utcp-cli-sec-dq-'));
+    try {
+      const canary = path.join(tmp, 'pwned-dq');
+      const tpl = CliCallTemplateSchema.parse({
+        call_template_type: 'cli',
+        commands: [
+          { command: `echo "URL=UTCP_ARG_id_UTCP_END"` },
+        ],
+        working_dir: tmp,
+      });
+      const payload = `"; touch ${canary}; "`;
+      const result = await new CliCommunicationProtocol().callTool(
+        mockClient,
+        'echo_url',
+        { id: payload },
+        tpl,
+      );
+
+      let canaryExists = false;
+      try { await fs.access(canary); canaryExists = true; } catch {}
+      expect(canaryExists).toBe(false);
+      // The literal payload should have appeared as part of the URL.
+      expect(String(result)).toContain('URL=');
+      expect(String(result)).toContain('touch');
+    } finally {
+      await fs.rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('attacker tool_arg cannot inject when placeholder is INSIDE SINGLE QUOTES', async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'utcp-cli-sec-sq-'));
+    try {
+      const canary = path.join(tmp, 'pwned-sq');
+      const tpl = CliCallTemplateSchema.parse({
+        call_template_type: 'cli',
+        commands: [
+          { command: `echo 'URL=UTCP_ARG_id_UTCP_END end'` },
+        ],
+        working_dir: tmp,
+      });
+      const payload = `'; touch ${canary}; '`;
+      const result = await new CliCommunicationProtocol().callTool(
+        mockClient,
+        'echo_url',
+        { id: payload },
+        tpl,
+      );
+
+      let canaryExists = false;
+      try { await fs.access(canary); canaryExists = true; } catch {}
+      expect(canaryExists).toBe(false);
+      expect(String(result)).toContain('URL=');
+    } finally {
+      await fs.rm(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('host secret not in inherit_env_vars does not reach subprocess', async () => {
+    const saved = process.env.UTCP_TEST_LEAK_PROBE;
+    process.env.UTCP_TEST_LEAK_PROBE = 'should-not-leak';
+    try {
+      const tpl = CliCallTemplateSchema.parse({
+        call_template_type: 'cli',
+        commands: [
+          { command: 'echo "probe=${UTCP_TEST_LEAK_PROBE:-MISSING}"' },
+        ],
+      });
+      const result = await new CliCommunicationProtocol().callTool(
+        mockClient,
+        'leak_probe',
+        {},
+        tpl,
+      );
+      expect(String(result)).toContain('probe=MISSING');
+      expect(String(result)).not.toContain('should-not-leak');
+    } finally {
+      if (saved === undefined) delete process.env.UTCP_TEST_LEAK_PROBE;
+      else process.env.UTCP_TEST_LEAK_PROBE = saved;
+    }
+  });
+
+  test('inherit_env_vars opts a host secret into the subprocess', async () => {
+    const saved = process.env.UTCP_TEST_LEAK_PROBE;
+    process.env.UTCP_TEST_LEAK_PROBE = 'inherited-value';
+    try {
+      const tpl = CliCallTemplateSchema.parse({
+        call_template_type: 'cli',
+        commands: [
+          { command: 'echo "probe=${UTCP_TEST_LEAK_PROBE:-MISSING}"' },
+        ],
+        inherit_env_vars: ['PATH', 'UTCP_TEST_LEAK_PROBE'],
+      });
+      const result = await new CliCommunicationProtocol().callTool(
+        mockClient,
+        'leak_probe',
+        {},
+        tpl,
+      );
+      expect(String(result)).toContain('probe=inherited-value');
+    } finally {
+      if (saved === undefined) delete process.env.UTCP_TEST_LEAK_PROBE;
+      else process.env.UTCP_TEST_LEAK_PROBE = saved;
+    }
+  });
+});

--- a/packages/cli/tests/security.test.ts
+++ b/packages/cli/tests/security.test.ts
@@ -55,24 +55,40 @@ const isWindows = process.platform === 'win32';
 
 describe('_substitute_utcp_args context-aware emission', () => {
   if (isWindows) {
-    test('PowerShell: bare placeholder emits $env:VAR', () => {
+    test('PowerShell: bare placeholder emits ${env:VAR} (braced form, var-name boundary safe)', () => {
       const { command, env } = proto._substitute_utcp_args(
         'mytool UTCP_ARG_x_UTCP_END',
         { x: 'a b' },
         NONCE,
       );
-      expect(command).toBe(`mytool $env:${expectedVar('x')}`);
+      expect(command).toBe(`mytool \${env:${expectedVar('x')}}`);
       expect(env[expectedVar('x')]).toBe('a b');
     });
 
-    test('PowerShell: placeholder inside double-quoted string emits $env:VAR (PS expands inside dq)', () => {
+    test('PowerShell: placeholder inside double-quoted string emits ${env:VAR} (PS expands inside dq)', () => {
       const { command, env } = proto._substitute_utcp_args(
         'Write-Output "Hi UTCP_ARG_x_UTCP_END!"',
         { x: 'a; rm /' },
         NONCE,
       );
-      expect(command).toBe(`Write-Output "Hi $env:${expectedVar('x')}!"`);
+      expect(command).toBe(`Write-Output "Hi \${env:${expectedVar('x')}}!"`);
       expect(env[expectedVar('x')]).toBe('a; rm /');
+    });
+
+    test('PowerShell: alphanumeric suffix does not extend the env var name', () => {
+      // Regression: with the bare `$env:VAR` form, an alphanumeric or
+      // underscore suffix in the template would be parsed as part of
+      // the env var name. The braced form `${env:VAR}` closes the
+      // boundary cleanly so the template suffix stays literal.
+      const { command, env } = proto._substitute_utcp_args(
+        'Write-Output "URL=UTCP_ARG_id_UTCP_END123suffix"',
+        { id: 'abc' },
+        NONCE,
+      );
+      expect(command).toBe(
+        `Write-Output "URL=\${env:${expectedVar('id')}}123suffix"`,
+      );
+      expect(env[expectedVar('id')]).toBe('abc');
     });
 
     test('PowerShell: placeholder inside single-quoted string throws with clear message', () => {
@@ -92,7 +108,9 @@ describe('_substitute_utcp_args context-aware emission', () => {
         NONCE,
       );
       // The dq state must still be active when the placeholder is hit.
-      expect(command).toBe(`Write-Output "pre \`"x\`" $env:${expectedVar('a')}"`);
+      expect(command).toBe(
+        `Write-Output "pre \`"x\`" \${env:${expectedVar('a')}}"`,
+      );
     });
   } else {
     test('bash: bare placeholder emits "$VAR" (quoted to prevent word-splitting)', () => {

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@utcp/http",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "HTTP utilities for UTCP",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@utcp/http",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "HTTP utilities for UTCP",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/packages/http/src/_security.ts
+++ b/packages/http/src/_security.ts
@@ -1,0 +1,108 @@
+/**
+ * URL validation shared by every HTTP-based communication protocol.
+ *
+ * Centralised so all three HTTP protocols (http, streamable_http, sse) enforce
+ * the same trust boundary at every network edge — manual discovery AND tool
+ * invocation. Issue universal-tool-calling-protocol/python-utcp#83
+ * (GHSA-39j6-4867-gg4w / CVE-2026-44661) was caused by the runtime invocation
+ * path forgetting the discovery-time check, so this module also provides an
+ * explicit `ensureSecureUrl` to call before every outbound HTTP request.
+ *
+ * Mirrors `utcp_http._security` from the Python reference implementation.
+ */
+
+const LOOPBACK_HOSTNAMES: ReadonlySet<string> = new Set([
+  'localhost',
+  '127.0.0.1',
+  '::1',
+]);
+
+function tryParseUrl(url: string): URL | null {
+  if (typeof url !== 'string' || url.length === 0) return null;
+  try {
+    return new URL(url);
+  } catch {
+    return null;
+  }
+}
+
+function getHostname(parsed: URL): string {
+  // Different URL implementations disagree about whether `URL.hostname`
+  // includes the surrounding brackets for IPv6 literals — Bun keeps them
+  // (`[::1]`), Node's WHATWG URL strips them (`::1`). Normalise both forms
+  // so the loopback set match works either way.
+  let host = parsed.hostname.toLowerCase();
+  if (host.startsWith('[') && host.endsWith(']')) {
+    host = host.slice(1, -1);
+  }
+  return host;
+}
+
+/**
+ * Returns true if `url` is safe to fetch from a UTCP HTTP protocol.
+ *
+ * Allowed:
+ *   - Any `https://` URL.
+ *   - `http://` URLs whose host is exactly `localhost`, `127.0.0.1`, or `::1`.
+ *
+ * Rejected:
+ *   - Plain `http://` to any other host (MITM exposure).
+ *   - URLs whose hostname *starts* with `localhost` / `127.0.0.1` but isn't
+ *     actually loopback (e.g. `http://localhost.evil.com`,
+ *     `http://127.0.0.1.attacker.example`). The earlier `startsWith` check
+ *     let these through.
+ *   - Anything without a scheme/host (file://, javascript:, etc.).
+ */
+export function isSecureUrl(url: string): boolean {
+  const parsed = tryParseUrl(url);
+  if (!parsed) return false;
+
+  const scheme = parsed.protocol.toLowerCase();
+  const host = getHostname(parsed);
+  if (!host) return false;
+
+  if (scheme === 'https:') return true;
+
+  if (scheme === 'http:') {
+    return LOOPBACK_HOSTNAMES.has(host);
+  }
+
+  return false;
+}
+
+/**
+ * Returns true if `url`'s host is a literal loopback address.
+ *
+ * Used by the OpenAPI converter to detect the SSRF case where a remote spec
+ * declares `servers: [{ url: "http://127.0.0.1:..." }]` to redirect tool
+ * invocation at the host running the agent. Hostname-based — not a string
+ * prefix — so `http://localhost.evil.com` returns false.
+ */
+export function isLoopbackUrl(url: string): boolean {
+  const parsed = tryParseUrl(url);
+  if (!parsed) return false;
+
+  const host = getHostname(parsed);
+  if (!host) return false;
+
+  return LOOPBACK_HOSTNAMES.has(host);
+}
+
+/**
+ * Throw an Error if `url` is not safe to fetch.
+ *
+ * `context` is a short label (`"manual discovery"`, `"tool invocation"`,
+ * etc.) included in the error so log readers can tell which trust boundary
+ * was breached.
+ */
+export function ensureSecureUrl(url: string, context?: string): void {
+  if (isSecureUrl(url)) return;
+
+  const where = context ? ` during ${context}` : '';
+  throw new Error(
+    `Security error${where}: URL must use HTTPS or be a literal loopback ` +
+      `address (localhost / 127.0.0.1 / ::1). Got: ${JSON.stringify(url)}. ` +
+      'Plain HTTP to any other host is rejected to prevent MITM attacks ' +
+      'and SSRF into internal services.',
+  );
+}

--- a/packages/http/src/http_communication_protocol.ts
+++ b/packages/http/src/http_communication_protocol.ts
@@ -12,6 +12,7 @@ import { OAuth2Auth } from '@utcp/sdk';
 import { IUtcpClient } from '@utcp/sdk'; 
 import { HttpCallTemplateSchema, HttpCallTemplate } from './http_call_template';
 import { OpenApiConverter } from './openapi_converter';
+import { ensureSecureUrl } from './_security';
 
 /**
  * HTTP communication protocol implementation for UTCP client.
@@ -52,12 +53,8 @@ export class HttpCommunicationProtocol implements CommunicationProtocol {
     try {
       const url = httpCallTemplate.url;
 
-      if (!url.startsWith('https://') && !url.startsWith('http://localhost') && !url.startsWith('http://127.0.0.1')) {
-        throw new Error(
-          `Security error: URL must use HTTPS or start with 'http://localhost' or 'http://127.0.0.1'. Got: ${url}. ` +
-          "Non-secure URLs are vulnerable to man-in-the-middle attacks."
-        );
-      }
+      // Security check: only HTTPS or loopback HTTP allowed for manual discovery.
+      ensureSecureUrl(url, 'manual discovery');
 
       this._logInfo(`Discovering tools from '${httpCallTemplate.name}' (HTTP) at ${url}`);
 
@@ -164,6 +161,12 @@ export class HttpCommunicationProtocol implements CommunicationProtocol {
     }
 
     const url = this._buildUrlWithPathParams(httpCallTemplate.url, remainingArgs);
+
+    // Security check: re-validate the resolved URL before each invocation.
+    // Defends against SSRF via attacker-controlled OpenAPI specs that point
+    // `servers[0].url` at internal services. See GHSA-39j6-4867-gg4w /
+    // CVE-2026-44661.
+    ensureSecureUrl(url, 'tool invocation');
 
     Object.assign(queryParams, remainingArgs);
 

--- a/packages/http/src/openapi_converter.ts
+++ b/packages/http/src/openapi_converter.ts
@@ -25,6 +25,7 @@ import { ApiKeyAuth } from '@utcp/sdk';
 import { BasicAuth } from '@utcp/sdk';
 import { OAuth2Auth } from '@utcp/sdk';
 import { HttpCallTemplate } from './http_call_template';
+import { isLoopbackUrl } from './_security';
 
 /**
  * Options for the OpenAPI converter.
@@ -122,13 +123,28 @@ export class OpenApiConverter {
     const tools: Tool[] = [];
     let baseUrl = '/';
 
-    // 1. Explicit baseUrl option (highest priority)
+    // 1. Explicit baseUrl option (highest priority).
+    //    Caller has accepted the trust decision, no further validation here.
     if (this.base_url) {
       baseUrl = this.base_url;
     }
     // 2. OpenAPI 3.0 servers field
     else if (this.spec.servers && Array.isArray(this.spec.servers) && this.spec.servers.length > 0 && this.spec.servers[0].url) {
       baseUrl = this.spec.servers[0].url;
+
+      // Rule: a spec fetched from a non-loopback source cannot declare a
+      // loopback server URL. A user pointing the converter at their own
+      // localhost OpenAPI spec is allowed to declare loopback servers,
+      // and an explicit `base_url` override always wins (handled above).
+      if (this.spec_url && !isLoopbackUrl(this.spec_url) && isLoopbackUrl(baseUrl)) {
+        throw new Error(
+          `Security error: OpenAPI spec fetched from ${JSON.stringify(this.spec_url)} ` +
+            `declares a loopback server URL (${JSON.stringify(baseUrl)}). ` +
+            "A remote spec is not allowed to redirect tool calls at the agent's own loopback interface — " +
+            'this is the SSRF pattern from GHSA-39j6-4867-gg4w / CVE-2026-44661. ' +
+            'If you trust this spec, set the call template\'s `base_url` override explicitly to bypass this check.',
+        );
+      }
     }
     // 3. OpenAPI 2.0 host and basePath fields
     else if (this.spec.host) {

--- a/packages/http/src/openapi_converter.ts
+++ b/packages/http/src/openapi_converter.ts
@@ -122,29 +122,19 @@ export class OpenApiConverter {
     this.placeholder_counter = 0;
     const tools: Tool[] = [];
     let baseUrl = '/';
+    // Tracks whether the caller explicitly chose `baseUrl` -- only an
+    // explicit override is allowed to bypass the SSRF check below.
+    let baseUrlIsExplicitOverride = false;
 
     // 1. Explicit baseUrl option (highest priority).
     //    Caller has accepted the trust decision, no further validation here.
     if (this.base_url) {
       baseUrl = this.base_url;
+      baseUrlIsExplicitOverride = true;
     }
     // 2. OpenAPI 3.0 servers field
     else if (this.spec.servers && Array.isArray(this.spec.servers) && this.spec.servers.length > 0 && this.spec.servers[0].url) {
       baseUrl = this.spec.servers[0].url;
-
-      // Rule: a spec fetched from a non-loopback source cannot declare a
-      // loopback server URL. A user pointing the converter at their own
-      // localhost OpenAPI spec is allowed to declare loopback servers,
-      // and an explicit `base_url` override always wins (handled above).
-      if (this.spec_url && !isLoopbackUrl(this.spec_url) && isLoopbackUrl(baseUrl)) {
-        throw new Error(
-          `Security error: OpenAPI spec fetched from ${JSON.stringify(this.spec_url)} ` +
-            `declares a loopback server URL (${JSON.stringify(baseUrl)}). ` +
-            "A remote spec is not allowed to redirect tool calls at the agent's own loopback interface — " +
-            'this is the SSRF pattern from GHSA-39j6-4867-gg4w / CVE-2026-44661. ' +
-            'If you trust this spec, set the call template\'s `base_url` override explicitly to bypass this check.',
-        );
-      }
     }
     // 3. OpenAPI 2.0 host and basePath fields
     else if (this.spec.host) {
@@ -162,6 +152,30 @@ export class OpenApiConverter {
       }
     } else {
       console.warn("[OpenApiConverter] No server info found in OpenAPI spec. Using fallback base URL: '/'. Tools may not work correctly without a valid base URL.");
+    }
+
+    // SSRF defense: a spec fetched from a non-loopback source cannot
+    // declare a base URL that points at the agent's own loopback
+    // interface. Applies uniformly to branches 2 (OpenAPI 3.0
+    // `servers`), 3 (OpenAPI 2.0 `host`), and 4 (`spec_url` fallback)
+    // -- the original fix only covered branch 2, leaving an
+    // OpenAPI-2.0-shaped bypass via `host: "127.0.0.1"`. Branch 1
+    // (explicit `base_url`) is always trusted: the caller has made the
+    // decision themselves. A user pointing the converter at their own
+    // localhost OpenAPI spec is also allowed to declare loopback URLs.
+    if (
+      !baseUrlIsExplicitOverride &&
+      this.spec_url &&
+      !isLoopbackUrl(this.spec_url) &&
+      isLoopbackUrl(baseUrl)
+    ) {
+      throw new Error(
+        `Security error: OpenAPI spec fetched from ${JSON.stringify(this.spec_url)} ` +
+          `declares a loopback base URL (${JSON.stringify(baseUrl)}). ` +
+          "A remote spec is not allowed to redirect tool calls at the agent's own loopback interface — " +
+          'this is the SSRF pattern from GHSA-39j6-4867-gg4w / CVE-2026-44661. ' +
+          'If you trust this spec, set the call template\'s `base_url` override explicitly to bypass this check.',
+      );
     }
 
     const paths = this.spec.paths || {};

--- a/packages/http/src/sse_communication_protocol.ts
+++ b/packages/http/src/sse_communication_protocol.ts
@@ -13,6 +13,7 @@ import { BasicAuth } from '@utcp/sdk';
 import { OAuth2Auth } from '@utcp/sdk';
 import { IUtcpClient } from '@utcp/sdk';
 import { SseCallTemplate } from './sse_call_template';
+import { ensureSecureUrl } from './_security';
 
 /**
  * REQUIRED
@@ -82,17 +83,8 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
     const provider = manualCallTemplate as SseCallTemplate;
     const url = provider.url;
 
-    // Security check: Enforce HTTPS or localhost to prevent MITM attacks
-    if (
-      !url.startsWith('https://') &&
-      !url.startsWith('http://localhost') &&
-      !url.startsWith('http://127.0.0.1')
-    ) {
-      throw new Error(
-        `Security error: URL must use HTTPS or start with 'http://localhost' or 'http://127.0.0.1'. Got: ${url}. ` +
-          'Non-secure URLs are vulnerable to man-in-the-middle attacks.'
-      );
-    }
+    // Security check: only HTTPS or loopback HTTP allowed for manual discovery.
+    ensureSecureUrl(url, 'manual discovery');
 
     this._logInfo(`Discovering tools from '${provider.name}' (SSE) at ${url}`);
 

--- a/packages/http/src/streamable_http_communication_protocol.ts
+++ b/packages/http/src/streamable_http_communication_protocol.ts
@@ -13,6 +13,7 @@ import { BasicAuth } from '@utcp/sdk';
 import { OAuth2Auth } from '@utcp/sdk';
 import { IUtcpClient } from '@utcp/sdk';
 import { StreamableHttpCallTemplate } from './streamable_http_call_template';
+import { ensureSecureUrl } from './_security';
 
 /**
  * REQUIRED
@@ -82,17 +83,8 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
     const provider = manualCallTemplate as StreamableHttpCallTemplate;
     const url = provider.url;
 
-    // Security check: Enforce HTTPS or localhost to prevent MITM attacks
-    if (
-      !url.startsWith('https://') &&
-      !url.startsWith('http://localhost') &&
-      !url.startsWith('http://127.0.0.1')
-    ) {
-      throw new Error(
-        `Security error: URL must use HTTPS or start with 'http://localhost' or 'http://127.0.0.1'. Got: ${url}. ` +
-          'Non-secure URLs are vulnerable to man-in-the-middle attacks.'
-      );
-    }
+    // Security check: only HTTPS or loopback HTTP allowed for manual discovery.
+    ensureSecureUrl(url, 'manual discovery');
 
     this._logInfo(`Discovering tools from '${provider.name}' (HTTP Stream) at ${url}`);
 

--- a/packages/http/tests/security.test.ts
+++ b/packages/http/tests/security.test.ts
@@ -1,0 +1,127 @@
+// packages/http/tests/security.test.ts
+//
+// Tests for the URL trust-boundary helper used by every HTTP-based protocol.
+// Backs the fix for GHSA-39j6-4867-gg4w / CVE-2026-44661 (SSRF via
+// attacker-controlled OpenAPI specs). Pin accept/reject decisions so the
+// historical bypass (`http://localhost.evil.com`) and the loopback-redirect
+// variant cannot silently regress.
+
+import { test, expect, describe } from 'bun:test';
+// Import the package index first so its register() side effect runs before
+// the converter tries to validate the generated HttpCallTemplate.
+import '@utcp/http';
+import { isSecureUrl, isLoopbackUrl, ensureSecureUrl } from '../src/_security';
+import { OpenApiConverter } from '../src/openapi_converter';
+
+describe('isSecureUrl', () => {
+  test.each([
+    'https://example.com/openapi.json',
+    'HTTPS://example.com/openapi.json',
+    'https://example.com:8443/v1/tool',
+    'http://localhost/openapi.json',
+    'http://localhost:8080/v1/tool',
+    'http://127.0.0.1:9090/sensitive',
+    'http://[::1]:9090/sensitive',
+  ])('accepts %s', (url) => {
+    expect(isSecureUrl(url)).toBe(true);
+  });
+
+  test.each([
+    'http://169.254.169.254/latest/meta-data/',
+    'http://internal.service.local/secret',
+    'http://10.0.0.5/admin',
+    'http://example.com/openapi.json',
+    'http://localhost.evil.com/path',
+    'http://127.0.0.1.attacker.example/path',
+    'file:///etc/passwd',
+    'ftp://example.com/x',
+    'javascript:alert(1)',
+    '',
+    'not-a-url',
+  ])('rejects %s', (url) => {
+    expect(isSecureUrl(url)).toBe(false);
+  });
+});
+
+describe('isLoopbackUrl', () => {
+  test.each([
+    'http://localhost/x',
+    'http://localhost:9090/x',
+    'http://127.0.0.1/x',
+    'http://127.0.0.1:8080/x',
+    'http://[::1]:9090/x',
+    'https://localhost/x',
+  ])('detects %s as loopback', (url) => {
+    expect(isLoopbackUrl(url)).toBe(true);
+  });
+
+  test.each([
+    'https://example.com/x',
+    'http://10.0.0.5/x',
+    'http://example.com/x',
+    'http://localhost.evil.com/x',
+    'http://127.0.0.1.attacker.example/x',
+    '',
+    'not-a-url',
+  ])('rejects %s as non-loopback', (url) => {
+    expect(isLoopbackUrl(url)).toBe(false);
+  });
+});
+
+describe('ensureSecureUrl', () => {
+  test('throws with context when url is insecure', () => {
+    expect(() =>
+      ensureSecureUrl('http://169.254.169.254/latest/meta-data/', 'tool invocation'),
+    ).toThrow(/tool invocation/);
+  });
+
+  test('passes silently for valid url', () => {
+    expect(() => ensureSecureUrl('https://example.com/v1/tool', 'manual discovery')).not.toThrow();
+  });
+});
+
+describe('OpenApiConverter SSRF defense', () => {
+  function specWithServer(serverUrl: string) {
+    return {
+      openapi: '3.0.0',
+      info: { title: 'T' },
+      servers: [{ url: serverUrl }],
+      paths: {
+        '/x': { get: { operationId: 'x', responses: { '200': { description: 'ok' } } } },
+      },
+    };
+  }
+
+  test('rejects loopback server from a remote spec', () => {
+    const converter = new OpenApiConverter(specWithServer('http://127.0.0.1:9090'), {
+      specUrl: 'https://attacker.example/openapi.json',
+    });
+    expect(() => converter.convert()).toThrow(/loopback/);
+    expect(() => converter.convert()).toThrow(/GHSA-39j6-4867-gg4w/);
+  });
+
+  test('allows loopback server from a loopback spec (local-dev case)', () => {
+    const converter = new OpenApiConverter(specWithServer('http://127.0.0.1:9090'), {
+      specUrl: 'http://localhost:8000/openapi.json',
+    });
+    const manual = converter.convert();
+    expect(manual.tools.length).toBe(1);
+  });
+
+  test('allows explicit base_url override even with remote spec', () => {
+    const converter = new OpenApiConverter(specWithServer('http://127.0.0.1:9090'), {
+      specUrl: 'https://attacker.example/openapi.json',
+      baseUrl: 'http://127.0.0.1:9090',
+    });
+    const manual = converter.convert();
+    expect(manual.tools.length).toBe(1);
+  });
+
+  test('allows remote spec with remote server (normal case)', () => {
+    const converter = new OpenApiConverter(specWithServer('https://api.example.com'), {
+      specUrl: 'https://api.example.com/openapi.json',
+    });
+    const manual = converter.convert();
+    expect(manual.tools.length).toBe(1);
+  });
+});

--- a/packages/http/tests/security.test.ts
+++ b/packages/http/tests/security.test.ts
@@ -124,4 +124,79 @@ describe('OpenApiConverter SSRF defense', () => {
     const manual = converter.convert();
     expect(manual.tools.length).toBe(1);
   });
+
+  // Regression tests for the OpenAPI-2.0 / spec_url-fallback bypass:
+  // the original fix only ran the loopback check inside the OpenAPI 3.0
+  // `servers` branch, so an attacker could ship the same SSRF payload
+  // via OpenAPI 2.0's `host` field or by omitting `servers`/`host` and
+  // letting the converter fall back to the spec_url itself.
+
+  function specV2WithHost(host: string, scheme: string = 'http') {
+    return {
+      swagger: '2.0',
+      info: { title: 'T', version: '1' },
+      host,
+      schemes: [scheme],
+      basePath: '/',
+      paths: {
+        '/x': {
+          get: {
+            operationId: 'x',
+            responses: { '200': { description: 'ok' } },
+          },
+        },
+      },
+    };
+  }
+
+  test('rejects loopback host in OpenAPI 2.0 spec from a remote source', () => {
+    const converter = new OpenApiConverter(specV2WithHost('127.0.0.1:9090'), {
+      specUrl: 'https://attacker.example/swagger.json',
+    });
+    expect(() => converter.convert()).toThrow(/loopback/);
+    expect(() => converter.convert()).toThrow(/GHSA-39j6-4867-gg4w/);
+  });
+
+  test('rejects "localhost" host in OpenAPI 2.0 spec from a remote source', () => {
+    const converter = new OpenApiConverter(specV2WithHost('localhost'), {
+      specUrl: 'https://attacker.example/swagger.json',
+    });
+    expect(() => converter.convert()).toThrow(/loopback/);
+  });
+
+  test('allows loopback host in OpenAPI 2.0 spec from a loopback source (local-dev)', () => {
+    const converter = new OpenApiConverter(specV2WithHost('127.0.0.1:9090'), {
+      specUrl: 'http://localhost:8000/swagger.json',
+    });
+    const manual = converter.convert();
+    expect(manual.tools.length).toBe(1);
+  });
+
+  test('explicit base_url override bypasses the check for OpenAPI 2.0', () => {
+    const converter = new OpenApiConverter(specV2WithHost('127.0.0.1:9090'), {
+      specUrl: 'https://attacker.example/swagger.json',
+      baseUrl: 'http://127.0.0.1:9090',
+    });
+    const manual = converter.convert();
+    expect(manual.tools.length).toBe(1);
+  });
+
+  test('spec without servers/host/baseUrl falling back to a loopback spec_url is fine', () => {
+    // The fallback branch derives baseUrl from spec_url itself, so by
+    // construction it cannot be the SSRF redirect pattern -- there is
+    // nothing the spec author can change to point elsewhere. This is
+    // the local-dev case.
+    const spec = {
+      openapi: '3.0.0',
+      info: { title: 'T' },
+      paths: {
+        '/x': { get: { operationId: 'x', responses: { '200': { description: 'ok' } } } },
+      },
+    };
+    const converter = new OpenApiConverter(spec, {
+      specUrl: 'http://localhost:8000/openapi.json',
+    });
+    const manual = converter.convert();
+    expect(manual.tools.length).toBe(1);
+  });
 });


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Strengthens the CLI and HTTP protocols to block command injection and SSRF. Adds context‑aware arg substitution with per‑call, nonce‑scoped env vars, controlled env inheritance, and centralized URL validation with runtime rechecks and broader OpenAPI coverage; adds tests; bumps `@utcp/cli` to 1.1.2 and `@utcp/http` to 1.1.3.

- **Bug Fixes**
  - CLI: Replaced `UTCP_ARG_*` inlining with context‑aware shell var refs plus per‑invocation env vars (nonce‑scoped); prevents injection in all quote contexts.
  - CLI: Introduced `inherit_env_vars` allowlist; stop inheriting the full host env; `env_vars` always override; removed any re‑merge of `process.env`.
  - CLI: PowerShell placeholders inside single‑quoted strings now throw with guidance to use double quotes; increased discovery timeout to 60s to handle slow PS startups.
  - HTTP/SSE/Streamable HTTP: Centralized URL guard; only allow HTTPS or loopback HTTP; fixed hostname‑prefix bypass; revalidate URLs before each invocation.
  - OpenAPI: Reject loopback `servers[0].url` and 2.0 `host` when the spec is fetched from a non‑loopback origin; explicit `base_url` and localhost‑fetched specs remain allowed.

- **Migration**
  - If a single placeholder previously expanded to multiple flags, split it into one placeholder per flag.
  - On Windows, wrap placeholders in double quotes; single‑quoted PowerShell strings will error.
  - If tools need specific host vars, set `inherit_env_vars` (include `PATH` when you override) or define them in `env_vars`.

<sup>Written for commit 2273daa43a2e8d30a3c63ba822b6a75ea852279f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

