### PR TITLE
feat(openapi): parse examples, normalize them, and validate HTTP methods

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@utcp/sdk",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Universal Tool Calling Protocol SDK",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/packages/core/src/data/tool.ts
+++ b/packages/core/src/data/tool.ts
@@ -75,6 +75,10 @@ export interface JsonSchema {
    */
   default?: JsonType;
   /**
+   * Example values for the schema (JSON Schema 'examples' keyword).
+   */
+  examples?: JsonType[];
+  /**
    * Optional format hint (e.g., 'date-time', 'email').
    */
   format?: string;
@@ -124,6 +128,7 @@ export const JsonSchemaSchema: z.ZodType<JsonSchema> = z.lazy(() => z.object({
   enum: z.array(JsonTypeSchema).optional(),
   const: JsonTypeSchema.optional(),
   default: JsonTypeSchema.optional(),
+  examples: z.array(JsonTypeSchema).optional(),
   format: z.string().optional(),
   additionalProperties: z.union([z.boolean(), z.lazy(() => JsonSchemaSchema)]).optional(),
   pattern: z.string().optional(),

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@utcp/http",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "HTTP utilities for UTCP",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/packages/http/src/openapi_converter.ts
+++ b/packages/http/src/openapi_converter.ts
@@ -18,7 +18,7 @@
  * defined by OpenAPI specifications, providing a bridge between OpenAPI and UTCP.
  */
 // packages/http/src/openapi_converter.ts
-import { Tool, JsonSchemaSchema, JsonSchema } from '@utcp/sdk';
+import { Tool, JsonSchemaSchema, JsonSchema, JsonType } from '@utcp/sdk';
 import { UtcpManual, UtcpManualSerializer } from '@utcp/sdk';
 import { Auth } from '@utcp/sdk';
 import { ApiKeyAuth } from '@utcp/sdk';
@@ -26,6 +26,14 @@ import { BasicAuth } from '@utcp/sdk';
 import { OAuth2Auth } from '@utcp/sdk';
 import { HttpCallTemplate } from './http_call_template';
 import { ensureSecureUrl, isLoopbackUrl } from './_security';
+
+/**
+ * HTTP methods that HttpCallTemplate.http_method accepts. Kept as the single
+ * source of truth for both the operation loop filter and per-operation
+ * validation so the two can never drift apart.
+ */
+const SUPPORTED_HTTP_METHODS = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH'] as const;
+type SupportedHttpMethod = typeof SUPPORTED_HTTP_METHODS[number];
 
 /**
  * Options for the OpenAPI converter.
@@ -181,7 +189,7 @@ export class OpenApiConverter {
     const paths = this.spec.paths || {};
     for (const [path, pathItem] of Object.entries(paths)) {
       for (const [method, operation] of Object.entries(pathItem as Record<string, any>)) {
-        if (['get', 'post', 'put', 'delete', 'patch'].includes(method.toLowerCase())) {
+        if ((SUPPORTED_HTTP_METHODS as readonly string[]).includes(method.toUpperCase())) {
           const tool = this._createTool(path, method, operation, baseUrl);
           if (tool) {
             tools.push(tool);
@@ -258,6 +266,81 @@ export class OpenApiConverter {
   }
 
   /**
+   * Extracts examples from an OpenAPI Parameter, Media Type, or Schema object.
+   *
+   * Supports both `example` (single value) and `examples` (map of Example
+   * Objects). Returns a list of example values suitable for the JSON Schema
+   * `examples` keyword, or undefined when none are present.
+   */
+  private _extractExamples(obj: Record<string, any> | undefined | null): JsonType[] | undefined {
+    if (!obj || typeof obj !== 'object') {
+      return undefined;
+    }
+
+    const examples: JsonType[] = [];
+
+    // Handle single 'example' field
+    if ('example' in obj && obj.example !== undefined && obj.example !== null) {
+      examples.push(obj.example);
+    }
+
+    // Handle 'examples' map (OpenAPI 3.0+ Example Objects keyed by name)
+    if ('examples' in obj && obj.examples && typeof obj.examples === 'object' && !Array.isArray(obj.examples)) {
+      for (let exampleObj of Object.values(obj.examples) as any[]) {
+        if (exampleObj && typeof exampleObj === 'object' && '$ref' in exampleObj) {
+          exampleObj = this._resolveSchema(exampleObj) ?? {};
+        }
+        if (exampleObj && typeof exampleObj === 'object') {
+          // Example Object can have 'value' or 'externalValue'
+          if ('value' in exampleObj) {
+            examples.push(exampleObj.value);
+          }
+          // Note: externalValue is a URI reference, we skip it as it's not inline
+        }
+      }
+    }
+
+    return examples.length > 0 ? examples : undefined;
+  }
+
+  /**
+   * Collects and de-duplicates examples from several OpenAPI objects, preserving order.
+   *
+   * Used to combine examples that can appear at more than one level for the
+   * same value, e.g. a Media Type Object and the Schema Object beneath it.
+   */
+  private _mergeExamples(...objs: Array<Record<string, any> | undefined | null>): JsonType[] | undefined {
+    const merged: JsonType[] = [];
+    for (const obj of objs) {
+      const extracted = this._extractExamples(obj);
+      if (!extracted) continue;
+      for (const ex of extracted) {
+        const key = JSON.stringify(ex);
+        if (!merged.some(m => JSON.stringify(m) === key)) {
+          merged.push(ex);
+        }
+      }
+    }
+    return merged.length > 0 ? merged : undefined;
+  }
+
+  /**
+   * Returns a copy of a schema object with the raw `example`/`examples` keys removed.
+   *
+   * Examples are normalized into the JSON Schema `examples` keyword via
+   * _mergeExamples, so the raw OpenAPI keys must not be spread back onto the
+   * property or they would leak through as untyped extra fields.
+   */
+  private _schemaWithoutExampleKeys(schema: Record<string, any>): Record<string, any> {
+    const out: Record<string, any> = {};
+    for (const [key, value] of Object.entries(schema)) {
+      if (key === 'example' || key === 'examples') continue;
+      out[key] = value;
+    }
+    return out;
+  }
+
+  /**
    * Creates a Tool object from an OpenAPI operation.
    * @param path The API path.
    * @param method The HTTP method (GET, POST, etc.).
@@ -276,6 +359,18 @@ export class OpenApiConverter {
       return null;
     }
 
+    // Validate the HTTP method against what HttpCallTemplate accepts before
+    // building the tool. OpenAPI allows operations like 'options'/'head'/'trace'
+    // that the call template's union type does not cover; skip them with a
+    // warning instead of emitting a tool with an invalid method. This explicit
+    // check is also what makes the cast below truthful rather than a blind
+    // assertion.
+    const httpMethod = method.toUpperCase();
+    if (!(SUPPORTED_HTTP_METHODS as readonly string[]).includes(httpMethod)) {
+      console.warn(`[OpenApiConverter] Skipping operation '${operationId}': unsupported HTTP method '${method}'.`);
+      return null;
+    }
+
     const description = operation.summary || operation.description || '';
     const tags = operation.tags || [];
 
@@ -287,7 +382,7 @@ export class OpenApiConverter {
     const callTemplate: HttpCallTemplate = {
       name: this.call_template_name,
       call_template_type: 'http',
-      http_method: method.toUpperCase() as 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH',
+      http_method: httpMethod as SupportedHttpMethod,
       url: fullUrl,
       body_field: bodyField ?? undefined,
       header_fields: headerFields.length > 0 ? headerFields : undefined,
@@ -339,10 +434,16 @@ export class OpenApiConverter {
       if (resolvedParam.in === 'body') {
         bodyField = 'body';
         const jsonSchema = this._resolveSchema(resolvedParam.schema || {});
+        // Examples can live on the parameter itself and on its schema;
+        // collect both into the normalized 'examples' keyword.
+        const bodyExamples = this._mergeExamples(resolvedParam, jsonSchema);
         properties[bodyField] = {
           description: resolvedParam.description || 'Request body',
-          ...jsonSchema,
+          ...this._schemaWithoutExampleKeys(jsonSchema),
         };
+        if (bodyExamples) {
+          properties[bodyField].examples = bodyExamples;
+        }
         if (resolvedParam.required) {
           required.push(bodyField);
         }
@@ -356,11 +457,16 @@ export class OpenApiConverter {
       if (!schema.items && resolvedParam.items) schema.items = resolvedParam.items;
       if (!schema.enum && resolvedParam.enum) schema.enum = resolvedParam.enum;
 
-
+      // Examples can live on the parameter itself and on its schema;
+      // collect both into the normalized 'examples' keyword.
+      const paramExamples = this._mergeExamples(resolvedParam, schema);
       properties[paramName] = {
         description: resolvedParam.description || '',
-        ...schema,
+        ...this._schemaWithoutExampleKeys(schema),
       };
+      if (paramExamples) {
+        properties[paramName].examples = paramExamples;
+      }
       if (resolvedParam.required) {
         required.push(paramName);
       }
@@ -371,14 +477,22 @@ export class OpenApiConverter {
     if (requestBody) {
       const resolvedBody = this._resolveSchema(requestBody);
       const content = resolvedBody.content || {};
+      const mediaTypeObj = content['application/json'] || content['application/x-www-form-urlencoded'];
       const jsonSchema = content['application/json']?.schema || content['application/x-www-form-urlencoded']?.schema;
 
       if (jsonSchema) {
         bodyField = 'body';
+        const resolvedJsonSchema = this._resolveSchema(jsonSchema);
+        // Examples can live on the media type object and on the schema;
+        // collect both into the normalized 'examples' keyword.
+        const bodyExamples = this._mergeExamples(mediaTypeObj, resolvedJsonSchema);
         properties[bodyField] = {
           description: resolvedBody.description || 'Request body',
-          ...this._resolveSchema(jsonSchema),
+          ...this._schemaWithoutExampleKeys(resolvedJsonSchema),
         };
+        if (bodyExamples) {
+          properties[bodyField].examples = bodyExamples;
+        }
         if (resolvedBody.required) {
           required.push(bodyField);
         }
@@ -410,15 +524,18 @@ export class OpenApiConverter {
 
     const resolvedResponse = this._resolveSchema(successResponse);
     let jsonSchema: any = null;
+    let mediaTypeObj: any = null;
 
     if ('content' in resolvedResponse) { // OpenAPI 3.0
       const content = resolvedResponse.content || {};
+      mediaTypeObj = content['application/json'] || content['text/plain'] || null;
       jsonSchema = content['application/json']?.schema || content['text/plain']?.schema;
       if (!jsonSchema && Object.keys(content).length > 0) {
         // Fallback to first content type's schema, with a type guard
         const firstContentTypeValue = Object.values(content)[0];
         if (typeof firstContentTypeValue === 'object' && firstContentTypeValue !== null && 'schema' in firstContentTypeValue) {
           jsonSchema = (firstContentTypeValue as { schema: any }).schema;
+          mediaTypeObj = firstContentTypeValue;
         }
       }
     } else if ('schema' in resolvedResponse) { // OpenAPI 2.0
@@ -430,6 +547,9 @@ export class OpenApiConverter {
     }
 
     const resolvedJsonSchema = this._resolveSchema(jsonSchema);
+    // Examples can live on the response media type object and on the schema;
+    // collect both into the normalized 'examples' keyword.
+    const responseExamples = this._mergeExamples(mediaTypeObj, resolvedJsonSchema);
     const schemaArgs: JsonSchema = {
       type: resolvedJsonSchema.type || 'object',
       properties: resolvedJsonSchema.properties || undefined,
@@ -442,6 +562,9 @@ export class OpenApiConverter {
       maximum: resolvedJsonSchema.maximum || undefined,
       format: resolvedJsonSchema.format || undefined,
     };
+    if (responseExamples) {
+      schemaArgs.examples = responseExamples;
+    }
 
     return schemaArgs;
   }

--- a/packages/http/src/openapi_converter.ts
+++ b/packages/http/src/openapi_converter.ts
@@ -28,9 +28,17 @@ import { HttpCallTemplate } from './http_call_template';
 import { ensureSecureUrl, isLoopbackUrl } from './_security';
 
 /**
- * HTTP methods that HttpCallTemplate.http_method accepts. Kept as the single
- * source of truth for both the operation loop filter and per-operation
- * validation so the two can never drift apart.
+ * All HTTP methods that OpenAPI defines as operation fields on a Path Item
+ * Object. Used by the conversion loop to tell operations apart from the other
+ * path-item keys (parameters, summary, $ref, servers, ...), so that genuinely
+ * unsupported operations still reach _createTool and get a warning rather than
+ * being silently dropped here.
+ */
+const OPENAPI_OPERATION_METHODS = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'] as const;
+
+/**
+ * The subset of HTTP methods that HttpCallTemplate.http_method accepts.
+ * _createTool validates against this and skips anything else with a warning.
  */
 const SUPPORTED_HTTP_METHODS = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH'] as const;
 type SupportedHttpMethod = typeof SUPPORTED_HTTP_METHODS[number];
@@ -189,7 +197,7 @@ export class OpenApiConverter {
     const paths = this.spec.paths || {};
     for (const [path, pathItem] of Object.entries(paths)) {
       for (const [method, operation] of Object.entries(pathItem as Record<string, any>)) {
-        if ((SUPPORTED_HTTP_METHODS as readonly string[]).includes(method.toUpperCase())) {
+        if ((OPENAPI_OPERATION_METHODS as readonly string[]).includes(method.toLowerCase())) {
           const tool = this._createTool(path, method, operation, baseUrl);
           if (tool) {
             tools.push(tool);

--- a/packages/http/tests/openapi_converter.test.ts
+++ b/packages/http/tests/openapi_converter.test.ts
@@ -1,0 +1,178 @@
+// packages/http/tests/openapi_converter.test.ts
+//
+// Tests for OpenAPI -> UTCP conversion of examples and HTTP method handling.
+// Mirrors the Python suite: parameter/body/response examples are extracted and
+// normalized into the JSON Schema `examples` keyword, schema-level examples are
+// merged (not leaked raw), and operations with unsupported HTTP methods are
+// skipped rather than producing invalid tools.
+
+import { test, expect, describe } from 'bun:test';
+// Import the package index first so its register() side effect runs before the
+// converter validates the generated HttpCallTemplate.
+import '@utcp/http';
+import { OpenApiConverter } from '../src/openapi_converter';
+
+describe('OpenApiConverter examples', () => {
+  test('extracts parameter, body, and response examples', () => {
+    const spec = {
+      openapi: '3.0.0',
+      info: { title: 'Test API', version: '1.0.0' },
+      paths: {
+        '/users/{userId}': {
+          get: {
+            operationId: 'getUser',
+            parameters: [
+              {
+                name: 'userId',
+                in: 'path',
+                description: 'ID of the user',
+                required: true,
+                schema: { type: 'string' },
+                example: 'user123',
+              },
+              {
+                name: 'includeDetails',
+                in: 'query',
+                required: false,
+                schema: { type: 'boolean' },
+                examples: {
+                  trueExample: { summary: 'Include details', value: true },
+                  falseExample: { summary: 'Exclude details', value: false },
+                },
+              },
+            ],
+            responses: {
+              '200': {
+                description: 'Successful response',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: { id: { type: 'string' }, name: { type: 'string' } },
+                    },
+                    examples: {
+                      userExample: {
+                        summary: 'Example user',
+                        value: { id: 'user123', name: 'John Doe' },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '/users': {
+          post: {
+            operationId: 'createUser',
+            requestBody: {
+              description: 'User to create',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: { name: { type: 'string' }, email: { type: 'string' } },
+                    required: ['name', 'email'],
+                  },
+                  examples: {
+                    newUser: {
+                      summary: 'New user example',
+                      value: { name: 'Jane Smith', email: 'jane@example.com' },
+                    },
+                  },
+                },
+              },
+            },
+            responses: { '201': { description: 'User created' } },
+          },
+        },
+      },
+    };
+
+    const manual = new OpenApiConverter(spec).convert();
+    expect(manual.tools.length).toBe(2);
+
+    const getUser = manual.tools.find(t => t.name === 'getUser')!;
+    expect(getUser).toBeDefined();
+
+    const userId = getUser.inputs.properties!.userId;
+    expect(userId.examples).toEqual(['user123']);
+
+    const includeDetails = getUser.inputs.properties!.includeDetails;
+    expect(includeDetails.examples).toEqual([true, false]);
+
+    expect(getUser.outputs.examples).toEqual([{ id: 'user123', name: 'John Doe' }]);
+
+    const createUser = manual.tools.find(t => t.name === 'createUser')!;
+    const body = createUser.inputs.properties!.body;
+    expect(body.examples).toEqual([{ name: 'Jane Smith', email: 'jane@example.com' }]);
+  });
+
+  test('normalizes schema-level examples and does not leak raw keys', () => {
+    const spec = {
+      openapi: '3.0.0',
+      info: { title: 'Test API', version: '1.0.0' },
+      paths: {
+        '/widgets': {
+          post: {
+            operationId: 'createWidget',
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: { name: { type: 'string' } },
+                    example: { name: 'Widget A' },
+                  },
+                },
+              },
+            },
+            responses: {
+              '200': {
+                description: 'ok',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: { id: { type: 'string' } },
+                      example: { id: 'w_1' },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const manual = new OpenApiConverter(spec).convert();
+    const tool = manual.tools.find(t => t.name === 'createWidget')!;
+
+    const body = tool.inputs.properties!.body;
+    expect(body.examples).toEqual([{ name: 'Widget A' }]);
+    // raw 'example' key must not leak through onto the property
+    expect('example' in body).toBe(false);
+
+    expect(tool.outputs.examples).toEqual([{ id: 'w_1' }]);
+  });
+
+  test('skips operations with unsupported HTTP methods', () => {
+    const spec = {
+      openapi: '3.0.0',
+      info: { title: 'Test API', version: '1.0.0' },
+      paths: {
+        '/things': {
+          get: { operationId: 'listThings', responses: { '200': { description: 'ok' } } },
+          options: { operationId: 'optionsThings', responses: { '200': { description: 'ok' } } },
+          head: { operationId: 'headThings', responses: { '200': { description: 'ok' } } },
+          trace: { operationId: 'traceThings', responses: { '200': { description: 'ok' } } },
+        },
+      },
+    };
+
+    const manual = new OpenApiConverter(spec).convert();
+    const names = manual.tools.map(t => t.name).sort();
+    expect(names).toEqual(['listThings']);
+  });
+});

--- a/packages/http/tests/openapi_converter.test.ts
+++ b/packages/http/tests/openapi_converter.test.ts
@@ -6,7 +6,7 @@
 // merged (not leaked raw), and operations with unsupported HTTP methods are
 // skipped rather than producing invalid tools.
 
-import { test, expect, describe } from 'bun:test';
+import { test, expect, describe, spyOn } from 'bun:test';
 // Import the package index first so its register() side effect runs before the
 // converter validates the generated HttpCallTemplate.
 import '@utcp/http';
@@ -171,8 +171,20 @@ describe('OpenApiConverter examples', () => {
       },
     };
 
-    const manual = new OpenApiConverter(spec).convert();
-    const names = manual.tools.map(t => t.name).sort();
-    expect(names).toEqual(['listThings']);
+    const warn = spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const manual = new OpenApiConverter(spec).convert();
+      const names = manual.tools.map(t => t.name).sort();
+      expect(names).toEqual(['listThings']);
+
+      // Unsupported operations must reach _createTool and emit a skip warning,
+      // not be silently dropped by the loop filter.
+      const warnings = warn.mock.calls.map(c => String(c[0])).join('\n');
+      expect(warnings).toContain('optionsThings');
+      expect(warnings).toContain('headThings');
+      expect(warnings).toContain('traceThings');
+    } finally {
+      warn.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
Ports the Python OpenAPI examples work (python-utcp #88 + #91 + follow-ups) to TypeScript.

## Core
- `JsonSchema` gains an explicit `examples?: JsonType[]` field (interface + zod schema). Previously examples only survived via the `catchall(z.unknown())`; now it's a first-class, validated field.

## HTTP converter
The TS converter never parsed examples at all — this adds the full feature:
- `_extractExamples` — reads `example` (scalar) and the `examples` map of Example Objects, resolves `$ref`, ignores `externalValue`.
- `_mergeExamples` — collects + de-duplicates examples that appear at more than one level (media type / parameter **and** schema), order-preserving.
- `_schemaWithoutExampleKeys` — strips raw `example`/`examples` before spreading the schema onto a property, so they don't leak through as untyped extra fields.
- Wired into path/query params, OAS2 body params, OAS3 `requestBody`, and responses.
- **HTTP method validation:** replaced the blind `as 'GET' | ...` cast with a `SUPPORTED_HTTP_METHODS` guard shared with the operation-loop filter. Operations using `options`/`head`/`trace` are skipped with a warning instead of producing a tool with an invalid method.

## Tests
New `packages/http/tests/openapi_converter.test.ts`: examples extraction (param/body/response), schema-level normalization (no raw-key leak), unsupported-method skipping. Full http+core suite: 85 pass, 0 fail. `tsup` builds clean.

## Versions
- `@utcp/sdk` 1.1.1 → 1.1.2
- `@utcp/http` 1.1.7 → 1.1.8

(No npm publish in this PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds OpenAPI example parsing and normalization across parameters, request bodies, and responses, and validates HTTP methods to skip unsupported operations. Introduces a first-class `examples` field in `JsonSchema` so tools receive clean, deduped examples.

- **New Features**
  - Add `examples?: JsonType[]` to `JsonSchema` (with zod validation).
  - Extract `example` and `examples` (resolving `$ref`, ignoring `externalValue`), merge/dedupe across parameter/media type/schema, and surface as `examples`; strip raw `example`/`examples` keys to prevent leaks.

- **Bug Fixes**
  - Guard HTTP methods against ['GET','POST','PUT','DELETE','PATCH'] and skip `options`/`head`/`trace` operations to avoid invalid tools.
  - Iterate over all OpenAPI operation methods in the convert loop; validate and skip unsupported methods in `_createTool` so the warning is emitted.
  - Add a regression test that spies on `console.warn` to assert the skip warning is produced for unsupported methods.

<sup>Written for commit a8196423d78e66a28106c9241834092969cbadd3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/universal-tool-calling-protocol/typescript-utcp/pull/27?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

