### PR TITLE
Add oauth with user signin

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@utcp/sdk",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Universal Tool Calling Protocol SDK",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/packages/core/src/data/auth_implementations/oauth2_user_auth.ts
+++ b/packages/core/src/data/auth_implementations/oauth2_user_auth.ts
@@ -1,0 +1,72 @@
+// packages/core/src/data/auth_implementations/oauth2_user_auth.ts
+import { z } from 'zod';
+import { Serializer } from '../../interfaces/serializer';
+import { Auth } from '../auth';
+
+/**
+ * Interface for interactive (user sign-in) OAuth2 authentication.
+ *
+ * This variant is DECLARATIVE ONLY: it describes how a user-delegated token is
+ * obtained (device-code or authorization-code flow) and carries the runtime
+ * bearer token once provisioned. UTCP itself NEVER runs the interactive flow —
+ * that requires a user channel and token persistence which a transport handler
+ * does not have. An external tool (e.g. `@utcp/code-mode-cli login`) performs
+ * the sign-in and writes the token into a variable referenced by `access_token`
+ * (typically `"${MY_TOKEN}"`). At call time UTCP simply injects the resolved
+ * token as a bearer header.
+ *
+ * For MCP manuals the endpoints are discovered from the server, so `grant_type`,
+ * `token_endpoint`, `client_id` and the endpoint fields are optional — only
+ * `access_token` is always required.
+ */
+export interface OAuth2UserAuth extends Auth {
+  auth_type: 'oauth2_user';
+  /** Runtime bearer token, normally an injected variable like "${MY_TOKEN}". */
+  access_token: string;
+  /** Which interactive flow the login tool should run. */
+  grant_type?: 'device_code' | 'authorization_code';
+  /** OAuth2 token endpoint (for HTTP manuals; discovered for MCP). */
+  token_endpoint?: string;
+  /** Public OAuth2 client id (omit for MCP dynamic client registration). */
+  client_id?: string;
+  /** Optional requested scope. */
+  scope?: string;
+  /** Device authorization endpoint — required for the device_code flow. */
+  device_authorization_endpoint?: string;
+  /** Authorization endpoint — required for the authorization_code flow. */
+  authorization_endpoint?: string;
+  /** Header name to inject the token into. Defaults to "Authorization". */
+  var_name?: string;
+  /** Token prefix. Defaults to "Bearer ". */
+  prefix?: string;
+}
+
+export class OAuth2UserAuthSerializer extends Serializer<OAuth2UserAuth> {
+  toDict(obj: OAuth2UserAuth): { [key: string]: any } {
+    // Just spread the object since it's already validated
+    return { ...obj };
+  }
+
+  validateDict(obj: { [key: string]: any }): OAuth2UserAuth {
+    return OAuth2UserAuthSchema.parse(obj);
+  }
+}
+
+/**
+ * Authentication using an interactive (user-delegated) OAuth2 token.
+ * The token is provisioned out-of-band by a login tool and injected as a
+ * bearer header at call time. Not `.strict()` so providers can carry the
+ * declarative flow metadata used by the login tool.
+ */
+const OAuth2UserAuthSchema: z.ZodType<OAuth2UserAuth> = z.object({
+  auth_type: z.literal('oauth2_user'),
+  access_token: z.string().describe('Runtime bearer token. Recommended to use an injected variable like "${MY_TOKEN}".'),
+  grant_type: z.enum(['device_code', 'authorization_code']).optional().describe('Interactive flow the login tool should run.'),
+  token_endpoint: z.string().optional().describe('OAuth2 token endpoint (discovered for MCP manuals).'),
+  client_id: z.string().optional().describe('Public OAuth2 client id (omit for MCP dynamic client registration).'),
+  scope: z.string().optional().describe('Optional requested scope.'),
+  device_authorization_endpoint: z.string().optional().describe('Device authorization endpoint — required for the device_code flow.'),
+  authorization_endpoint: z.string().optional().describe('Authorization endpoint — required for the authorization_code flow.'),
+  var_name: z.string().optional().describe('Header name to inject the token into. Defaults to "Authorization".'),
+  prefix: z.string().optional().describe('Token prefix. Defaults to "Bearer ".'),
+}) as z.ZodType<OAuth2UserAuth>;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,6 +8,7 @@ export * from './data/auth';
 export * from './data/auth_implementations/api_key_auth';
 export * from './data/auth_implementations/basic_auth';
 export * from './data/auth_implementations/oauth2_auth';
+export * from './data/auth_implementations/oauth2_user_auth';
 export * from './data/call_template';
 export * from './data/tool';
 export * from './data/utcp_manual';

--- a/packages/core/src/plugins/plugin_loader.ts
+++ b/packages/core/src/plugins/plugin_loader.ts
@@ -3,6 +3,7 @@ import { AuthSerializer } from '../data/auth';
 import { ApiKeyAuthSerializer } from '../data/auth_implementations/api_key_auth';
 import { BasicAuthSerializer } from '../data/auth_implementations/basic_auth';
 import { OAuth2AuthSerializer } from '../data/auth_implementations/oauth2_auth';
+import { OAuth2UserAuthSerializer } from '../data/auth_implementations/oauth2_user_auth';
 import { setPluginInitializer } from '../interfaces/serializer';
 
 // Core Tool Repository
@@ -29,6 +30,7 @@ function _registerCorePlugins(): void {
   AuthSerializer.registerAuth('api_key', new ApiKeyAuthSerializer());
   AuthSerializer.registerAuth('basic', new BasicAuthSerializer());
   AuthSerializer.registerAuth('oauth2', new OAuth2AuthSerializer());
+  AuthSerializer.registerAuth('oauth2_user', new OAuth2UserAuthSerializer());
 
   // Register Tool Repository Serializers
   ConcurrentToolRepositoryConfigSerializer.registerRepository('in_memory', new InMemConcurrentToolRepositorySerializer());

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@utcp/http",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "HTTP utilities for UTCP",
   "main": "dist/index.cjs",
   "module": "dist/index.js",
@@ -43,7 +43,7 @@
     }
   },
   "dependencies": {
-    "@utcp/sdk": "^1.1.0",
+    "@utcp/sdk": "^1.1.1",
     "axios": "^1.11.0",
     "js-yaml": "^4.1.0"
   },

--- a/packages/http/src/_security.ts
+++ b/packages/http/src/_security.ts
@@ -179,6 +179,37 @@ export function ensureSecureUrl(url: string, context?: string): void {
   );
 }
 
+/**
+ * Refuse CR/LF in attacker-influenceable strings that will land in
+ * HTTP headers.
+ *
+ * The underlying Node http stack already rejects CR/LF in header
+ * names/values (`ERR_INVALID_CHAR`), and axios + fetch ride that code
+ * path. This helper is defense-in-depth -- enforcing the trust
+ * boundary inside UTCP means a transport swap, polyfill, or future
+ * runtime change can't silently regress.
+ *
+ * Centralised here so every protocol in `@utcp/http` (http, sse,
+ * streamable_http) shares a single implementation and future fixes
+ * apply consistently. Mirrors `utcp_http._security._assert_no_crlf`
+ * from the Python reference implementation.
+ *
+ * @param value Any string field that will become part of an outbound
+ *   header (header name, prefix, or value).
+ * @param fieldName Short label included in the error so log readers
+ *   know which input was rejected.
+ * @throws Error if `value` contains `\r` or `\n`.
+ */
+export function assertNoCrlf(value: string | undefined, fieldName: string): void {
+  if (typeof value !== 'string') return;
+  if (value.includes('\r') || value.includes('\n')) {
+    throw new Error(
+      `Refusing to construct request: ${fieldName} contains CR/LF, ` +
+        `which would enable HTTP header injection.`,
+    );
+  }
+}
+
 // Local type alias avoids importing the full axios type surface here.
 // The helper is intentionally axios-agnostic at the type level so the
 // (de-facto small) request surface stays decoupled.

--- a/packages/http/src/_security.ts
+++ b/packages/http/src/_security.ts
@@ -298,12 +298,22 @@ function sameOrigin(a: string, b: string): boolean {
  *     exact credentials we're trying to protect. Refuse to resend it
  *     cross-origin.
  */
-function scrubCrossOriginCredentials(config: Record<string, any>): void {
+function scrubCrossOriginCredentials(
+  config: Record<string, any>,
+  extraAuthHeaderNames: ReadonlySet<string> = new Set<string>(),
+): void {
   const headers = config.headers;
   if (headers && typeof headers === 'object') {
     const scrubbed: Record<string, any> = {};
     for (const [k, v] of Object.entries(headers)) {
       if (headerIsAuthSensitive(k)) continue;
+      // Strip caller-configured auth header names too -- e.g. an
+      // `ApiKeyAuth` with `var_name: "X-MyApp"` whose name doesn't
+      // match the auth-pattern regex. Without this, custom auth
+      // header names survive cross-origin redirects.
+      if (typeof k === 'string' && extraAuthHeaderNames.has(k.toLowerCase())) {
+        continue;
+      }
       scrubbed[k] = v;
     }
     config.headers = scrubbed;
@@ -344,6 +354,7 @@ export async function safeRequestWithRedirects<T = any>(
   config: { url: string; method: string; data?: any; [key: string]: any },
   context: string,
   maxHops: number = 5,
+  authHeaderNames: ReadonlyArray<string> = [],
 ): Promise<{ status: number; headers: Record<string, any>; data: T }> {
   ensureSecureUrl(config.url, context);
 
@@ -356,6 +367,17 @@ export async function safeRequestWithRedirects<T = any>(
   if (working.headers && typeof working.headers === 'object') {
     working.headers = { ...working.headers };
   }
+
+  // ``authHeaderNames`` is the explicit declaration of which header
+  // names the caller populated with a secret. Used to extend the
+  // cross-origin scrub beyond the canonical set so a custom-named
+  // API-key header (e.g. ``X-MyApp``) configured via ``ApiKeyAuth``
+  // / ``OAuth2UserAuth`` is also stripped on cross-origin redirect.
+  const extraAuthHeaderNames: ReadonlySet<string> = new Set(
+    authHeaderNames
+      .filter((n): n is string => typeof n === 'string')
+      .map((n) => n.toLowerCase()),
+  );
 
   let currentUrl = working.url;
   let hops = 0;
@@ -398,7 +420,7 @@ export async function safeRequestWithRedirects<T = any>(
     // server and our ``Authorization`` header / basic ``auth`` /
     // ``params`` API key would be forwarded along.
     if (!sameOrigin(currentUrl, nextUrl)) {
-      scrubCrossOriginCredentials(working);
+      scrubCrossOriginCredentials(working, extraAuthHeaderNames);
     }
 
     if (response.status === 303) {

--- a/packages/http/src/http_communication_protocol.ts
+++ b/packages/http/src/http_communication_protocol.ts
@@ -9,10 +9,27 @@ import { UtcpManualSchema } from '@utcp/sdk';
 import { ApiKeyAuth } from '@utcp/sdk'; 
 import { BasicAuth } from '@utcp/sdk';
 import { OAuth2Auth } from '@utcp/sdk';
-import { IUtcpClient } from '@utcp/sdk'; 
+import { OAuth2UserAuth } from '@utcp/sdk';
+import { IUtcpClient } from '@utcp/sdk';
 import { HttpCallTemplateSchema, HttpCallTemplate } from './http_call_template';
 import { OpenApiConverter } from './openapi_converter';
 import { ensureSecureUrl, safeRequestWithRedirects } from './_security';
+
+/**
+ * Refuse CR/LF in attacker-influenceable strings that will land in HTTP
+ * headers. Node's http stack already rejects these (it throws
+ * ``ERR_INVALID_CHAR``), so this is defense-in-depth -- if the underlying
+ * transport ever changes, we keep the trust boundary.
+ */
+function assertNoCrlf(value: string | undefined, fieldName: string): void {
+  if (typeof value !== 'string') return;
+  if (value.includes('\r') || value.includes('\n')) {
+    throw new Error(
+      `Refusing to construct request: ${fieldName} contains CR/LF, ` +
+        `which would enable HTTP header injection.`,
+    );
+  }
+}
 
 /**
  * HTTP communication protocol implementation for UTCP client.
@@ -68,15 +85,18 @@ export class HttpCommunicationProtocol implements CommunicationProtocol {
         timeout: 10000
       };
 
-      await this._applyAuthToRequestConfig(httpCallTemplate, requestConfig);
+      const { authHeaderNames } = await this._applyAuthToRequestConfig(httpCallTemplate, requestConfig);
       // Re-validate every redirect hop. axios's default
       // ``maxRedirects: 5`` would otherwise let an attacker-controlled
       // discovery URL 302 us into an internal service
-      // (GHSA-9qhg-99ww-9mqc).
+      // (GHSA-9qhg-99ww-9mqc). ``authHeaderNames`` extends the scrub
+      // so custom-named auth headers also get stripped cross-origin.
       const response = await safeRequestWithRedirects(
         this._axiosInstance,
         requestConfig as any,
         'manual discovery',
+        undefined,
+        authHeaderNames,
       );
       const contentType = response.headers['content-type'] || '';
       let responseData: any;
@@ -188,7 +208,7 @@ export class HttpCommunicationProtocol implements CommunicationProtocol {
       timeout: httpCallTemplate.timeout
     };
 
-    await this._applyAuthToRequestConfig(httpCallTemplate, requestConfig);
+    const { authHeaderNames } = await this._applyAuthToRequestConfig(httpCallTemplate, requestConfig);
 
     try {
       if (bodyContent !== undefined && !('Content-Type' in (requestConfig.headers || {}))) {
@@ -207,6 +227,8 @@ export class HttpCommunicationProtocol implements CommunicationProtocol {
         this._axiosInstance,
         requestConfig as any,
         'tool invocation',
+        undefined,
+        authHeaderNames,
       );
 
       const contentType = response.headers['content-type'] || '';
@@ -248,15 +270,27 @@ export class HttpCommunicationProtocol implements CommunicationProtocol {
   }
 
   /**
-   * Applies authentication details from the HttpCallTemplate to the Axios request configuration.
-   * This modifies `requestConfig.headers`, `requestConfig.params`, `requestConfig.auth`, and returns cookies.
+   * Applies authentication details from the HttpCallTemplate to the
+   * Axios request configuration. This modifies `requestConfig.headers`,
+   * `requestConfig.params`, `requestConfig.auth`, and returns cookies
+   * plus the list of header names that received a secret.
+   *
+   * The header-name list is threaded through to `safeRequestWithRedirects`
+   * so a custom-named API-key / OAuth2-user header is also stripped on
+   * cross-origin redirect -- without this, an `ApiKeyAuth` with
+   * `var_name: "X-MyApp"` would survive the scrub because the name
+   * doesn't match the auth-pattern regex.
    *
    * @param httpCallTemplate The CallTemplate containing authentication details.
    * @param requestConfig The Axios request configuration to modify.
-   * @returns A Promise that resolves to an object containing any cookies to be set.
+   * @returns Promise resolving to `{ cookies, authHeaderNames }`.
    */
-  private async _applyAuthToRequestConfig(httpCallTemplate: HttpCallTemplate, requestConfig: AxiosRequestConfig): Promise<Record<string, string>> {
+  private async _applyAuthToRequestConfig(
+    httpCallTemplate: HttpCallTemplate,
+    requestConfig: AxiosRequestConfig,
+  ): Promise<{ cookies: Record<string, string>; authHeaderNames: string[] }> {
     const cookies: Record<string, string> = {};
+    const authHeaderNames: string[] = [];
 
     if (httpCallTemplate.auth) {
       if (httpCallTemplate.auth.auth_type === 'api_key') {
@@ -264,10 +298,12 @@ export class HttpCommunicationProtocol implements CommunicationProtocol {
         if (!apiKeyAuth.api_key) {
           throw new Error("API key for ApiKeyAuth is empty.");
         }
+        assertNoCrlf(apiKeyAuth.var_name, 'ApiKeyAuth.var_name');
         // Default to 'header' if location is not specified
         const location = apiKeyAuth.location || 'header';
         if (location === 'header') {
           requestConfig.headers = { ...requestConfig.headers, [apiKeyAuth.var_name]: apiKeyAuth.api_key };
+          authHeaderNames.push(apiKeyAuth.var_name);
         } else if (location === 'query') {
           requestConfig.params = { ...requestConfig.params, [apiKeyAuth.var_name]: apiKeyAuth.api_key };
         } else if (location === 'cookie') {
@@ -279,13 +315,31 @@ export class HttpCommunicationProtocol implements CommunicationProtocol {
           username: basicAuth.username,
           password: basicAuth.password
         };
+        // axios sets the ``Authorization: Basic ...`` header from
+        // ``config.auth``. The scrubber strips ``config.auth``
+        // directly on cross-origin, so no name to track here.
       } else if (httpCallTemplate.auth.auth_type === 'oauth2') {
         const oauth2Auth = httpCallTemplate.auth as OAuth2Auth;
         const token = await this._handleOAuth2(oauth2Auth);
         requestConfig.headers = { ...requestConfig.headers, 'Authorization': `Bearer ${token}` };
+        authHeaderNames.push('Authorization');
+      } else if (httpCallTemplate.auth.auth_type === 'oauth2_user') {
+        // Interactive (user-delegated) OAuth2: the token is provisioned out-of-band
+        // by a login tool and injected here. UTCP never runs the interactive flow.
+        const userAuth = httpCallTemplate.auth as OAuth2UserAuth;
+        if (!userAuth.access_token) {
+          throw new Error("access_token for oauth2_user auth is empty. Run an interactive login (e.g. `code-mode login <manual>`) to provision it.");
+        }
+        const headerName = userAuth.var_name || 'Authorization';
+        const prefix = userAuth.prefix ?? 'Bearer ';
+        assertNoCrlf(headerName, 'OAuth2UserAuth.var_name');
+        assertNoCrlf(prefix, 'OAuth2UserAuth.prefix');
+        assertNoCrlf(userAuth.access_token, 'OAuth2UserAuth.access_token');
+        requestConfig.headers = { ...requestConfig.headers, [headerName]: `${prefix}${userAuth.access_token}` };
+        authHeaderNames.push(headerName);
       }
     }
-    return cookies;
+    return { cookies, authHeaderNames };
   }
 
   /**

--- a/packages/http/src/http_communication_protocol.ts
+++ b/packages/http/src/http_communication_protocol.ts
@@ -13,23 +13,7 @@ import { OAuth2UserAuth } from '@utcp/sdk';
 import { IUtcpClient } from '@utcp/sdk';
 import { HttpCallTemplateSchema, HttpCallTemplate } from './http_call_template';
 import { OpenApiConverter } from './openapi_converter';
-import { ensureSecureUrl, safeRequestWithRedirects } from './_security';
-
-/**
- * Refuse CR/LF in attacker-influenceable strings that will land in HTTP
- * headers. Node's http stack already rejects these (it throws
- * ``ERR_INVALID_CHAR``), so this is defense-in-depth -- if the underlying
- * transport ever changes, we keep the trust boundary.
- */
-function assertNoCrlf(value: string | undefined, fieldName: string): void {
-  if (typeof value !== 'string') return;
-  if (value.includes('\r') || value.includes('\n')) {
-    throw new Error(
-      `Refusing to construct request: ${fieldName} contains CR/LF, ` +
-        `which would enable HTTP header injection.`,
-    );
-  }
-}
+import { ensureSecureUrl, safeRequestWithRedirects, assertNoCrlf } from './_security';
 
 /**
  * HTTP communication protocol implementation for UTCP client.

--- a/packages/http/src/sse_communication_protocol.ts
+++ b/packages/http/src/sse_communication_protocol.ts
@@ -11,9 +11,22 @@ import { UtcpManual, UtcpManualSerializer } from '@utcp/sdk';
 import { ApiKeyAuth } from '@utcp/sdk';
 import { BasicAuth } from '@utcp/sdk';
 import { OAuth2Auth } from '@utcp/sdk';
+import { OAuth2UserAuth } from '@utcp/sdk';
 import { IUtcpClient } from '@utcp/sdk';
 import { SseCallTemplate } from './sse_call_template';
 import { ensureSecureUrl } from './_security';
+
+/** Defense-in-depth: refuse CR/LF in attacker-influenceable strings
+ *  that will land in HTTP headers. */
+function assertNoCrlf(value: string | undefined, fieldName: string): void {
+  if (typeof value !== 'string') return;
+  if (value.includes('\r') || value.includes('\n')) {
+    throw new Error(
+      `Refusing to construct request: ${fieldName} contains CR/LF, ` +
+        `which would enable HTTP header injection.`,
+    );
+  }
+}
 
 /**
  * REQUIRED
@@ -44,6 +57,7 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
       if ('api_key' in provider.auth) {
         const apiKeyAuth = provider.auth as ApiKeyAuth;
         if (apiKeyAuth.api_key) {
+          assertNoCrlf(apiKeyAuth.var_name, 'ApiKeyAuth.var_name');
           // Default to 'header' if location is not specified
           const location = apiKeyAuth.location || 'header';
           if (location === 'header') {
@@ -62,6 +76,21 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
         auth = { username: basicAuth.username, password: basicAuth.password };
       } else if ('token_url' in provider.auth) {
         // OAuth2 will be handled separately
+      } else if (provider.auth.auth_type === 'oauth2_user') {
+        // Interactive (user-delegated) OAuth2: token provisioned out-of-band.
+        const userAuth = provider.auth as OAuth2UserAuth;
+        if (!userAuth.access_token) {
+          throw new Error(
+            "access_token for oauth2_user auth is empty. Run an interactive " +
+              "login to provision it.",
+          );
+        }
+        const headerName = userAuth.var_name || 'Authorization';
+        const prefix = userAuth.prefix ?? 'Bearer ';
+        assertNoCrlf(headerName, 'OAuth2UserAuth.var_name');
+        assertNoCrlf(prefix, 'OAuth2UserAuth.prefix');
+        assertNoCrlf(userAuth.access_token, 'OAuth2UserAuth.access_token');
+        headers[headerName] = `${prefix}${userAuth.access_token}`;
       }
     }
 

--- a/packages/http/src/sse_communication_protocol.ts
+++ b/packages/http/src/sse_communication_protocol.ts
@@ -14,19 +14,7 @@ import { OAuth2Auth } from '@utcp/sdk';
 import { OAuth2UserAuth } from '@utcp/sdk';
 import { IUtcpClient } from '@utcp/sdk';
 import { SseCallTemplate } from './sse_call_template';
-import { ensureSecureUrl } from './_security';
-
-/** Defense-in-depth: refuse CR/LF in attacker-influenceable strings
- *  that will land in HTTP headers. */
-function assertNoCrlf(value: string | undefined, fieldName: string): void {
-  if (typeof value !== 'string') return;
-  if (value.includes('\r') || value.includes('\n')) {
-    throw new Error(
-      `Refusing to construct request: ${fieldName} contains CR/LF, ` +
-        `which would enable HTTP header injection.`,
-    );
-  }
-}
+import { ensureSecureUrl, assertNoCrlf } from './_security';
 
 /**
  * REQUIRED

--- a/packages/http/src/streamable_http_communication_protocol.ts
+++ b/packages/http/src/streamable_http_communication_protocol.ts
@@ -14,17 +14,7 @@ import { OAuth2Auth } from '@utcp/sdk';
 import { OAuth2UserAuth } from '@utcp/sdk';
 import { IUtcpClient } from '@utcp/sdk';
 import { StreamableHttpCallTemplate } from './streamable_http_call_template';
-import { ensureSecureUrl } from './_security';
-
-function assertNoCrlf(value: string | undefined, fieldName: string): void {
-  if (typeof value !== 'string') return;
-  if (value.includes('\r') || value.includes('\n')) {
-    throw new Error(
-      `Refusing to construct request: ${fieldName} contains CR/LF, ` +
-        `which would enable HTTP header injection.`,
-    );
-  }
-}
+import { ensureSecureUrl, assertNoCrlf } from './_security';
 
 /**
  * REQUIRED

--- a/packages/http/src/streamable_http_communication_protocol.ts
+++ b/packages/http/src/streamable_http_communication_protocol.ts
@@ -11,9 +11,20 @@ import { UtcpManual, UtcpManualSerializer } from '@utcp/sdk';
 import { ApiKeyAuth } from '@utcp/sdk';
 import { BasicAuth } from '@utcp/sdk';
 import { OAuth2Auth } from '@utcp/sdk';
+import { OAuth2UserAuth } from '@utcp/sdk';
 import { IUtcpClient } from '@utcp/sdk';
 import { StreamableHttpCallTemplate } from './streamable_http_call_template';
 import { ensureSecureUrl } from './_security';
+
+function assertNoCrlf(value: string | undefined, fieldName: string): void {
+  if (typeof value !== 'string') return;
+  if (value.includes('\r') || value.includes('\n')) {
+    throw new Error(
+      `Refusing to construct request: ${fieldName} contains CR/LF, ` +
+        `which would enable HTTP header injection.`,
+    );
+  }
+}
 
 /**
  * REQUIRED
@@ -44,6 +55,7 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
       if ('api_key' in provider.auth) {
         const apiKeyAuth = provider.auth as ApiKeyAuth;
         if (apiKeyAuth.api_key) {
+          assertNoCrlf(apiKeyAuth.var_name, 'ApiKeyAuth.var_name');
           // Default to 'header' if location is not specified
           const location = apiKeyAuth.location || 'header';
           if (location === 'header') {
@@ -62,6 +74,21 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
         auth = { username: basicAuth.username, password: basicAuth.password };
       } else if ('token_url' in provider.auth) {
         // OAuth2 will be handled separately
+      } else if (provider.auth.auth_type === 'oauth2_user') {
+        // Interactive (user-delegated) OAuth2: token provisioned out-of-band.
+        const userAuth = provider.auth as OAuth2UserAuth;
+        if (!userAuth.access_token) {
+          throw new Error(
+            "access_token for oauth2_user auth is empty. Run an interactive " +
+              "login to provision it.",
+          );
+        }
+        const headerName = userAuth.var_name || 'Authorization';
+        const prefix = userAuth.prefix ?? 'Bearer ';
+        assertNoCrlf(headerName, 'OAuth2UserAuth.var_name');
+        assertNoCrlf(prefix, 'OAuth2UserAuth.prefix');
+        assertNoCrlf(userAuth.access_token, 'OAuth2UserAuth.access_token');
+        headers[headerName] = `${prefix}${userAuth.access_token}`;
       }
     }
 

--- a/packages/http/tests/redirect_security.test.ts
+++ b/packages/http/tests/redirect_security.test.ts
@@ -272,6 +272,69 @@ describe('safeRequestWithRedirects', () => {
     }
   });
 
+  test('caller-declared custom auth header stripped on cross-origin redirect', async () => {
+    let landedKey: string | undefined;
+    const target = await startServer((req, res) => {
+      landedKey = req.headers['x-myapp'] as string | undefined;
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ ok: true }));
+    });
+    const attacker = await startServer((req, res) => {
+      res.writeHead(302, { Location: `http://127.0.0.1:${target.port}/landed` });
+      res.end();
+    });
+    try {
+      const ax = axios.create({ timeout: 5000 });
+      await safeRequestWithRedirects(
+        ax,
+        {
+          url: `http://127.0.0.1:${attacker.port}/tool`,
+          method: 'GET',
+          headers: { 'X-MyApp': 'secret-key' },
+        },
+        'tool invocation',
+        undefined,
+        ['X-MyApp'],
+      );
+      expect(landedKey).toBeUndefined();
+    } finally {
+      await attacker.close();
+      await target.close();
+    }
+  });
+
+  test('caller-declared custom auth header kept on same-origin redirect', async () => {
+    let landedKey: string | undefined;
+    const handler = (req: IncomingMessage, res: ServerResponse) => {
+      if (req.url === '/start') {
+        res.writeHead(302, { Location: '/landed' });
+        res.end();
+        return;
+      }
+      landedKey = req.headers['x-myapp'] as string | undefined;
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ ok: true }));
+    };
+    const server = await startServer(handler);
+    try {
+      const ax = axios.create({ timeout: 5000 });
+      await safeRequestWithRedirects(
+        ax,
+        {
+          url: `http://127.0.0.1:${server.port}/start`,
+          method: 'GET',
+          headers: { 'X-MyApp': 'secret-key' },
+        },
+        'tool invocation',
+        undefined,
+        ['X-MyApp'],
+      );
+      expect(landedKey).toBe('secret-key');
+    } finally {
+      await server.close();
+    }
+  });
+
   test('caps the redirect chain at maxHops', async () => {
     const loop = await startServer((req, res) => {
       res.writeHead(302, { Location: '/loop' });

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@utcp/mcp",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Model Context Protocol integration for UTCP",
   "main": "dist/index.cjs",
   "module": "dist/index.js",
@@ -46,7 +46,7 @@
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^15.1.2",
     "@modelcontextprotocol/sdk": "^1.17.4",
-    "@utcp/sdk": "^1.1.0",
+    "@utcp/sdk": "^1.1.1",
     "axios": "^1.11.0"
   },
   "devDependencies": {

--- a/packages/mcp/src/mcp_call_template.ts
+++ b/packages/mcp/src/mcp_call_template.ts
@@ -1,7 +1,7 @@
 // packages/mcp/src/mcp_call_template.ts
 import { z } from 'zod';
 import { CallTemplate } from '@utcp/sdk';
-import { OAuth2Auth } from '@utcp/sdk';
+import { Auth } from '@utcp/sdk';
 import { AuthSchema } from '@utcp/sdk';
 import { Serializer } from '@utcp/sdk';
 
@@ -123,7 +123,7 @@ export interface McpCallTemplate extends CallTemplate {
   name?: string;
   call_template_type: 'mcp';
   config: McpConfig;
-  auth?: OAuth2Auth;
+  auth?: Auth;
   register_resources_as_tools?: boolean;
   allowed_communication_protocols?: string[];
 }

--- a/packages/mcp/src/mcp_communication_protocol.ts
+++ b/packages/mcp/src/mcp_communication_protocol.ts
@@ -8,8 +8,72 @@ import { RegisterManualResult } from '@utcp/sdk';
 import { CallTemplate } from '@utcp/sdk';
 import { UtcpManualSchema } from '@utcp/sdk';
 import { Tool, JsonSchema } from '@utcp/sdk';
-import { OAuth2Auth } from '@utcp/sdk';
-import { IUtcpClient } from '@utcp/sdk'; 
+import { Auth, OAuth2Auth, OAuth2UserAuth } from '@utcp/sdk';
+import { IUtcpClient } from '@utcp/sdk';
+
+/** Defense-in-depth: refuse CR/LF in attacker-influenceable strings
+ *  that will land in HTTP headers. */
+function assertNoCrlf(value: string | undefined, fieldName: string): void {
+  if (typeof value !== 'string') return;
+  if (value.includes('\r') || value.includes('\n')) {
+    throw new Error(
+      `Refusing to construct request: ${fieldName} contains CR/LF, ` +
+        `which would enable HTTP header injection.`,
+    );
+  }
+}
+
+/**
+ * Minimal HTTPS-or-loopback URL guard for the MCP HTTP transport.
+ * Mirrors the validator in `@utcp/http`'s `_security.ts` to keep MCP
+ * from being a back-door SSRF vector when the MCP call template comes
+ * from an attacker-influenceable source (e.g. a discovered manual).
+ * Hostname-based -- not prefix-based -- so the bypass from
+ * GHSA-39j6-4867-gg4w / CVE-2026-44661 (`http://localhost.evil.com`)
+ * is rejected.
+ */
+const MCP_LOOPBACK_HOSTNAMES: ReadonlySet<string> = new Set([
+  'localhost',
+  '127.0.0.1',
+  '::1',
+]);
+
+function ensureSecureMcpUrl(rawUrl: string, context: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    throw new Error(
+      `Security error during ${context}: not a valid URL: ${JSON.stringify(rawUrl)}.`,
+    );
+  }
+  const scheme = parsed.protocol.toLowerCase();
+  let host = parsed.hostname.toLowerCase();
+  if (host.startsWith('[') && host.endsWith(']')) host = host.slice(1, -1);
+  if (scheme === 'https:') return;
+  if (scheme === 'http:' && MCP_LOOPBACK_HOSTNAMES.has(host)) return;
+  // Match the broader 127.0.0.0/8 + 0.0.0.0 + IPv4-mapped IPv6
+  // loopback set that ``isLoopbackUrl`` in @utcp/http covers, so an
+  // attacker can't paper over the hostname check with `127.0.0.2`.
+  if (scheme === 'http:') {
+    const v4 = host.match(/^(\d{1,3})\.\d{1,3}\.\d{1,3}\.\d{1,3}$/);
+    if (v4 && parseInt(v4[1], 10) === 127) return;
+    if (host === '0.0.0.0' || host === '::') return;
+    if (host.startsWith('::ffff:')) {
+      const tail = host.slice('::ffff:'.length);
+      const tailV4 = tail.match(/^(\d{1,3})\.\d{1,3}\.\d{1,3}\.\d{1,3}$/);
+      if (tailV4 && parseInt(tailV4[1], 10) === 127) return;
+      const tailHex = tail.match(/^([0-9a-f]{1,4}):[0-9a-f]{1,4}$/);
+      if (tailHex && ((parseInt(tailHex[1], 16) >>> 8) & 0xff) === 127) return;
+    }
+  }
+  throw new Error(
+    `Security error during ${context}: URL must use HTTPS or be a literal ` +
+      `loopback address. Got: ${JSON.stringify(rawUrl)}. Plain HTTP to any ` +
+      `other host is rejected to prevent MITM attacks and SSRF into ` +
+      `internal services.`,
+  );
+}
 import { McpCallTemplateSchema, McpHttpServer, McpServerConfig, McpStdioServer } from './mcp_call_template';
 import { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import $RefParser from '@apidevtools/json-schema-ref-parser';
@@ -103,7 +167,7 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
   private async _getOrCreateSession(
     serverName: string,
     serverConfig: McpServerConfig,
-    auth?: OAuth2Auth
+    auth?: Auth
   ): Promise<McpClient> {
     const sessionKey = `${serverName}:${serverConfig.transport}`;
 
@@ -134,10 +198,29 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
 
     } else if (serverConfig.transport === 'http') {
       const httpConfig = serverConfig as McpHttpServer;
+      // Reject plain-HTTP non-loopback URLs and obvious SSRF targets
+      // before any connection attempt. Matches the trust boundary
+      // @utcp/http enforces for its own discovery / invocation URLs.
+      ensureSecureMcpUrl(httpConfig.url, 'MCP HTTP transport');
       let authHeader: Record<string, string> = {};
       if (auth) {
-        const token = await this._handleOAuth2(auth);
-        authHeader['Authorization'] = `Bearer ${token}`;
+        if (auth.auth_type === 'oauth2_user') {
+          // Interactive (user-delegated) OAuth2: token provisioned out-of-band
+          // by a login tool (e.g. `code-mode login <manual>`). No fetch here.
+          const userAuth = auth as OAuth2UserAuth;
+          if (!userAuth.access_token) {
+            throw new Error("access_token for oauth2_user auth is empty. Run an interactive login (e.g. `code-mode login <manual>`) to provision it.");
+          }
+          const headerName = userAuth.var_name || 'Authorization';
+          const prefix = userAuth.prefix ?? 'Bearer ';
+          assertNoCrlf(headerName, 'OAuth2UserAuth.var_name');
+          assertNoCrlf(prefix, 'OAuth2UserAuth.prefix');
+          assertNoCrlf(userAuth.access_token, 'OAuth2UserAuth.access_token');
+          authHeader[headerName] = `${prefix}${userAuth.access_token}`;
+        } else {
+          const token = await this._handleOAuth2(auth as OAuth2Auth);
+          authHeader['Authorization'] = `Bearer ${token}`;
+        }
       }
 
       const transportOptions: StreamableHTTPClientTransportOptions = {
@@ -173,7 +256,7 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
   private async _withSession<T>(
     serverName: string,
     serverConfig: McpServerConfig,
-    auth: OAuth2Auth | undefined,
+    auth: Auth | undefined,
     operation: (client: McpClient) => Promise<T>
   ): Promise<T> {
     const sessionKey = `${serverName}:${serverConfig.transport}`;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add declarative OAuth2 user sign-in (`oauth2_user`) so tools can use user-provisioned tokens across `@utcp/sdk`, `@utcp/http`, and `@utcp/mcp`. Also harden redirect behavior and header handling to prevent secret leaks and header injection.

- **New Features**
  - Added `oauth2_user` auth type in `@utcp/sdk` with serializer and plugin registration.
  - HTTP, SSE, and streamable HTTP inject user tokens via header (configurable `var_name`, default `Authorization`; configurable `prefix`, default `Bearer `).
  - MCP HTTP transport supports `oauth2_user`; `McpCallTemplate.auth` now accepts `Auth` (not only `OAuth2Auth`).

- **Security**
  - Centralized CR/LF guard as `assertNoCrlf` in `@utcp/http` and applied across HTTP, SSE, and streamable HTTP; MCP HTTP transport mirrors the guard.
  - Strip caller-declared auth headers on cross-origin redirects by passing explicit auth header names to `safeRequestWithRedirects` (tests verify stripping on cross-origin and retention on same-origin).
  - Enforce HTTPS or loopback-only URLs for MCP HTTP transport to block MITM/SSRF.

<sup>Written for commit 409e8220d0d956018734e249aa5763fcea7cb813. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/universal-tool-calling-protocol/typescript-utcp/pull/25?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

