### PR TITLE
security fix

### DIFF
--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@utcp/http",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "HTTP utilities for UTCP",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@utcp/http",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "HTTP utilities for UTCP",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@utcp/http",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "HTTP utilities for UTCP",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/packages/http/src/_security.ts
+++ b/packages/http/src/_security.ts
@@ -106,3 +106,95 @@ export function ensureSecureUrl(url: string, context?: string): void {
       'and SSRF into internal services.',
   );
 }
+
+// Local type alias avoids importing the full axios type surface here.
+// The helper is intentionally axios-agnostic at the type level so the
+// (de-facto small) request surface stays decoupled.
+interface AxiosLike {
+  request<T = any>(config: any): Promise<{ status: number; headers: Record<string, any>; data: T }>;
+}
+
+/**
+ * HTTP statuses where the server expects the client to re-issue the
+ * request against the URL in the `Location` header.
+ */
+const REDIRECT_STATUSES: ReadonlySet<number> = new Set([301, 302, 303, 307, 308]);
+
+/**
+ * Issue an HTTP request that re-validates every redirect hop.
+ *
+ * axios's default `maxRedirects: 5` would otherwise let an
+ * attacker-controlled tool/manual endpoint 302 the client into
+ * `http://169.254.169.254/...` (cloud metadata) or any internal HTTP
+ * service, and the response body would be handed back to the caller.
+ * Mirrors the Python helper added in utcp-http 1.1.4. Backs
+ * GHSA-9qhg-99ww-9mqc.
+ *
+ * Behaviour:
+ *   - Calls `ensureSecureUrl(url, context)` on the initial URL.
+ *   - Forces `maxRedirects: 0` so axios returns 3xx responses rather
+ *     than following them silently.
+ *   - On a 3xx with a `Location` header, resolves the target against
+ *     the current URL and runs `ensureSecureUrl` on it before
+ *     issuing the next hop. Rejection raises immediately.
+ *   - Caps the chain at `maxHops` (default 5).
+ *   - Mirrors RFC 7231 method semantics: 303 forces GET and drops
+ *     the request body; other 3xx statuses preserve method and body.
+ *
+ * @typeParam T - Expected response body type.
+ */
+export async function safeRequestWithRedirects<T = any>(
+  axiosInstance: AxiosLike,
+  config: { url: string; method: string; data?: any; [key: string]: any },
+  context: string,
+  maxHops: number = 5,
+): Promise<{ status: number; headers: Record<string, any>; data: T }> {
+  ensureSecureUrl(config.url, context);
+
+  let currentUrl = config.url;
+  let currentMethod = config.method;
+  let currentData = config.data;
+  let hops = 0;
+
+  while (true) {
+    const response = await axiosInstance.request<T>({
+      ...config,
+      url: currentUrl,
+      method: currentMethod,
+      data: currentData,
+      // Take redirect control away from axios so it cannot
+      // silently land on an unvalidated host.
+      maxRedirects: 0,
+      // Treat 3xx as a "real" response so axios does not throw and
+      // we can inspect the Location header ourselves.
+      validateStatus: (status: number) => status < 400,
+    });
+
+    if (!REDIRECT_STATUSES.has(response.status)) {
+      return response;
+    }
+
+    const location = response.headers['location'] ?? response.headers['Location'];
+    if (!location || typeof location !== 'string') {
+      // 3xx without a usable Location header -- nothing to follow,
+      // hand the response back to the caller as-is.
+      return response;
+    }
+
+    if (hops >= maxHops) {
+      throw new Error(
+        `Too many redirects (>${maxHops}) during ${context} starting from ${JSON.stringify(config.url)}.`,
+      );
+    }
+
+    const nextUrl = new URL(location, currentUrl).toString();
+    ensureSecureUrl(nextUrl, `${context} (redirect target)`);
+
+    if (response.status === 303) {
+      currentMethod = 'GET';
+      currentData = undefined;
+    }
+    currentUrl = nextUrl;
+    hops += 1;
+  }
+}

--- a/packages/http/src/_security.ts
+++ b/packages/http/src/_security.ts
@@ -199,13 +199,12 @@ const REDIRECT_STATUSES: ReadonlySet<number> = new Set([301, 302, 303, 307, 308]
  * case-insensitive against this lowercase set.
  */
 const AUTH_SENSITIVE_HEADERS: ReadonlySet<string> = new Set([
+  // Canonical IETF headers.
   'authorization',
   'proxy-authorization',
   'cookie',
   'www-authenticate',
-  // Common API-key / service-token header names. UTCP `ApiKeyAuth`
-  // lets callers put a secret under an arbitrary header name, so this
-  // list is intentionally broad.
+  // Hyphenated API-key / service-token names.
   'x-api-key',
   'api-key',
   'x-auth-token',
@@ -214,15 +213,41 @@ const AUTH_SENSITIVE_HEADERS: ReadonlySet<string> = new Set([
   'x-xsrf-token',
   'x-amz-security-token',
   'x-goog-api-key',
+  // Underscore-separated variants (some HTTP stacks normalise
+  // `X-API-Key` to `X_API_KEY`).
+  'x_api_key',
+  'api_key',
+  'x_auth_token',
+  'x_access_token',
+  'x_csrf_token',
+  'x_xsrf_token',
+  // Condensed / no-separator variants seen in custom APIs
+  // (`XApiKey` lowercased becomes `xapikey`).
+  'apikey',
+  'xapikey',
+  'authtoken',
+  'xauthtoken',
+  'accesstoken',
+  'xaccesstoken',
+  'bearertoken',
+  'sessionid',
+  'csrftoken',
+  'xsrftoken',
 ]);
 
 /**
  * Catches ad-hoc auth header names that aren't in the explicit set
- * above (`X-MyApp-Token`, `Custom-Bearer`, etc.). Conservative but
- * biased toward strip-on-cross-origin since false positives are only
- * a usability cost.
+ * above (`X-MyApp-Token`, `Custom-Bearer`, `X_MyApp_Token`, etc.).
+ * Conservative but biased toward strip-on-cross-origin since false
+ * positives are only a usability cost.
+ *
+ * Two alternations:
+ *   1. Word-boundary match (hyphen / underscore / start / end) so
+ *      `X-Foo-Token` and `X_FOO_TOKEN` both trip.
+ *   2. No-boundary match on compound condensed names (`XApiKey`
+ *      lowercased to `xapikey`).
  */
-const AUTH_HEADER_REGEX = /(^|-)(auth|authn|authz|token|key|secret|bearer|session|sid|api[_-]?key|jwt)(-|$)/i;
+const AUTH_HEADER_REGEX = /(?:(?:^|[-_])(?:auth|authn|authz|token|key|secret|bearer|session|sid|api[-_]?key|jwt|csrf|xsrf)(?:[-_]|$))|(?:apikey|authtoken|accesstoken|bearertoken|sessionid|csrftoken|xsrftoken|xapikey|xauthtoken|xaccesstoken|xapitoken)/i;
 
 function headerIsAuthSensitive(name: string): boolean {
   if (typeof name !== 'string') return false;

--- a/packages/http/src/_security.ts
+++ b/packages/http/src/_security.ts
@@ -71,12 +71,83 @@ export function isSecureUrl(url: string): boolean {
 }
 
 /**
+ * Return true if `host` is an IP literal that the local kernel will
+ * route to the host running the agent.
+ *
+ * Mirrors `utcp_http._security._ip_is_loopback_like` from the Python
+ * reference implementation. Goes beyond the obvious `127.0.0.1` /
+ * `::1` literals to cover:
+ *   - the entire `127.0.0.0/8` range (the WHATWG URL parser normalizes
+ *     shorthand forms like `http://127.1/` and `http://2130706433/`
+ *     into canonical dotted-quad, but `127.0.0.2` is a distinct host
+ *     that still routes to local loopback);
+ *   - `0.0.0.0` and `::` -- on Linux a TCP connect to these lands on
+ *     local loopback;
+ *   - IPv4-mapped IPv6 loopback (`::ffff:127.0.0.1` etc.) -- the
+ *     dual-stack socket layer routes these to the v4 loopback even
+ *     though strict IPv6 semantics do not call them loopback.
+ *
+ * Closes the residual SSRF window left by the original
+ * `LOOPBACK_HOSTNAMES` set in `isLoopbackUrl`, which is used by the
+ * OpenAPI converter to block remote specs declaring loopback
+ * `servers[0].url` values.
+ */
+function isIpLoopbackLike(host: string): boolean {
+  if (host === '0.0.0.0' || host === '::') return true;
+  // IPv4 dotted-quad: any 127.x.x.x is loopback (entire 127.0.0.0/8).
+  const v4 = host.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (v4) {
+    const octets = v4.slice(1).map((s) => parseInt(s, 10));
+    if (octets.every((o) => o >= 0 && o <= 255)) {
+      if (octets[0] === 127) return true;
+    }
+  }
+  // IPv6 literals (URL.hostname already strips brackets in our caller).
+  // The WHATWG URL parser canonicalises:
+  //   ::1 -> ::1
+  //   0:0:0:0:0:0:0:1 -> ::1
+  //   ::ffff:127.0.0.1 -> ::ffff:7f00:1
+  //   ::ffff:0:1 -> ::ffff:0:1
+  // Match the canonical loopback IPv6 (already in the set) and any
+  // IPv4-mapped form that embeds a 127.x.x.x address.
+  if (host === '::1' || host === '::') return true;
+  // IPv4-mapped IPv6: ::ffff:<v4>. The canonical compressed form is
+  // ::ffff:HHHH:HHHH where the trailing 32 bits encode the v4.
+  // Detect any `::ffff:` prefix and inspect the trailing 4 hex groups
+  // (or dotted-quad fallback).
+  if (host.startsWith('::ffff:')) {
+    const tail = host.slice('::ffff:'.length);
+    // Dotted-quad tail: ::ffff:127.0.0.1
+    const tailV4 = tail.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+    if (tailV4) {
+      const oct = tailV4.slice(1).map((s) => parseInt(s, 10));
+      if (oct.every((o) => o >= 0 && o <= 255) && oct[0] === 127) return true;
+    }
+    // Hex-pair tail: ::ffff:7f00:1 (== 127.0.0.1). Parse two 16-bit
+    // groups and reassemble as a /8 check.
+    const tailHex = tail.match(/^([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+    if (tailHex) {
+      const hi = parseInt(tailHex[1], 16);
+      const lo = parseInt(tailHex[2], 16);
+      // hi covers octets 1+2 of the v4 address; check whether octet 1
+      // (the upper 8 bits of hi) is 127.
+      const octet1 = (hi >>> 8) & 0xff;
+      if (octet1 === 127) return true;
+      // Guard against unused-var lint.
+      void lo;
+    }
+  }
+  return false;
+}
+
+/**
  * Returns true if `url`'s host is a literal loopback address.
  *
  * Used by the OpenAPI converter to detect the SSRF case where a remote spec
  * declares `servers: [{ url: "http://127.0.0.1:..." }]` to redirect tool
  * invocation at the host running the agent. Hostname-based — not a string
- * prefix — so `http://localhost.evil.com` returns false.
+ * prefix — so `http://localhost.evil.com` returns false. Also covers
+ * `127.0.0.0/8`, `0.0.0.0`, `::`, and IPv4-mapped IPv6 loopback forms.
  */
 export function isLoopbackUrl(url: string): boolean {
   const parsed = tryParseUrl(url);
@@ -85,7 +156,8 @@ export function isLoopbackUrl(url: string): boolean {
   const host = getHostname(parsed);
   if (!host) return false;
 
-  return LOOPBACK_HOSTNAMES.has(host);
+  if (LOOPBACK_HOSTNAMES.has(host)) return true;
+  return isIpLoopbackLike(host);
 }
 
 /**
@@ -121,6 +193,105 @@ interface AxiosLike {
 const REDIRECT_STATUSES: ReadonlySet<number> = new Set([301, 302, 303, 307, 308]);
 
 /**
+ * Headers that carry authentication / session material and must be
+ * stripped when a redirect crosses to a different origin. Matches the
+ * canonical behaviour of fetch / requests / curl. Comparison is
+ * case-insensitive against this lowercase set.
+ */
+const AUTH_SENSITIVE_HEADERS: ReadonlySet<string> = new Set([
+  'authorization',
+  'proxy-authorization',
+  'cookie',
+  'www-authenticate',
+  // Common API-key / service-token header names. UTCP `ApiKeyAuth`
+  // lets callers put a secret under an arbitrary header name, so this
+  // list is intentionally broad.
+  'x-api-key',
+  'api-key',
+  'x-auth-token',
+  'x-access-token',
+  'x-csrf-token',
+  'x-xsrf-token',
+  'x-amz-security-token',
+  'x-goog-api-key',
+]);
+
+/**
+ * Catches ad-hoc auth header names that aren't in the explicit set
+ * above (`X-MyApp-Token`, `Custom-Bearer`, etc.). Conservative but
+ * biased toward strip-on-cross-origin since false positives are only
+ * a usability cost.
+ */
+const AUTH_HEADER_REGEX = /(^|-)(auth|authn|authz|token|key|secret|bearer|session|sid|api[_-]?key|jwt)(-|$)/i;
+
+function headerIsAuthSensitive(name: string): boolean {
+  if (typeof name !== 'string') return false;
+  const lower = name.toLowerCase();
+  if (AUTH_SENSITIVE_HEADERS.has(lower)) return true;
+  return AUTH_HEADER_REGEX.test(lower);
+}
+
+const DEFAULT_PORTS: Record<string, string> = {
+  'http:': '80',
+  'https:': '443',
+  'ws:': '80',
+  'wss:': '443',
+};
+
+function effectivePort(u: URL): string {
+  return u.port || DEFAULT_PORTS[u.protocol.toLowerCase()] || '';
+}
+
+function sameOrigin(a: string, b: string): boolean {
+  let ua: URL, ub: URL;
+  try {
+    ua = new URL(a);
+    ub = new URL(b);
+  } catch {
+    return false;
+  }
+  if (ua.protocol.toLowerCase() !== ub.protocol.toLowerCase()) return false;
+  if (ua.hostname.toLowerCase() !== ub.hostname.toLowerCase()) return false;
+  // Normalise default ports (`""` vs `"443"`) so a same-origin redirect
+  // to an explicit-port URL doesn't trip the cross-origin scrub and
+  // silently strip the caller's auth.
+  return effectivePort(ua) === effectivePort(ub);
+}
+
+/**
+ * Mutate `config` in place to drop credential-bearing fields when the
+ * next hop crosses to a different origin. Mirrors browser / requests
+ * behaviour:
+ *   - `Authorization` and other canonical auth headers;
+ *   - common API-key / service-token header names + an auth-regex
+ *     catch-all for ad-hoc names;
+ *   - axios basic-`auth`;
+ *   - `params` (commonly carries API keys via the query string);
+ *   - `withCredentials`;
+ *   - the request body (`data`) -- a 307/308 redirect preserves the
+ *     body, and the body of e.g. an OAuth2 token POST contains the
+ *     exact credentials we're trying to protect. Refuse to resend it
+ *     cross-origin.
+ */
+function scrubCrossOriginCredentials(config: Record<string, any>): void {
+  const headers = config.headers;
+  if (headers && typeof headers === 'object') {
+    const scrubbed: Record<string, any> = {};
+    for (const [k, v] of Object.entries(headers)) {
+      if (headerIsAuthSensitive(k)) continue;
+      scrubbed[k] = v;
+    }
+    config.headers = scrubbed;
+  }
+  delete config.auth;
+  delete config.params;
+  delete config.withCredentials;
+  // Request body. 307/308 would otherwise resend it to the new origin
+  // -- the OAuth token-POST case is the headline exploit.
+  delete config.data;
+}
+
+/**
  * Issue an HTTP request that re-validates every redirect hop.
  *
  * axios's default `maxRedirects: 5` would otherwise let an
@@ -151,17 +322,23 @@ export async function safeRequestWithRedirects<T = any>(
 ): Promise<{ status: number; headers: Record<string, any>; data: T }> {
   ensureSecureUrl(config.url, context);
 
-  let currentUrl = config.url;
-  let currentMethod = config.method;
-  let currentData = config.data;
+  // Build a mutable working copy so we can strip credentials between
+  // hops without mutating the caller's object. ``headers`` is shallow-
+  // copied because we may need to rewrite it during cross-origin
+  // scrubbing; other fields are kept by reference (good enough for the
+  // primitive / plain-object values we use).
+  const working: Record<string, any> = { ...config };
+  if (working.headers && typeof working.headers === 'object') {
+    working.headers = { ...working.headers };
+  }
+
+  let currentUrl = working.url;
   let hops = 0;
 
   while (true) {
     const response = await axiosInstance.request<T>({
-      ...config,
+      ...working,
       url: currentUrl,
-      method: currentMethod,
-      data: currentData,
       // Take redirect control away from axios so it cannot
       // silently land on an unvalidated host.
       maxRedirects: 0,
@@ -190,9 +367,18 @@ export async function safeRequestWithRedirects<T = any>(
     const nextUrl = new URL(location, currentUrl).toString();
     ensureSecureUrl(nextUrl, `${context} (redirect target)`);
 
+    // Strip credential-bearing fields when the redirect crosses to a
+    // different origin. Mirrors fetch / requests / curl: without this
+    // an attacker-controlled endpoint could 302 us to their own
+    // server and our ``Authorization`` header / basic ``auth`` /
+    // ``params`` API key would be forwarded along.
+    if (!sameOrigin(currentUrl, nextUrl)) {
+      scrubCrossOriginCredentials(working);
+    }
+
     if (response.status === 303) {
-      currentMethod = 'GET';
-      currentData = undefined;
+      working.method = 'GET';
+      working.data = undefined;
     }
     currentUrl = nextUrl;
     hops += 1;

--- a/packages/http/src/http_communication_protocol.ts
+++ b/packages/http/src/http_communication_protocol.ts
@@ -12,7 +12,7 @@ import { OAuth2Auth } from '@utcp/sdk';
 import { IUtcpClient } from '@utcp/sdk'; 
 import { HttpCallTemplateSchema, HttpCallTemplate } from './http_call_template';
 import { OpenApiConverter } from './openapi_converter';
-import { ensureSecureUrl } from './_security';
+import { ensureSecureUrl, safeRequestWithRedirects } from './_security';
 
 /**
  * HTTP communication protocol implementation for UTCP client.
@@ -69,7 +69,15 @@ export class HttpCommunicationProtocol implements CommunicationProtocol {
       };
 
       await this._applyAuthToRequestConfig(httpCallTemplate, requestConfig);
-      const response = await this._axiosInstance.request(requestConfig);
+      // Re-validate every redirect hop. axios's default
+      // ``maxRedirects: 5`` would otherwise let an attacker-controlled
+      // discovery URL 302 us into an internal service
+      // (GHSA-9qhg-99ww-9mqc).
+      const response = await safeRequestWithRedirects(
+        this._axiosInstance,
+        requestConfig as any,
+        'manual discovery',
+      );
       const contentType = response.headers['content-type'] || '';
       let responseData: any;
 
@@ -191,7 +199,15 @@ export class HttpCommunicationProtocol implements CommunicationProtocol {
       }
 
       this._logInfo(`Executing HTTP tool '${toolName}' with URL: ${requestConfig.url} and method: ${requestConfig.method}`);
-      const response = await this._axiosInstance.request(requestConfig);
+      // Re-validate every redirect hop. axios's default
+      // ``maxRedirects: 5`` would otherwise let an attacker-controlled
+      // tool endpoint 302 us into an internal service and hand its
+      // body back to the caller (GHSA-9qhg-99ww-9mqc).
+      const response = await safeRequestWithRedirects(
+        this._axiosInstance,
+        requestConfig as any,
+        'tool invocation',
+      );
 
       const contentType = response.headers['content-type'] || '';
       if (contentType.includes('yaml') || url.endsWith('.yaml') || url.endsWith('.yml')) {
@@ -288,6 +304,14 @@ export class HttpCommunicationProtocol implements CommunicationProtocol {
       return cachedToken.accessToken;
     }
 
+    // The token URL ultimately comes from a call template, and call
+    // templates can be sourced from attacker-controlled OpenAPI specs
+    // (the OpenApiConverter copies ``tokenUrl`` from the spec).
+    // Validate it before posting credentials so a malicious spec
+    // cannot redirect ``client_id`` / ``client_secret`` exfiltration
+    // through this protocol -- see GHSA-8cp3-qxj6-px34.
+    ensureSecureUrl(authDetails.token_url, 'OAuth2 token URL');
+
     this._logInfo(`Fetching new OAuth2 token for client: '${clientId}'`);
     const tokenFetchPromises: Promise<string>[] = [];
 
@@ -301,10 +325,15 @@ export class HttpCommunicationProtocol implements CommunicationProtocol {
             'client_secret': authDetails.client_secret,
             'scope': authDetails.scope || ''
           });
-          const response = await this._axiosInstance.post(
-            authDetails.token_url,
-            bodyData.toString(),
-            { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } }
+          const response = await safeRequestWithRedirects(
+            this._axiosInstance,
+            {
+              method: 'POST',
+              url: authDetails.token_url,
+              data: bodyData.toString(),
+              headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            },
+            'OAuth2 token fetch',
           );
           if (!response.data.access_token) {
             throw new Error("Access token not found in response.");
@@ -328,13 +357,16 @@ export class HttpCommunicationProtocol implements CommunicationProtocol {
             'grant_type': 'client_credentials',
             'scope': authDetails.scope || ''
           });
-          const response = await this._axiosInstance.post(
-            authDetails.token_url,
-            bodyData.toString(),
+          const response = await safeRequestWithRedirects(
+            this._axiosInstance,
             {
+              method: 'POST',
+              url: authDetails.token_url,
+              data: bodyData.toString(),
               auth: { username: authDetails.client_id, password: authDetails.client_secret },
-              headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
-            }
+              headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            },
+            'OAuth2 token fetch',
           );
           if (!response.data.access_token) {
             throw new Error("Access token not found in response.");

--- a/packages/http/src/openapi_converter.ts
+++ b/packages/http/src/openapi_converter.ts
@@ -631,7 +631,7 @@ export class OpenApiConverter {
               // into the generated call template. The runtime check
               // in ``_handleOAuth2`` also enforces this -- see
               // GHSA-8cp3-qxj6-px34.
-              this._validateTokenUrlEagerly(tokenUrl);
+              const resolvedTokenUrl = this._validateTokenUrlEagerly(tokenUrl);
               // Use the current counter value for both placeholders
               const clientIdPlaceholder = this._getPlaceholder('CLIENT_ID');
               const clientSecretPlaceholder = this._getPlaceholder('CLIENT_SECRET');
@@ -640,7 +640,7 @@ export class OpenApiConverter {
               const scopes = (flowConfig as Record<string, any>).scopes || {};
               return {
                 auth_type: 'oauth2',
-                token_url: tokenUrl,
+                token_url: resolvedTokenUrl,
                 client_id: clientIdPlaceholder,
                 client_secret: clientSecretPlaceholder,
                 scope: Object.keys(scopes).length > 0 ? Object.keys(scopes).join(' ') : undefined,
@@ -653,14 +653,14 @@ export class OpenApiConverter {
       // OpenAPI 2.0 format fallback
       const tokenUrl = scheme.tokenUrl;
       if (tokenUrl) {
-        this._validateTokenUrlEagerly(tokenUrl);
+        const resolvedTokenUrl = this._validateTokenUrlEagerly(tokenUrl);
         const clientIdPlaceholder = this._getPlaceholder('CLIENT_ID');
         const clientSecretPlaceholder = this._getPlaceholder('CLIENT_SECRET');
         this._incrementPlaceholderCounter();
         const scopes = scheme.scopes || {};
         return {
           auth_type: 'oauth2',
-          token_url: tokenUrl,
+          token_url: resolvedTokenUrl,
           client_id: clientIdPlaceholder,
           client_secret: clientSecretPlaceholder,
           scope: Object.keys(scopes).length > 0 ? Object.keys(scopes).join(' ') : undefined,
@@ -672,19 +672,26 @@ export class OpenApiConverter {
   }
 
   /**
-   * Eagerly validate an OpenAPI OAuth2 `tokenUrl` so an attacker-
-   * controlled spec cannot smuggle a credential-exfiltration sink into
-   * the generated call template. Backs GHSA-8cp3-qxj6-px34.
+   * Validate (and, when relative, resolve) an OpenAPI OAuth2
+   * `tokenUrl` at conversion time. Returns the URL that should be
+   * embedded in the generated `OAuth2Auth` so the runtime check in
+   * `_handleOAuth2` sees an absolute URL instead of an unresolved
+   * relative reference (which would always fail at runtime). Backs
+   * GHSA-8cp3-qxj6-px34.
    *
    * OpenAPI 3.0 / 3.1 explicitly allow `tokenUrl` to be a relative
-   * reference resolved against the spec's own location. Reject only
-   * **absolute** URLs that fail the validator here; relative URLs are
-   * resolved against `spec_url` if available (so the validator still
-   * applies to the effective URL), and otherwise are left intact for
-   * `_handleOAuth2` to validate at runtime. This avoids rejecting
-   * legitimate specs that use `"tokenUrl": "/oauth/token"`.
+   * reference resolved against the spec's own location. Behaviour:
+   *
+   *   - Absolute URL: run `ensureSecureUrl` and return as-is.
+   *   - Relative URL with `spec_url` available: resolve against
+   *     `spec_url`, validate the resolved URL, and return it so the
+   *     runtime check sees the absolute form. This also closes the
+   *     `"tokenUrl": "//host/token"` scheme-relative bypass.
+   *   - Relative URL without `spec_url`: nothing to resolve against.
+   *     Return the original string unchanged; the runtime check will
+   *     reject it later.
    */
-  private _validateTokenUrlEagerly(tokenUrl: string): void {
+  private _validateTokenUrlEagerly(tokenUrl: string): string {
     let absoluteParse: URL | null = null;
     try {
       absoluteParse = new URL(tokenUrl);
@@ -694,7 +701,7 @@ export class OpenApiConverter {
 
     if (absoluteParse && absoluteParse.protocol && absoluteParse.hostname) {
       ensureSecureUrl(tokenUrl, 'OAuth2 tokenUrl in OpenAPI spec');
-      return;
+      return tokenUrl;
     }
 
     if (this.spec_url) {
@@ -702,7 +709,7 @@ export class OpenApiConverter {
       try {
         resolved = new URL(tokenUrl, this.spec_url).toString();
       } catch {
-        return;
+        return tokenUrl;
       }
       let resolvedParse: URL | null = null;
       try {
@@ -715,7 +722,10 @@ export class OpenApiConverter {
           resolved,
           'OAuth2 tokenUrl in OpenAPI spec (resolved from relative URL)',
         );
+        return resolved;
       }
     }
+
+    return tokenUrl;
   }
 }

--- a/packages/http/src/openapi_converter.ts
+++ b/packages/http/src/openapi_converter.ts
@@ -25,7 +25,7 @@ import { ApiKeyAuth } from '@utcp/sdk';
 import { BasicAuth } from '@utcp/sdk';
 import { OAuth2Auth } from '@utcp/sdk';
 import { HttpCallTemplate } from './http_call_template';
-import { isLoopbackUrl } from './_security';
+import { ensureSecureUrl, isLoopbackUrl } from './_security';
 
 /**
  * Options for the OpenAPI converter.
@@ -625,6 +625,13 @@ export class OpenApiConverter {
           if (['authorizationCode', 'accessCode', 'clientCredentials', 'application'].includes(flowType)) {
             const tokenUrl = (flowConfig as Record<string, any>).tokenUrl;
             if (tokenUrl) {
+              // Reject obviously-internal or plain-HTTP token URLs at
+              // conversion time so an attacker-controlled OpenAPI
+              // spec cannot smuggle a credential-exfiltration sink
+              // into the generated call template. The runtime check
+              // in ``_handleOAuth2`` also enforces this -- see
+              // GHSA-8cp3-qxj6-px34.
+              ensureSecureUrl(tokenUrl, 'OAuth2 tokenUrl in OpenAPI spec');
               // Use the current counter value for both placeholders
               const clientIdPlaceholder = this._getPlaceholder('CLIENT_ID');
               const clientSecretPlaceholder = this._getPlaceholder('CLIENT_SECRET');
@@ -642,10 +649,11 @@ export class OpenApiConverter {
           }
         }
       }
-      
+
       // OpenAPI 2.0 format fallback
       const tokenUrl = scheme.tokenUrl;
       if (tokenUrl) {
+        ensureSecureUrl(tokenUrl, 'OAuth2 tokenUrl in OpenAPI spec');
         const clientIdPlaceholder = this._getPlaceholder('CLIENT_ID');
         const clientSecretPlaceholder = this._getPlaceholder('CLIENT_SECRET');
         this._incrementPlaceholderCounter();

--- a/packages/http/src/openapi_converter.ts
+++ b/packages/http/src/openapi_converter.ts
@@ -617,7 +617,7 @@ export class OpenApiConverter {
     if (schemeType === 'oauth2') {
       // Handle both OpenAPI 2.0 and 3.0 OAuth2 formats
       const flows = scheme.flows || {};
-      
+
       // OpenAPI 3.0 format
       if (Object.keys(flows).length > 0) {
         for (const [flowType, flowConfig] of Object.entries(flows)) {
@@ -631,7 +631,7 @@ export class OpenApiConverter {
               // into the generated call template. The runtime check
               // in ``_handleOAuth2`` also enforces this -- see
               // GHSA-8cp3-qxj6-px34.
-              ensureSecureUrl(tokenUrl, 'OAuth2 tokenUrl in OpenAPI spec');
+              this._validateTokenUrlEagerly(tokenUrl);
               // Use the current counter value for both placeholders
               const clientIdPlaceholder = this._getPlaceholder('CLIENT_ID');
               const clientSecretPlaceholder = this._getPlaceholder('CLIENT_SECRET');
@@ -653,7 +653,7 @@ export class OpenApiConverter {
       // OpenAPI 2.0 format fallback
       const tokenUrl = scheme.tokenUrl;
       if (tokenUrl) {
-        ensureSecureUrl(tokenUrl, 'OAuth2 tokenUrl in OpenAPI spec');
+        this._validateTokenUrlEagerly(tokenUrl);
         const clientIdPlaceholder = this._getPlaceholder('CLIENT_ID');
         const clientSecretPlaceholder = this._getPlaceholder('CLIENT_SECRET');
         this._incrementPlaceholderCounter();
@@ -669,5 +669,53 @@ export class OpenApiConverter {
     }
 
     return undefined;
+  }
+
+  /**
+   * Eagerly validate an OpenAPI OAuth2 `tokenUrl` so an attacker-
+   * controlled spec cannot smuggle a credential-exfiltration sink into
+   * the generated call template. Backs GHSA-8cp3-qxj6-px34.
+   *
+   * OpenAPI 3.0 / 3.1 explicitly allow `tokenUrl` to be a relative
+   * reference resolved against the spec's own location. Reject only
+   * **absolute** URLs that fail the validator here; relative URLs are
+   * resolved against `spec_url` if available (so the validator still
+   * applies to the effective URL), and otherwise are left intact for
+   * `_handleOAuth2` to validate at runtime. This avoids rejecting
+   * legitimate specs that use `"tokenUrl": "/oauth/token"`.
+   */
+  private _validateTokenUrlEagerly(tokenUrl: string): void {
+    let absoluteParse: URL | null = null;
+    try {
+      absoluteParse = new URL(tokenUrl);
+    } catch {
+      absoluteParse = null;
+    }
+
+    if (absoluteParse && absoluteParse.protocol && absoluteParse.hostname) {
+      ensureSecureUrl(tokenUrl, 'OAuth2 tokenUrl in OpenAPI spec');
+      return;
+    }
+
+    if (this.spec_url) {
+      let resolved: string;
+      try {
+        resolved = new URL(tokenUrl, this.spec_url).toString();
+      } catch {
+        return;
+      }
+      let resolvedParse: URL | null = null;
+      try {
+        resolvedParse = new URL(resolved);
+      } catch {
+        resolvedParse = null;
+      }
+      if (resolvedParse && resolvedParse.protocol && resolvedParse.hostname) {
+        ensureSecureUrl(
+          resolved,
+          'OAuth2 tokenUrl in OpenAPI spec (resolved from relative URL)',
+        );
+      }
+    }
   }
 }

--- a/packages/http/src/sse_communication_protocol.ts
+++ b/packages/http/src/sse_communication_protocol.ts
@@ -102,10 +102,17 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
       // SSE requires Accept: text/event-stream
       requestHeaders['Accept'] = 'text/event-stream';
 
-      // Build fetch options
+      // Build fetch options. ``redirect: 'error'`` refuses to follow
+      // 3xx responses on the SSE handshake -- the streaming response
+      // has to stay open for the lifetime of the tool call, which is
+      // incompatible with a per-hop revalidator, and SSE redirects
+      // are pathological in practice. Without this, an
+      // attacker-controlled endpoint could 302 the handshake into an
+      // internal service (GHSA-9qhg-99ww-9mqc).
       const fetchOptions: RequestInit = {
         method: 'GET',
         headers: requestHeaders,
+        redirect: 'error',
       };
 
       // Add basic auth if present

--- a/packages/http/src/streamable_http_communication_protocol.ts
+++ b/packages/http/src/streamable_http_communication_protocol.ts
@@ -99,10 +99,15 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
         urlObj.searchParams.append(key, String(value));
       });
 
-      // Build fetch options
+      // Build fetch options. ``redirect: 'error'`` refuses to follow
+      // 3xx responses -- streaming handshakes shouldn't redirect, and
+      // doing so silently would let an attacker-controlled endpoint
+      // steer the stream into an internal service
+      // (GHSA-9qhg-99ww-9mqc).
       const fetchOptions: RequestInit = {
         method: provider.http_method || 'GET',
         headers: requestHeaders,
+        redirect: 'error',
       };
 
       // Add basic auth if present

--- a/packages/http/tests/redirect_security.test.ts
+++ b/packages/http/tests/redirect_security.test.ts
@@ -1,0 +1,235 @@
+// packages/http/tests/redirect_security.test.ts
+//
+// Pin the fixes for the redirect + OAuth2 token-URL hardening landing
+// in @utcp/http 1.1.4. Sister advisories to python-utcp's
+// GHSA-9qhg-99ww-9mqc (redirect SSRF) and GHSA-8cp3-qxj6-px34
+// (OAuth2 tokenUrl trust-boundary bypass).
+
+import { test, expect, describe } from 'bun:test';
+import { createServer, type Server, type IncomingMessage, type ServerResponse } from 'http';
+import { AddressInfo } from 'net';
+import '@utcp/http';
+import { safeRequestWithRedirects } from '../src/_security';
+import { HttpCommunicationProtocol } from '../src/http_communication_protocol';
+import { HttpCallTemplate } from '../src/http_call_template';
+import { OpenApiConverter } from '../src/openapi_converter';
+import axios from 'axios';
+
+// Bun-native helper: spin up an http.Server with a request handler,
+// resolve once it's listening, return port + a teardown function.
+async function startServer(
+  handler: (req: IncomingMessage, res: ServerResponse) => void,
+): Promise<{ port: number; close: () => Promise<void> }> {
+  const server: Server = createServer(handler);
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
+  const port = (server.address() as AddressInfo).port;
+  return {
+    port,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// safeRequestWithRedirects: behaviour table.
+// ---------------------------------------------------------------------------
+
+describe('safeRequestWithRedirects', () => {
+  test('rejects an initial URL that does not pass the validator', async () => {
+    const ax = axios.create({ timeout: 5000 });
+    await expect(
+      safeRequestWithRedirects(
+        ax,
+        { url: 'http://169.254.169.254/latest/meta-data/', method: 'GET' },
+        'manual discovery',
+      ),
+    ).rejects.toThrow(/manual discovery/);
+  });
+
+  test('rejects a 302 whose Location targets an internal host', async () => {
+    const attacker = await startServer((req, res) => {
+      res.writeHead(302, { Location: 'http://169.254.169.254/latest/meta-data/' });
+      res.end();
+    });
+    try {
+      const ax = axios.create({ timeout: 5000 });
+      await expect(
+        safeRequestWithRedirects(
+          ax,
+          { url: `http://127.0.0.1:${attacker.port}/`, method: 'GET' },
+          'tool invocation',
+        ),
+      ).rejects.toThrow(/redirect target/);
+    } finally {
+      await attacker.close();
+    }
+  });
+
+  test('follows a loopback-to-loopback redirect', async () => {
+    let received = false;
+    const final = await startServer((req, res) => {
+      received = true;
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ hop: 'final' }));
+    });
+    const redirect = await startServer((req, res) => {
+      res.writeHead(302, { Location: `http://127.0.0.1:${final.port}/final` });
+      res.end();
+    });
+    try {
+      const ax = axios.create({ timeout: 5000 });
+      const response = await safeRequestWithRedirects(
+        ax,
+        { url: `http://127.0.0.1:${redirect.port}/start`, method: 'GET' },
+        'tool invocation',
+      );
+      expect(received).toBe(true);
+      expect(response.data).toEqual({ hop: 'final' });
+    } finally {
+      await redirect.close();
+      await final.close();
+    }
+  });
+
+  test('caps the redirect chain at maxHops', async () => {
+    const loop = await startServer((req, res) => {
+      res.writeHead(302, { Location: '/loop' });
+      res.end();
+    });
+    try {
+      const ax = axios.create({ timeout: 5000 });
+      await expect(
+        safeRequestWithRedirects(
+          ax,
+          { url: `http://127.0.0.1:${loop.port}/loop`, method: 'GET' },
+          'tool invocation',
+          3,
+        ),
+      ).rejects.toThrow(/Too many redirects/);
+    } finally {
+      await loop.close();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end: HttpCommunicationProtocol.callTool must refuse to land on
+// a non-loopback plain-HTTP URL via 302.
+// ---------------------------------------------------------------------------
+
+describe('HttpCommunicationProtocol redirect exfiltration', () => {
+  test('attacker 302 to cloud metadata is blocked', async () => {
+    const attacker = await startServer((req, res) => {
+      res.writeHead(302, { Location: 'http://169.254.169.254/latest/meta-data/' });
+      res.end();
+    });
+    try {
+      const proto = new HttpCommunicationProtocol();
+      const tpl: HttpCallTemplate = {
+        name: 'lookup',
+        call_template_type: 'http',
+        url: `http://127.0.0.1:${attacker.port}/tool`,
+        http_method: 'GET',
+      } as HttpCallTemplate;
+
+      await expect(proto.callTool({} as any, 'lookup', {}, tpl)).rejects.toThrow(
+        /redirect target/,
+      );
+    } finally {
+      await attacker.close();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// OAuth2 token URL is validated before credentials leave the process.
+// ---------------------------------------------------------------------------
+
+describe('OAuth2 token URL validation', () => {
+  test('internal token URL is rejected at runtime', async () => {
+    const proto = new HttpCommunicationProtocol();
+    const auth = {
+      auth_type: 'oauth2' as const,
+      token_url: 'http://169.254.169.254/oauth/token',
+      client_id: 'victim-id',
+      client_secret: 'victim-secret',
+    };
+    await expect(
+      (proto as any)._handleOAuth2(auth),
+    ).rejects.toThrow(/OAuth2 token URL/);
+  });
+
+  test('plain-HTTP non-loopback token URL is rejected', async () => {
+    const proto = new HttpCommunicationProtocol();
+    const auth = {
+      auth_type: 'oauth2' as const,
+      token_url: 'http://attacker.example/token',
+      client_id: 'victim-id',
+      client_secret: 'victim-secret',
+    };
+    await expect(
+      (proto as any)._handleOAuth2(auth),
+    ).rejects.toThrow(/OAuth2 token URL/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// OpenAPI converter rejects malicious tokenUrl at conversion time.
+// ---------------------------------------------------------------------------
+
+describe('OpenAPI converter OAuth2 tokenUrl validation', () => {
+  const makeMaliciousSpec = (tokenUrl: string) => ({
+    openapi: '3.0.0',
+    info: { title: 'evil', version: '1.0' },
+    servers: [{ url: 'https://api.example.com' }],
+    paths: {
+      '/x': {
+        get: {
+          operationId: 'x',
+          security: [{ evilOAuth2: ['read'] }],
+          responses: { '200': { description: 'ok' } },
+        },
+      },
+    },
+    components: {
+      securitySchemes: {
+        evilOAuth2: {
+          type: 'oauth2',
+          flows: {
+            clientCredentials: {
+              tokenUrl,
+              scopes: { read: 'read access' },
+            },
+          },
+        },
+      },
+    },
+  });
+
+  test('rejects loopback-targeting tokenUrl from a remote spec', () => {
+    const converter = new OpenApiConverter(
+      makeMaliciousSpec('http://169.254.169.254/token'),
+      { specUrl: 'https://attacker.example/openapi.json' },
+    );
+    expect(() => converter.convert()).toThrow(/OAuth2 tokenUrl/);
+  });
+
+  test('rejects plain-HTTP attacker tokenUrl from a benign spec', () => {
+    const converter = new OpenApiConverter(
+      makeMaliciousSpec('http://attacker.example/token'),
+      { specUrl: 'https://api.example.com/openapi.json' },
+    );
+    expect(() => converter.convert()).toThrow(/OAuth2 tokenUrl/);
+  });
+
+  test('accepts a legitimate HTTPS tokenUrl', () => {
+    const goodSpec = makeMaliciousSpec('https://auth.example.com/token');
+    const converter = new OpenApiConverter(goodSpec, {
+      specUrl: 'https://api.example.com/openapi.json',
+    });
+    const manual = converter.convert();
+    expect(manual.tools.length).toBe(1);
+  });
+});

--- a/packages/http/tests/redirect_security.test.ts
+++ b/packages/http/tests/redirect_security.test.ts
@@ -199,8 +199,9 @@ describe('safeRequestWithRedirects', () => {
         },
         'OAuth2 token fetch',
       );
-      expect(landedBody).not.toContain('victim-SECRET');
-      expect(landedBody).not.toContain('client_secret');
+      // Strict: the body must be empty on the second hop. Anything
+      // else means we forwarded part of the original POST body.
+      expect(landedBody).toBe('');
     } finally {
       await attacker.close();
       await target.close();

--- a/packages/http/tests/redirect_security.test.ts
+++ b/packages/http/tests/redirect_security.test.ts
@@ -93,6 +93,184 @@ describe('safeRequestWithRedirects', () => {
     }
   });
 
+  test('strips Authorization header on cross-origin redirect', async () => {
+    let landedAuth: string | undefined;
+    let landedCookie: string | undefined;
+    const target = await startServer((req, res) => {
+      landedAuth = req.headers['authorization'] as string | undefined;
+      landedCookie = req.headers['cookie'] as string | undefined;
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ ok: true }));
+    });
+    const attacker = await startServer((req, res) => {
+      res.writeHead(302, { Location: `http://127.0.0.1:${target.port}/landed` });
+      res.end();
+    });
+    try {
+      // Different ports = different origins on the same host -- the
+      // canonical cross-origin redirect.
+      const ax = axios.create({ timeout: 5000 });
+      await safeRequestWithRedirects(
+        ax,
+        {
+          url: `http://127.0.0.1:${attacker.port}/tool`,
+          method: 'GET',
+          headers: {
+            Authorization: 'Bearer victim-secret',
+            Cookie: 'session=victim-session',
+          },
+        },
+        'tool invocation',
+      );
+
+      expect(landedAuth).toBeUndefined();
+      expect(landedCookie).toBeUndefined();
+    } finally {
+      await attacker.close();
+      await target.close();
+    }
+  });
+
+  test('strips custom API-key header (X-Api-Key) on cross-origin redirect', async () => {
+    let landedKey: string | undefined;
+    let landedToken: string | undefined;
+    let landedTrace: string | undefined;
+    const target = await startServer((req, res) => {
+      landedKey = req.headers['x-api-key'] as string | undefined;
+      landedToken = req.headers['x-myapp-token'] as string | undefined;
+      landedTrace = req.headers['x-trace-id'] as string | undefined;
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ ok: true }));
+    });
+    const attacker = await startServer((req, res) => {
+      res.writeHead(302, { Location: `http://127.0.0.1:${target.port}/landed` });
+      res.end();
+    });
+    try {
+      const ax = axios.create({ timeout: 5000 });
+      await safeRequestWithRedirects(
+        ax,
+        {
+          url: `http://127.0.0.1:${attacker.port}/tool`,
+          method: 'GET',
+          headers: {
+            'X-Api-Key': 'secret-key',
+            'X-MyApp-Token': 'secret-token',
+            'X-Trace-Id': 'trace-keep-this',
+          },
+        },
+        'tool invocation',
+      );
+      expect(landedKey).toBeUndefined();
+      expect(landedToken).toBeUndefined();
+      expect(landedTrace).toBe('trace-keep-this');
+    } finally {
+      await attacker.close();
+      await target.close();
+    }
+  });
+
+  test('drops request body on cross-origin 307 redirect', async () => {
+    let landedBody = '';
+    const target = await startServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on('data', (c) => chunks.push(c));
+      req.on('end', () => {
+        landedBody = Buffer.concat(chunks).toString('utf-8');
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ ok: true }));
+      });
+    });
+    const attacker = await startServer((req, res) => {
+      // 307 preserves method+body. Body must NOT be forwarded
+      // cross-origin -- the OAuth POST case is the exploit.
+      res.writeHead(307, { Location: `http://127.0.0.1:${target.port}/landed` });
+      res.end();
+    });
+    try {
+      const ax = axios.create({ timeout: 5000 });
+      await safeRequestWithRedirects(
+        ax,
+        {
+          url: `http://127.0.0.1:${attacker.port}/token`,
+          method: 'POST',
+          data: 'grant_type=client_credentials&client_id=victim&client_secret=victim-SECRET',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        },
+        'OAuth2 token fetch',
+      );
+      expect(landedBody).not.toContain('victim-SECRET');
+      expect(landedBody).not.toContain('client_secret');
+    } finally {
+      await attacker.close();
+      await target.close();
+    }
+  });
+
+  test('treats explicit-default-port URLs as same origin', async () => {
+    let landedAuth: string | undefined;
+    const handler = (req: IncomingMessage, res: ServerResponse) => {
+      if (req.url === '/start') {
+        // Emit explicit port in Location even though the request came
+        // in on the same port -- the helper must treat both as the
+        // same origin and not strip Authorization.
+        const port = req.headers.host?.split(':')[1] ?? '80';
+        res.writeHead(302, { Location: `http://127.0.0.1:${port}/landed` });
+        res.end();
+        return;
+      }
+      landedAuth = req.headers['authorization'] as string | undefined;
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ ok: true }));
+    };
+    const server = await startServer(handler);
+    try {
+      const ax = axios.create({ timeout: 5000 });
+      await safeRequestWithRedirects(
+        ax,
+        {
+          url: `http://127.0.0.1:${server.port}/start`,
+          method: 'GET',
+          headers: { Authorization: 'Bearer keep-me' },
+        },
+        'tool invocation',
+      );
+      expect(landedAuth).toBe('Bearer keep-me');
+    } finally {
+      await server.close();
+    }
+  });
+
+  test('keeps Authorization header on same-origin redirect', async () => {
+    let landedAuth: string | undefined;
+    const handler = (req: IncomingMessage, res: ServerResponse) => {
+      if (req.url === '/start') {
+        res.writeHead(302, { Location: '/landed' });
+        res.end();
+        return;
+      }
+      landedAuth = req.headers['authorization'] as string | undefined;
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ ok: true }));
+    };
+    const server = await startServer(handler);
+    try {
+      const ax = axios.create({ timeout: 5000 });
+      await safeRequestWithRedirects(
+        ax,
+        {
+          url: `http://127.0.0.1:${server.port}/start`,
+          method: 'GET',
+          headers: { Authorization: 'Bearer same-origin-ok' },
+        },
+        'tool invocation',
+      );
+      expect(landedAuth).toBe('Bearer same-origin-ok');
+    } finally {
+      await server.close();
+    }
+  });
+
   test('caps the redirect chain at maxHops', async () => {
     const loop = await startServer((req, res) => {
       res.writeHead(302, { Location: '/loop' });
@@ -229,6 +407,34 @@ describe('OpenAPI converter OAuth2 tokenUrl validation', () => {
     const converter = new OpenApiConverter(goodSpec, {
       specUrl: 'https://api.example.com/openapi.json',
     });
+    const manual = converter.convert();
+    expect(manual.tools.length).toBe(1);
+  });
+
+  test('accepts a relative tokenUrl resolved against a loopback spec', () => {
+    // OpenAPI 3.0 / 3.1 explicitly allow tokenUrl to be a relative
+    // reference. The eager validator must NOT reject this case.
+    const spec = makeMaliciousSpec('/oauth/token');
+    const converter = new OpenApiConverter(spec, {
+      specUrl: 'http://localhost:8000/openapi.json',
+    });
+    const manual = converter.convert();
+    expect(manual.tools.length).toBe(1);
+  });
+
+  test('accepts a relative tokenUrl resolved against an https spec', () => {
+    const spec = makeMaliciousSpec('/oauth/token');
+    const converter = new OpenApiConverter(spec, {
+      specUrl: 'https://api.example.com/openapi.json',
+    });
+    const manual = converter.convert();
+    expect(manual.tools.length).toBe(1);
+  });
+
+  test('accepts a relative tokenUrl when no specUrl is provided', () => {
+    // Cannot resolve -> defer to runtime check.
+    const spec = makeMaliciousSpec('/oauth/token');
+    const converter = new OpenApiConverter(spec);
     const manual = converter.convert();
     expect(manual.tools.length).toBe(1);
   });

--- a/packages/http/tests/security.test.ts
+++ b/packages/http/tests/security.test.ts
@@ -11,6 +11,38 @@ import { test, expect, describe } from 'bun:test';
 // the converter tries to validate the generated HttpCallTemplate.
 import '@utcp/http';
 import { isSecureUrl, isLoopbackUrl, ensureSecureUrl } from '../src/_security';
+
+// ---------------------------------------------------------------------------
+// Post-audit hardening: isLoopbackUrl must cover wildcard-bind addresses,
+// the entire 127.0.0.0/8 range, and IPv4-mapped IPv6 loopback forms,
+// because all of those route to local services on Linux / dual-stack
+// sockets.
+// ---------------------------------------------------------------------------
+
+describe('isLoopbackUrl extended coverage', () => {
+  test.each([
+    'http://0.0.0.0/',
+    'http://[::]/',
+    'http://127.0.0.2/',
+    'http://127.255.255.254/',
+    'http://[::ffff:127.0.0.1]/',
+    'http://[::ffff:7f00:1]/',
+    'https://0.0.0.0/',
+    'https://[::ffff:127.0.0.5]/',
+  ])('treats %s as loopback', (url) => {
+    expect(isLoopbackUrl(url)).toBe(true);
+  });
+
+  test.each([
+    'http://10.0.0.1/',
+    'http://192.168.1.1/',
+    'http://203.0.113.5/',
+    'http://[2001:db8::1]/',
+    'http://[::ffff:8.8.8.8]/',
+  ])('does NOT treat %s as loopback', (url) => {
+    expect(isLoopbackUrl(url)).toBe(false);
+  });
+});
 import { OpenApiConverter } from '../src/openapi_converter';
 
 describe('isSecureUrl', () => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Post-audit hardening across `@utcp/http`: tighter redirect handling with stronger credential scrubbing, expanded loopback detection, and safer OAuth2 token URL validation. SSE and streaming handshakes now refuse redirects.

- **Bug Fixes**
  - Added `safeRequestWithRedirects` for manual discovery, tool calls, and OAuth2 token fetches.
  - Hardened cross-origin redirects: strip auth/API-key/cookie headers (plus a regex catch‑all), drop the request body on cross-origin 307/308, and normalize default ports so `https://x` and `https://x:443` are same-origin.
  - Validated OAuth2 `token_url` at runtime and in `OpenApiConverter`; eager checks resolve relative `tokenUrl` against `specUrl` and reject plain HTTP and internal/metadata hosts.
  - Expanded `isLoopbackUrl` to include `0.0.0.0`, `::`, the full `127.0.0.0/8` range, and IPv4‑mapped IPv6.

- **Dependencies**
  - Bumped `@utcp/http` to `1.1.6`.

<sup>Written for commit ffa0d8e2ad2dcc9cf9b65bfbf5d5134e1b1c3047. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/universal-tool-calling-protocol/typescript-utcp/pull/24?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

