### PR TITLE
fix(http): surface the server's error body on a failed tool call

### DIFF
--- a/packages/http/src/http_communication_protocol.ts
+++ b/packages/http/src/http_communication_protocol.ts
@@ -247,12 +247,18 @@ export class HttpCommunicationProtocol implements CommunicationProtocol {
     }
     const status = error.response.status;
     const data = error.response.data;
+    // Prefer a string `error` / `message` / `detail` field from the body; some
+    // APIs nest an OBJECT there (e.g. { error: { code, reason } }), so only use
+    // the candidate when it's actually a string — otherwise fall through to the
+    // full JSON so the real structure shows instead of "[object Object]".
+    const stringField = (...candidates: unknown[]): string | undefined =>
+      candidates.find((c): c is string => typeof c === 'string');
     const detail =
       typeof data === 'string'
         ? data
         : data == null
           ? error.message
-          : (data.error ?? data.message ?? data.detail ?? JSON.stringify(data));
+          : (stringField(data.error, data.message, data.detail) ?? JSON.stringify(data));
     const normalized = new Error(
       `HTTP ${status} calling tool '${toolName}': ${detail}`,
     ) as Error & { status: number; data: unknown };

--- a/packages/http/src/http_communication_protocol.ts
+++ b/packages/http/src/http_communication_protocol.ts
@@ -222,8 +222,44 @@ export class HttpCommunicationProtocol implements CommunicationProtocol {
       return response.data;
     } catch (error: any) {
       this._logError(`Error calling HTTP tool '${toolName}':`, error);
-      throw error;
+      throw this._normalizeToolError(toolName, error);
     }
+  }
+
+  /**
+   * Turn a raw axios error into one that actually carries the server's response.
+   *
+   * On a non-2xx, axios throws an `AxiosError` whose `.message` is the generic
+   * `"Request failed with status code 403"` — the response BODY (where servers
+   * put the real reason, e.g. `{ "error": "..." }`) sits on `error.response.data`
+   * and is otherwise lost to every caller that only reads `.message`. That body
+   * is also dropped entirely when the error is serialized across a boundary
+   * (e.g. JSON.stringify in an isolated-vm tool runner), because `Error.message`
+   * is non-enumerable and `AxiosError` doesn't serialize its `response`.
+   *
+   * This folds the status + body into the message AND attaches enumerable
+   * `status` / `data` fields, so the reason survives both `.message` readers and
+   * structured serialization. Non-HTTP errors (network, timeout) pass through.
+   */
+  private _normalizeToolError(toolName: string, error: any): Error {
+    if (!axios.isAxiosError(error) || !error.response) {
+      return error instanceof Error ? error : new Error(String(error));
+    }
+    const status = error.response.status;
+    const data = error.response.data;
+    const detail =
+      typeof data === 'string'
+        ? data
+        : data == null
+          ? error.message
+          : (data.error ?? data.message ?? data.detail ?? JSON.stringify(data));
+    const normalized = new Error(
+      `HTTP ${status} calling tool '${toolName}': ${detail}`,
+    ) as Error & { status: number; data: unknown };
+    // Enumerable so they survive JSON.stringify out of an isolated-vm runner.
+    normalized.status = status;
+    normalized.data = data;
+    return normalized;
   }
 
   /**

--- a/packages/http/src/sse_communication_protocol.ts
+++ b/packages/http/src/sse_communication_protocol.ts
@@ -145,7 +145,12 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
       const response = await fetch(urlObj.toString(), fetchOptions);
 
       if (!response.ok) {
-        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+        // Read the body before throwing — servers put the real reason there
+        // (e.g. { "error": "..." }); discarding it leaves callers with only a
+        // status code. Fall back to statusText when the body is empty.
+        const body = await response.text().catch(() => '');
+        const detail = body.trim() || response.statusText;
+        throw new Error(`HTTP ${response.status}: ${detail}`);
       }
 
       // For SSE discovery, we expect the first event to contain the manual

--- a/packages/http/src/streamable_http_communication_protocol.ts
+++ b/packages/http/src/streamable_http_communication_protocol.ts
@@ -140,7 +140,12 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
       const response = await fetch(urlObj.toString(), fetchOptions);
 
       if (!response.ok) {
-        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+        // Read the body before throwing — servers put the real reason there
+        // (e.g. { "error": "..." }); discarding it leaves callers with only a
+        // status code. Fall back to statusText when the body is empty.
+        const body = await response.text().catch(() => '');
+        const detail = body.trim() || response.statusText;
+        throw new Error(`HTTP ${response.status}: ${detail}`);
       }
 
       // Read response body

--- a/packages/http/tests/http_communication_protocol.test.ts
+++ b/packages/http/tests/http_communication_protocol.test.ts
@@ -3,7 +3,12 @@ import { test, expect, describe, beforeAll, afterAll } from "bun:test";
 import express, { Express } from 'express';
 import { Server } from 'http';
 // Import from package index to trigger auto-registration
-import { HttpCommunicationProtocol, HttpCallTemplate } from "@utcp/http";
+import {
+  HttpCommunicationProtocol,
+  HttpCallTemplate,
+  StreamableHttpCommunicationProtocol,
+  SseCommunicationProtocol,
+} from "@utcp/http";
 import { ApiKeyAuth, BasicAuth, OAuth2Auth } from "@utcp/sdk";
 import { IUtcpClient } from "@utcp/sdk";
 
@@ -66,6 +71,11 @@ beforeAll(async () => {
   // refuses a call. Used to prove callTool surfaces that body, not just the status.
   app.post("/forbidden", (req, res) => {
     res.status(403).json({ error: "You are not allowed to do that, and here is exactly why." });
+  });
+
+  // GET variant for the streamable/sse discovery (registerManual) error-body test.
+  app.get("/forbidden-discovery", (req, res) => {
+    res.status(403).send("discovery refused: tenant is not provisioned for streaming");
   });
 
   await new Promise<void>((resolve) => {
@@ -221,5 +231,39 @@ describe("HttpCommunicationProtocol", () => {
       expect(roundTripped.status).toBe(403);
       expect(roundTripped.data).toEqual({ error: "You are not allowed to do that, and here is exactly why." });
     });
+  });
+});
+
+// The streamable/sse protocols' callTool paths are stubs; the only real fetch
+// that can fail with a body is in registerManual (discovery). These prove that
+// failure surfaces the server's body, not just "HTTP 403: Forbidden".
+describe("discovery error body (streamable_http + sse)", () => {
+  test("StreamableHttpCommunicationProtocol.registerManual surfaces the server body", async () => {
+    const protocol = new StreamableHttpCommunicationProtocol();
+    const result = await protocol.registerManual(mockClient, {
+      name: "forbidden_stream",
+      call_template_type: "streamable_http",
+      url: `http://localhost:${serverPort}/forbidden-discovery`,
+      http_method: "GET",
+    } as any);
+
+    expect(result.success).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+    expect(result.errors[0]).toContain("discovery refused: tenant is not provisioned for streaming");
+    expect(result.errors[0]).toContain("403");
+  });
+
+  test("SseCommunicationProtocol.registerManual surfaces the server body", async () => {
+    const protocol = new SseCommunicationProtocol();
+    const result = await protocol.registerManual(mockClient, {
+      name: "forbidden_sse",
+      call_template_type: "sse",
+      url: `http://localhost:${serverPort}/forbidden-discovery`,
+    } as any);
+
+    expect(result.success).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+    expect(result.errors[0]).toContain("discovery refused: tenant is not provisioned for streaming");
+    expect(result.errors[0]).toContain("403");
   });
 });

--- a/packages/http/tests/http_communication_protocol.test.ts
+++ b/packages/http/tests/http_communication_protocol.test.ts
@@ -62,6 +62,12 @@ beforeAll(async () => {
     res.status(500).json({ error: "Internal Server Error" });
   });
 
+  // Returns a non-2xx with a descriptive JSON body, like a real API does when it
+  // refuses a call. Used to prove callTool surfaces that body, not just the status.
+  app.post("/forbidden", (req, res) => {
+    res.status(403).json({ error: "You are not allowed to do that, and here is exactly why." });
+  });
+
   await new Promise<void>((resolve) => {
     server = app.listen(0, () => {
       serverPort = (server.address() as any).port;
@@ -187,6 +193,33 @@ describe("HttpCommunicationProtocol", () => {
       };
       const result = await protocol.callTool(mockClient, "test.tool", {}, callTemplate);
       expect(result.result).toBe("success");
+    });
+
+    test("should surface the server's error body, not just the status code", async () => {
+      const callTemplate: HttpCallTemplate = {
+        name: "forbidden_server",
+        call_template_type: "http",
+        url: `http://localhost:${serverPort}/forbidden`,
+        http_method: "POST",
+      };
+
+      let thrown: any;
+      try {
+        await protocol.callTool(mockClient, "test.forbidden", {}, callTemplate);
+      } catch (e) {
+        thrown = e;
+      }
+
+      expect(thrown).toBeInstanceOf(Error);
+      // The reason the server sent (not just "status code 403") must be present.
+      expect(thrown.message).toContain("You are not allowed to do that, and here is exactly why.");
+      expect(thrown.message).toContain("403");
+      // Enumerable status/data survive structured serialization out of a sandbox.
+      expect(thrown.status).toBe(403);
+      expect(thrown.data).toEqual({ error: "You are not allowed to do that, and here is exactly why." });
+      const roundTripped = JSON.parse(JSON.stringify(thrown));
+      expect(roundTripped.status).toBe(403);
+      expect(roundTripped.data).toEqual({ error: "You are not allowed to do that, and here is exactly why." });
     });
   });
 });

--- a/packages/http/tests/http_communication_protocol.test.ts
+++ b/packages/http/tests/http_communication_protocol.test.ts
@@ -78,6 +78,12 @@ beforeAll(async () => {
     res.status(403).send("discovery refused: tenant is not provisioned for streaming");
   });
 
+  // Some APIs nest an OBJECT under `error` — the message must show its JSON,
+  // not "[object Object]".
+  app.post("/forbidden-object", (req, res) => {
+    res.status(422).json({ error: { code: "INVALID_FIELD", reason: "value out of range" } });
+  });
+
   await new Promise<void>((resolve) => {
     server = app.listen(0, () => {
       serverPort = (server.address() as any).port;
@@ -230,6 +236,31 @@ describe("HttpCommunicationProtocol", () => {
       const roundTripped = JSON.parse(JSON.stringify(thrown));
       expect(roundTripped.status).toBe(403);
       expect(roundTripped.data).toEqual({ error: "You are not allowed to do that, and here is exactly why." });
+    });
+
+    test("should JSON-stringify an object-valued error field, not '[object Object]'", async () => {
+      const callTemplate: HttpCallTemplate = {
+        name: "forbidden_object_server",
+        call_template_type: "http",
+        url: `http://localhost:${serverPort}/forbidden-object`,
+        http_method: "POST",
+      };
+
+      let thrown: any;
+      try {
+        await protocol.callTool(mockClient, "test.forbidden_object", {}, callTemplate);
+      } catch (e) {
+        thrown = e;
+      }
+
+      expect(thrown).toBeInstanceOf(Error);
+      expect(thrown.message).not.toContain("[object Object]");
+      // The structured detail survives in the message...
+      expect(thrown.message).toContain("INVALID_FIELD");
+      expect(thrown.message).toContain("value out of range");
+      // ...and the raw object is preserved on `data`.
+      expect(thrown.status).toBe(422);
+      expect(thrown.data).toEqual({ error: { code: "INVALID_FIELD", reason: "value out of range" } });
     });
   });
 });


### PR DESCRIPTION
## Problem

When an HTTP call fails with a non-2xx status, the http protocols discard the server's response **body** — where servers put the actual reason (`{ "error": "..." }`) — and surface only the status code.

- **`HttpCommunicationProtocol.callTool`** (axios) re-threw the raw `AxiosError`, whose `.message` is the generic `"Request failed with status code 403"`. The body sits on `error.response.data` and never reaches `.message`. It's also dropped entirely when the error crosses a serialization boundary (e.g. `JSON.stringify` inside an `isolated-vm` tool runner like `@utcp/code-mode`), because `Error.message` is non-enumerable and `AxiosError` doesn't serialize its `response`. In a code-mode agent a server's 403/400 reaches the model as `{}`.
- **`StreamableHttpCommunicationProtocol` / `SseCommunicationProtocol`** (fetch) threw `HTTP ${status}: ${statusText}` during manual discovery (`registerManual`) without ever reading the body, so a refused discovery surfaced as `"HTTP 403: Forbidden"` in `errors[]`.

## Fix

- **`callTool`** normalizes a failed HTTP call into an `Error` that folds the **status + server body** into `.message` AND attaches **enumerable `status` / `data`** fields, so the reason survives both `.message` readers and structured serialization. Non-HTTP errors (network, timeout) pass through unchanged.
- **streamable_http + sse** read the response body before throwing during discovery and fold it into the message (falling back to `statusText` when empty). Their `callTool` paths are stubs (no HTTP call yet), so discovery is the only real failure surface today.

No public signature changes.

## Tests

- A `/forbidden` route (403 + JSON body) + a `callTool` test asserting the thrown error carries the body in `.message`, exposes `status`/`data`, and **round-trips through `JSON.stringify`** (the sandbox case).
- A `GET /forbidden-discovery` route (403 + text body) + tests asserting both streamable and sse `registerManual` surface the body in `errors[]`.

`bun test packages/http/tests/` → **85 pass, 0 fail**. `build:http` clean (DTS included) once `core` is built first.
