### PR TITLE
Dev

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@utcp/sdk",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Universal Tool Calling Protocol SDK",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/packages/core/src/data/tool.ts
+++ b/packages/core/src/data/tool.ts
@@ -75,6 +75,10 @@ export interface JsonSchema {
    */
   default?: JsonType;
   /**
+   * Example values for the schema (JSON Schema 'examples' keyword).
+   */
+  examples?: JsonType[];
+  /**
    * Optional format hint (e.g., 'date-time', 'email').
    */
   format?: string;
@@ -124,6 +128,7 @@ export const JsonSchemaSchema: z.ZodType<JsonSchema> = z.lazy(() => z.object({
   enum: z.array(JsonTypeSchema).optional(),
   const: JsonTypeSchema.optional(),
   default: JsonTypeSchema.optional(),
+  examples: z.array(JsonTypeSchema).optional(),
   format: z.string().optional(),
   additionalProperties: z.union([z.boolean(), z.lazy(() => JsonSchemaSchema)]).optional(),
   pattern: z.string().optional(),

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@utcp/http",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "HTTP utilities for UTCP",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@utcp/http",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "description": "HTTP utilities for UTCP",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@utcp/http",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "HTTP utilities for UTCP",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@utcp/http",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "description": "HTTP utilities for UTCP",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/packages/http/src/openapi_converter.ts
+++ b/packages/http/src/openapi_converter.ts
@@ -276,9 +276,15 @@ export class OpenApiConverter {
   /**
    * Extracts examples from an OpenAPI Parameter, Media Type, or Schema object.
    *
-   * Supports both `example` (single value) and `examples` (map of Example
-   * Objects). Returns a list of example values suitable for the JSON Schema
-   * `examples` keyword, or undefined when none are present.
+   * Handles all three shapes the spec allows:
+   *   - `example` (single value) — OpenAPI Parameter / Media Type / 3.0 Schema.
+   *   - `examples` as a map of named Example Objects — OpenAPI Parameter /
+   *     Media Type Object (each entry carries an inline `value`).
+   *   - `examples` as an array of literal values — JSON Schema / OpenAPI 3.1
+   *     Schema Object.
+   *
+   * Returns a list of example values suitable for the JSON Schema `examples`
+   * keyword, or undefined when none are present.
    */
   private _extractExamples(obj: Record<string, any> | undefined | null): JsonType[] | undefined {
     if (!obj || typeof obj !== 'object') {
@@ -292,18 +298,25 @@ export class OpenApiConverter {
       examples.push(obj.example);
     }
 
-    // Handle 'examples' map (OpenAPI 3.0+ Example Objects keyed by name)
-    if ('examples' in obj && obj.examples && typeof obj.examples === 'object' && !Array.isArray(obj.examples)) {
-      for (let exampleObj of Object.values(obj.examples) as any[]) {
-        if (exampleObj && typeof exampleObj === 'object' && '$ref' in exampleObj) {
-          exampleObj = this._resolveSchema(exampleObj) ?? {};
+    if ('examples' in obj && obj.examples) {
+      if (Array.isArray(obj.examples)) {
+        // JSON Schema / OpenAPI 3.1 Schema form: a plain array of example values.
+        for (const ex of obj.examples) {
+          examples.push(ex);
         }
-        if (exampleObj && typeof exampleObj === 'object') {
-          // Example Object can have 'value' or 'externalValue'
-          if ('value' in exampleObj) {
-            examples.push(exampleObj.value);
+      } else if (typeof obj.examples === 'object') {
+        // OpenAPI 3.0 form: a map of named Example Objects.
+        for (let exampleObj of Object.values(obj.examples) as any[]) {
+          if (exampleObj && typeof exampleObj === 'object' && '$ref' in exampleObj) {
+            exampleObj = this._resolveSchema(exampleObj) ?? {};
           }
-          // Note: externalValue is a URI reference, we skip it as it's not inline
+          if (exampleObj && typeof exampleObj === 'object') {
+            // Example Object can have 'value' or 'externalValue'
+            if ('value' in exampleObj) {
+              examples.push(exampleObj.value);
+            }
+            // Note: externalValue is a URI reference, we skip it as it's not inline
+          }
         }
       }
     }

--- a/packages/http/src/openapi_converter.ts
+++ b/packages/http/src/openapi_converter.ts
@@ -325,6 +325,41 @@ export class OpenApiConverter {
   }
 
   /**
+   * Whether a value is representable as JSON (and therefore as a valid JsonType
+   * once it reaches JsonSchemaSchema.parse). Non-finite numbers (NaN/Infinity)
+   * and `undefined` are not, and would otherwise make the zod parse throw and
+   * abort the entire conversion. Such example values are dropped instead.
+   */
+  private _isJsonSafe(value: any): boolean {
+    if (value === undefined) return false;
+    if (typeof value === 'number') return Number.isFinite(value);
+    if (Array.isArray(value)) return value.every(v => this._isJsonSafe(v));
+    if (value !== null && typeof value === 'object') {
+      return Object.values(value).every(v => this._isJsonSafe(v));
+    }
+    return true; // string, boolean, null, finite number
+  }
+
+  /**
+   * Order-insensitive, type-aware canonical key for de-duplicating example
+   * values: object keys are sorted recursively before serialization, so
+   * `{a:1,b:2}` and `{b:2,a:1}` collapse, while `true`/`1` stay distinct.
+   */
+  private _exampleKey(value: JsonType): string {
+    const canon = (v: any): any => {
+      if (Array.isArray(v)) return v.map(canon);
+      if (v !== null && typeof v === 'object') {
+        return Object.keys(v).sort().reduce((acc: Record<string, any>, k) => {
+          acc[k] = canon(v[k]);
+          return acc;
+        }, {});
+      }
+      return v;
+    };
+    return JSON.stringify(canon(value));
+  }
+
+  /**
    * Collects and de-duplicates examples from several OpenAPI objects, preserving order.
    *
    * Used to combine examples that can appear at more than one level for the
@@ -332,12 +367,17 @@ export class OpenApiConverter {
    */
   private _mergeExamples(...objs: Array<Record<string, any> | undefined | null>): JsonType[] | undefined {
     const merged: JsonType[] = [];
+    const seen = new Set<string>();
     for (const obj of objs) {
       const extracted = this._extractExamples(obj);
       if (!extracted) continue;
       for (const ex of extracted) {
-        const key = JSON.stringify(ex);
-        if (!merged.some(m => JSON.stringify(m) === key)) {
+        // Drop values that aren't valid JSON so a single bad example can't make
+        // JsonSchemaSchema.parse throw and abort the whole conversion.
+        if (!this._isJsonSafe(ex)) continue;
+        const key = this._exampleKey(ex);
+        if (!seen.has(key)) {
+          seen.add(key);
           merged.push(ex);
         }
       }

--- a/packages/http/src/openapi_converter.ts
+++ b/packages/http/src/openapi_converter.ts
@@ -18,7 +18,7 @@
  * defined by OpenAPI specifications, providing a bridge between OpenAPI and UTCP.
  */
 // packages/http/src/openapi_converter.ts
-import { Tool, JsonSchemaSchema, JsonSchema } from '@utcp/sdk';
+import { Tool, JsonSchemaSchema, JsonSchema, JsonType } from '@utcp/sdk';
 import { UtcpManual, UtcpManualSerializer } from '@utcp/sdk';
 import { Auth } from '@utcp/sdk';
 import { ApiKeyAuth } from '@utcp/sdk';
@@ -26,6 +26,14 @@ import { BasicAuth } from '@utcp/sdk';
 import { OAuth2Auth } from '@utcp/sdk';
 import { HttpCallTemplate } from './http_call_template';
 import { ensureSecureUrl, isLoopbackUrl } from './_security';
+
+/**
+ * HTTP methods that HttpCallTemplate.http_method accepts. Kept as the single
+ * source of truth for both the operation loop filter and per-operation
+ * validation so the two can never drift apart.
+ */
+const SUPPORTED_HTTP_METHODS = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH'] as const;
+type SupportedHttpMethod = typeof SUPPORTED_HTTP_METHODS[number];
 
 /**
  * Options for the OpenAPI converter.
@@ -181,7 +189,7 @@ export class OpenApiConverter {
     const paths = this.spec.paths || {};
     for (const [path, pathItem] of Object.entries(paths)) {
       for (const [method, operation] of Object.entries(pathItem as Record<string, any>)) {
-        if (['get', 'post', 'put', 'delete', 'patch'].includes(method.toLowerCase())) {
+        if ((SUPPORTED_HTTP_METHODS as readonly string[]).includes(method.toUpperCase())) {
           const tool = this._createTool(path, method, operation, baseUrl);
           if (tool) {
             tools.push(tool);
@@ -258,6 +266,81 @@ export class OpenApiConverter {
   }
 
   /**
+   * Extracts examples from an OpenAPI Parameter, Media Type, or Schema object.
+   *
+   * Supports both `example` (single value) and `examples` (map of Example
+   * Objects). Returns a list of example values suitable for the JSON Schema
+   * `examples` keyword, or undefined when none are present.
+   */
+  private _extractExamples(obj: Record<string, any> | undefined | null): JsonType[] | undefined {
+    if (!obj || typeof obj !== 'object') {
+      return undefined;
+    }
+
+    const examples: JsonType[] = [];
+
+    // Handle single 'example' field
+    if ('example' in obj && obj.example !== undefined && obj.example !== null) {
+      examples.push(obj.example);
+    }
+
+    // Handle 'examples' map (OpenAPI 3.0+ Example Objects keyed by name)
+    if ('examples' in obj && obj.examples && typeof obj.examples === 'object' && !Array.isArray(obj.examples)) {
+      for (let exampleObj of Object.values(obj.examples) as any[]) {
+        if (exampleObj && typeof exampleObj === 'object' && '$ref' in exampleObj) {
+          exampleObj = this._resolveSchema(exampleObj) ?? {};
+        }
+        if (exampleObj && typeof exampleObj === 'object') {
+          // Example Object can have 'value' or 'externalValue'
+          if ('value' in exampleObj) {
+            examples.push(exampleObj.value);
+          }
+          // Note: externalValue is a URI reference, we skip it as it's not inline
+        }
+      }
+    }
+
+    return examples.length > 0 ? examples : undefined;
+  }
+
+  /**
+   * Collects and de-duplicates examples from several OpenAPI objects, preserving order.
+   *
+   * Used to combine examples that can appear at more than one level for the
+   * same value, e.g. a Media Type Object and the Schema Object beneath it.
+   */
+  private _mergeExamples(...objs: Array<Record<string, any> | undefined | null>): JsonType[] | undefined {
+    const merged: JsonType[] = [];
+    for (const obj of objs) {
+      const extracted = this._extractExamples(obj);
+      if (!extracted) continue;
+      for (const ex of extracted) {
+        const key = JSON.stringify(ex);
+        if (!merged.some(m => JSON.stringify(m) === key)) {
+          merged.push(ex);
+        }
+      }
+    }
+    return merged.length > 0 ? merged : undefined;
+  }
+
+  /**
+   * Returns a copy of a schema object with the raw `example`/`examples` keys removed.
+   *
+   * Examples are normalized into the JSON Schema `examples` keyword via
+   * _mergeExamples, so the raw OpenAPI keys must not be spread back onto the
+   * property or they would leak through as untyped extra fields.
+   */
+  private _schemaWithoutExampleKeys(schema: Record<string, any>): Record<string, any> {
+    const out: Record<string, any> = {};
+    for (const [key, value] of Object.entries(schema)) {
+      if (key === 'example' || key === 'examples') continue;
+      out[key] = value;
+    }
+    return out;
+  }
+
+  /**
    * Creates a Tool object from an OpenAPI operation.
    * @param path The API path.
    * @param method The HTTP method (GET, POST, etc.).
@@ -276,6 +359,18 @@ export class OpenApiConverter {
       return null;
     }
 
+    // Validate the HTTP method against what HttpCallTemplate accepts before
+    // building the tool. OpenAPI allows operations like 'options'/'head'/'trace'
+    // that the call template's union type does not cover; skip them with a
+    // warning instead of emitting a tool with an invalid method. This explicit
+    // check is also what makes the cast below truthful rather than a blind
+    // assertion.
+    const httpMethod = method.toUpperCase();
+    if (!(SUPPORTED_HTTP_METHODS as readonly string[]).includes(httpMethod)) {
+      console.warn(`[OpenApiConverter] Skipping operation '${operationId}': unsupported HTTP method '${method}'.`);
+      return null;
+    }
+
     const description = operation.summary || operation.description || '';
     const tags = operation.tags || [];
 
@@ -287,7 +382,7 @@ export class OpenApiConverter {
     const callTemplate: HttpCallTemplate = {
       name: this.call_template_name,
       call_template_type: 'http',
-      http_method: method.toUpperCase() as 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH',
+      http_method: httpMethod as SupportedHttpMethod,
       url: fullUrl,
       body_field: bodyField ?? undefined,
       header_fields: headerFields.length > 0 ? headerFields : undefined,
@@ -339,10 +434,16 @@ export class OpenApiConverter {
       if (resolvedParam.in === 'body') {
         bodyField = 'body';
         const jsonSchema = this._resolveSchema(resolvedParam.schema || {});
+        // Examples can live on the parameter itself and on its schema;
+        // collect both into the normalized 'examples' keyword.
+        const bodyExamples = this._mergeExamples(resolvedParam, jsonSchema);
         properties[bodyField] = {
           description: resolvedParam.description || 'Request body',
-          ...jsonSchema,
+          ...this._schemaWithoutExampleKeys(jsonSchema),
         };
+        if (bodyExamples) {
+          properties[bodyField].examples = bodyExamples;
+        }
         if (resolvedParam.required) {
           required.push(bodyField);
         }
@@ -356,11 +457,16 @@ export class OpenApiConverter {
       if (!schema.items && resolvedParam.items) schema.items = resolvedParam.items;
       if (!schema.enum && resolvedParam.enum) schema.enum = resolvedParam.enum;
 
-
+      // Examples can live on the parameter itself and on its schema;
+      // collect both into the normalized 'examples' keyword.
+      const paramExamples = this._mergeExamples(resolvedParam, schema);
       properties[paramName] = {
         description: resolvedParam.description || '',
-        ...schema,
+        ...this._schemaWithoutExampleKeys(schema),
       };
+      if (paramExamples) {
+        properties[paramName].examples = paramExamples;
+      }
       if (resolvedParam.required) {
         required.push(paramName);
       }
@@ -371,14 +477,22 @@ export class OpenApiConverter {
     if (requestBody) {
       const resolvedBody = this._resolveSchema(requestBody);
       const content = resolvedBody.content || {};
+      const mediaTypeObj = content['application/json'] || content['application/x-www-form-urlencoded'];
       const jsonSchema = content['application/json']?.schema || content['application/x-www-form-urlencoded']?.schema;
 
       if (jsonSchema) {
         bodyField = 'body';
+        const resolvedJsonSchema = this._resolveSchema(jsonSchema);
+        // Examples can live on the media type object and on the schema;
+        // collect both into the normalized 'examples' keyword.
+        const bodyExamples = this._mergeExamples(mediaTypeObj, resolvedJsonSchema);
         properties[bodyField] = {
           description: resolvedBody.description || 'Request body',
-          ...this._resolveSchema(jsonSchema),
+          ...this._schemaWithoutExampleKeys(resolvedJsonSchema),
         };
+        if (bodyExamples) {
+          properties[bodyField].examples = bodyExamples;
+        }
         if (resolvedBody.required) {
           required.push(bodyField);
         }
@@ -410,15 +524,18 @@ export class OpenApiConverter {
 
     const resolvedResponse = this._resolveSchema(successResponse);
     let jsonSchema: any = null;
+    let mediaTypeObj: any = null;
 
     if ('content' in resolvedResponse) { // OpenAPI 3.0
       const content = resolvedResponse.content || {};
+      mediaTypeObj = content['application/json'] || content['text/plain'] || null;
       jsonSchema = content['application/json']?.schema || content['text/plain']?.schema;
       if (!jsonSchema && Object.keys(content).length > 0) {
         // Fallback to first content type's schema, with a type guard
         const firstContentTypeValue = Object.values(content)[0];
         if (typeof firstContentTypeValue === 'object' && firstContentTypeValue !== null && 'schema' in firstContentTypeValue) {
           jsonSchema = (firstContentTypeValue as { schema: any }).schema;
+          mediaTypeObj = firstContentTypeValue;
         }
       }
     } else if ('schema' in resolvedResponse) { // OpenAPI 2.0
@@ -430,6 +547,9 @@ export class OpenApiConverter {
     }
 
     const resolvedJsonSchema = this._resolveSchema(jsonSchema);
+    // Examples can live on the response media type object and on the schema;
+    // collect both into the normalized 'examples' keyword.
+    const responseExamples = this._mergeExamples(mediaTypeObj, resolvedJsonSchema);
     const schemaArgs: JsonSchema = {
       type: resolvedJsonSchema.type || 'object',
       properties: resolvedJsonSchema.properties || undefined,
@@ -442,6 +562,9 @@ export class OpenApiConverter {
       maximum: resolvedJsonSchema.maximum || undefined,
       format: resolvedJsonSchema.format || undefined,
     };
+    if (responseExamples) {
+      schemaArgs.examples = responseExamples;
+    }
 
     return schemaArgs;
   }

--- a/packages/http/src/openapi_converter.ts
+++ b/packages/http/src/openapi_converter.ts
@@ -331,13 +331,21 @@ export class OpenApiConverter {
    * abort the entire conversion. Such example values are dropped instead.
    */
   private _isJsonSafe(value: any): boolean {
-    if (value === undefined) return false;
-    if (typeof value === 'number') return Number.isFinite(value);
+    if (value === null) return true;
     if (Array.isArray(value)) return value.every(v => this._isJsonSafe(v));
-    if (value !== null && typeof value === 'object') {
-      return Object.values(value).every(v => this._isJsonSafe(v));
+    switch (typeof value) {
+      case 'string':
+      case 'boolean':
+        return true;
+      case 'number':
+        return Number.isFinite(value); // reject NaN / Infinity
+      case 'object':
+        return Object.values(value).every(v => this._isJsonSafe(v));
+      default:
+        // undefined, bigint, symbol, function: not representable as JSON.
+        // (bigint would even throw inside JSON.stringify during de-dup.)
+        return false;
     }
-    return true; // string, boolean, null, finite number
   }
 
   /**

--- a/packages/http/src/openapi_converter.ts
+++ b/packages/http/src/openapi_converter.ts
@@ -28,9 +28,17 @@ import { HttpCallTemplate } from './http_call_template';
 import { ensureSecureUrl, isLoopbackUrl } from './_security';
 
 /**
- * HTTP methods that HttpCallTemplate.http_method accepts. Kept as the single
- * source of truth for both the operation loop filter and per-operation
- * validation so the two can never drift apart.
+ * All HTTP methods that OpenAPI defines as operation fields on a Path Item
+ * Object. Used by the conversion loop to tell operations apart from the other
+ * path-item keys (parameters, summary, $ref, servers, ...), so that genuinely
+ * unsupported operations still reach _createTool and get a warning rather than
+ * being silently dropped here.
+ */
+const OPENAPI_OPERATION_METHODS = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'] as const;
+
+/**
+ * The subset of HTTP methods that HttpCallTemplate.http_method accepts.
+ * _createTool validates against this and skips anything else with a warning.
  */
 const SUPPORTED_HTTP_METHODS = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH'] as const;
 type SupportedHttpMethod = typeof SUPPORTED_HTTP_METHODS[number];
@@ -189,7 +197,7 @@ export class OpenApiConverter {
     const paths = this.spec.paths || {};
     for (const [path, pathItem] of Object.entries(paths)) {
       for (const [method, operation] of Object.entries(pathItem as Record<string, any>)) {
-        if ((SUPPORTED_HTTP_METHODS as readonly string[]).includes(method.toUpperCase())) {
+        if ((OPENAPI_OPERATION_METHODS as readonly string[]).includes(method.toLowerCase())) {
           const tool = this._createTool(path, method, operation, baseUrl);
           if (tool) {
             tools.push(tool);

--- a/packages/http/tests/openapi_converter.test.ts
+++ b/packages/http/tests/openapi_converter.test.ts
@@ -1,0 +1,178 @@
+// packages/http/tests/openapi_converter.test.ts
+//
+// Tests for OpenAPI -> UTCP conversion of examples and HTTP method handling.
+// Mirrors the Python suite: parameter/body/response examples are extracted and
+// normalized into the JSON Schema `examples` keyword, schema-level examples are
+// merged (not leaked raw), and operations with unsupported HTTP methods are
+// skipped rather than producing invalid tools.
+
+import { test, expect, describe } from 'bun:test';
+// Import the package index first so its register() side effect runs before the
+// converter validates the generated HttpCallTemplate.
+import '@utcp/http';
+import { OpenApiConverter } from '../src/openapi_converter';
+
+describe('OpenApiConverter examples', () => {
+  test('extracts parameter, body, and response examples', () => {
+    const spec = {
+      openapi: '3.0.0',
+      info: { title: 'Test API', version: '1.0.0' },
+      paths: {
+        '/users/{userId}': {
+          get: {
+            operationId: 'getUser',
+            parameters: [
+              {
+                name: 'userId',
+                in: 'path',
+                description: 'ID of the user',
+                required: true,
+                schema: { type: 'string' },
+                example: 'user123',
+              },
+              {
+                name: 'includeDetails',
+                in: 'query',
+                required: false,
+                schema: { type: 'boolean' },
+                examples: {
+                  trueExample: { summary: 'Include details', value: true },
+                  falseExample: { summary: 'Exclude details', value: false },
+                },
+              },
+            ],
+            responses: {
+              '200': {
+                description: 'Successful response',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: { id: { type: 'string' }, name: { type: 'string' } },
+                    },
+                    examples: {
+                      userExample: {
+                        summary: 'Example user',
+                        value: { id: 'user123', name: 'John Doe' },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        '/users': {
+          post: {
+            operationId: 'createUser',
+            requestBody: {
+              description: 'User to create',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: { name: { type: 'string' }, email: { type: 'string' } },
+                    required: ['name', 'email'],
+                  },
+                  examples: {
+                    newUser: {
+                      summary: 'New user example',
+                      value: { name: 'Jane Smith', email: 'jane@example.com' },
+                    },
+                  },
+                },
+              },
+            },
+            responses: { '201': { description: 'User created' } },
+          },
+        },
+      },
+    };
+
+    const manual = new OpenApiConverter(spec).convert();
+    expect(manual.tools.length).toBe(2);
+
+    const getUser = manual.tools.find(t => t.name === 'getUser')!;
+    expect(getUser).toBeDefined();
+
+    const userId = getUser.inputs.properties!.userId;
+    expect(userId.examples).toEqual(['user123']);
+
+    const includeDetails = getUser.inputs.properties!.includeDetails;
+    expect(includeDetails.examples).toEqual([true, false]);
+
+    expect(getUser.outputs.examples).toEqual([{ id: 'user123', name: 'John Doe' }]);
+
+    const createUser = manual.tools.find(t => t.name === 'createUser')!;
+    const body = createUser.inputs.properties!.body;
+    expect(body.examples).toEqual([{ name: 'Jane Smith', email: 'jane@example.com' }]);
+  });
+
+  test('normalizes schema-level examples and does not leak raw keys', () => {
+    const spec = {
+      openapi: '3.0.0',
+      info: { title: 'Test API', version: '1.0.0' },
+      paths: {
+        '/widgets': {
+          post: {
+            operationId: 'createWidget',
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: { name: { type: 'string' } },
+                    example: { name: 'Widget A' },
+                  },
+                },
+              },
+            },
+            responses: {
+              '200': {
+                description: 'ok',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      properties: { id: { type: 'string' } },
+                      example: { id: 'w_1' },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const manual = new OpenApiConverter(spec).convert();
+    const tool = manual.tools.find(t => t.name === 'createWidget')!;
+
+    const body = tool.inputs.properties!.body;
+    expect(body.examples).toEqual([{ name: 'Widget A' }]);
+    // raw 'example' key must not leak through onto the property
+    expect('example' in body).toBe(false);
+
+    expect(tool.outputs.examples).toEqual([{ id: 'w_1' }]);
+  });
+
+  test('skips operations with unsupported HTTP methods', () => {
+    const spec = {
+      openapi: '3.0.0',
+      info: { title: 'Test API', version: '1.0.0' },
+      paths: {
+        '/things': {
+          get: { operationId: 'listThings', responses: { '200': { description: 'ok' } } },
+          options: { operationId: 'optionsThings', responses: { '200': { description: 'ok' } } },
+          head: { operationId: 'headThings', responses: { '200': { description: 'ok' } } },
+          trace: { operationId: 'traceThings', responses: { '200': { description: 'ok' } } },
+        },
+      },
+    };
+
+    const manual = new OpenApiConverter(spec).convert();
+    const names = manual.tools.map(t => t.name).sort();
+    expect(names).toEqual(['listThings']);
+  });
+});

--- a/packages/http/tests/openapi_converter.test.ts
+++ b/packages/http/tests/openapi_converter.test.ts
@@ -6,7 +6,7 @@
 // merged (not leaked raw), and operations with unsupported HTTP methods are
 // skipped rather than producing invalid tools.
 
-import { test, expect, describe } from 'bun:test';
+import { test, expect, describe, spyOn } from 'bun:test';
 // Import the package index first so its register() side effect runs before the
 // converter validates the generated HttpCallTemplate.
 import '@utcp/http';
@@ -171,8 +171,20 @@ describe('OpenApiConverter examples', () => {
       },
     };
 
-    const manual = new OpenApiConverter(spec).convert();
-    const names = manual.tools.map(t => t.name).sort();
-    expect(names).toEqual(['listThings']);
+    const warn = spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const manual = new OpenApiConverter(spec).convert();
+      const names = manual.tools.map(t => t.name).sort();
+      expect(names).toEqual(['listThings']);
+
+      // Unsupported operations must reach _createTool and emit a skip warning,
+      // not be silently dropped by the loop filter.
+      const warnings = warn.mock.calls.map(c => String(c[0])).join('\n');
+      expect(warnings).toContain('optionsThings');
+      expect(warnings).toContain('headThings');
+      expect(warnings).toContain('traceThings');
+    } finally {
+      warn.mockRestore();
+    }
   });
 });

--- a/packages/http/tests/openapi_converter.test.ts
+++ b/packages/http/tests/openapi_converter.test.ts
@@ -285,6 +285,39 @@ describe('OpenApiConverter examples', () => {
     expect(tool.inputs.properties!.body.examples).toEqual([1.5]);
   });
 
+  test('non-JSON primitive examples (bigint/symbol) are dropped, not crash', () => {
+    const spec = {
+      openapi: '3.1.0',
+      info: { title: 'Test API', version: '1.0.0' },
+      paths: {
+        '/p': {
+          post: {
+            operationId: 'p',
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    // bigint would even throw inside JSON.stringify during de-dup;
+                    // symbol is not JSON either. Both must be dropped.
+                    examples: [10n as unknown as never, Symbol('x') as unknown as never, { ok: true }],
+                  },
+                },
+              },
+            },
+            responses: { '200': { description: 'ok' } },
+          },
+        },
+      },
+    };
+
+    let manual!: ReturnType<OpenApiConverter['convert']>;
+    expect(() => { manual = new OpenApiConverter(spec).convert(); }).not.toThrow();
+    const tool = manual.tools.find(t => t.name === 'p')!;
+    expect(tool).toBeDefined();
+    expect(tool.inputs.properties!.body.examples).toEqual([{ ok: true }]);
+  });
+
   test('skips operations with unsupported HTTP methods', () => {
     const spec = {
       openapi: '3.0.0',

--- a/packages/http/tests/openapi_converter.test.ts
+++ b/packages/http/tests/openapi_converter.test.ts
@@ -203,6 +203,88 @@ describe('OpenApiConverter examples', () => {
     expect(tool.outputs.examples).toEqual(['ok', 'done']);
   });
 
+  test('de-dups examples order-insensitively but keeps distinct types', () => {
+    const spec = {
+      openapi: '3.0.0',
+      info: { title: 'Test API', version: '1.0.0' },
+      paths: {
+        '/items': {
+          post: {
+            operationId: 'createItem',
+            requestBody: {
+              content: {
+                'application/json': {
+                  // media-type example with one key order...
+                  examples: { e1: { value: { a: 1, b: 2 } } },
+                  schema: {
+                    type: 'object',
+                    // ...schema example with the other key order (should de-dup to one)
+                    examples: [{ b: 2, a: 1 }],
+                  },
+                },
+              },
+            },
+            responses: {
+              '200': {
+                description: 'ok',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      // true and 1 are distinct examples and must both survive
+                      examples: [true, 1, true],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const manual = new OpenApiConverter(spec).convert();
+    const tool = manual.tools.find(t => t.name === 'createItem')!;
+
+    // {a:1,b:2} and {b:2,a:1} are the same example -> collapsed to one
+    expect(tool.inputs.properties!.body.examples).toEqual([{ a: 1, b: 2 }]);
+    // true vs 1 kept distinct; duplicate true removed
+    expect(tool.outputs.examples).toEqual([true, 1]);
+  });
+
+  test('a non-JSON example value does not abort conversion', () => {
+    const spec = {
+      openapi: '3.1.0',
+      info: { title: 'Test API', version: '1.0.0' },
+      paths: {
+        '/calc': {
+          post: {
+            operationId: 'calc',
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'number',
+                    // NaN is not valid JSON; must be dropped, not throw
+                    examples: [NaN, 1.5],
+                  },
+                },
+              },
+            },
+            responses: { '200': { description: 'ok' } },
+          },
+        },
+      },
+    };
+
+    let manual!: ReturnType<OpenApiConverter['convert']>;
+    expect(() => { manual = new OpenApiConverter(spec).convert(); }).not.toThrow();
+    const tool = manual.tools.find(t => t.name === 'calc')!;
+    expect(tool).toBeDefined();
+    // NaN dropped, the valid example kept
+    expect(tool.inputs.properties!.body.examples).toEqual([1.5]);
+  });
+
   test('skips operations with unsupported HTTP methods', () => {
     const spec = {
       openapi: '3.0.0',

--- a/packages/http/tests/openapi_converter.test.ts
+++ b/packages/http/tests/openapi_converter.test.ts
@@ -157,6 +157,52 @@ describe('OpenApiConverter examples', () => {
     expect(tool.outputs.examples).toEqual([{ id: 'w_1' }]);
   });
 
+  test('preserves array-form (JSON Schema / OAS 3.1) schema examples', () => {
+    const spec = {
+      openapi: '3.1.0',
+      info: { title: 'Test API', version: '1.0.0' },
+      paths: {
+        '/gadgets': {
+          post: {
+            operationId: 'createGadget',
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: { name: { type: 'string' } },
+                    // JSON Schema 'examples' keyword: an array of values
+                    examples: [{ name: 'Gadget A' }, { name: 'Gadget B' }],
+                  },
+                },
+              },
+            },
+            responses: {
+              '200': {
+                description: 'ok',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'string',
+                      examples: ['ok', 'done'],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const manual = new OpenApiConverter(spec).convert();
+    const tool = manual.tools.find(t => t.name === 'createGadget')!;
+
+    const body = tool.inputs.properties!.body;
+    expect(body.examples).toEqual([{ name: 'Gadget A' }, { name: 'Gadget B' }]);
+    expect(tool.outputs.examples).toEqual(['ok', 'done']);
+  });
+
   test('skips operations with unsupported HTTP methods', () => {
     const spec = {
       openapi: '3.0.0',


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds OpenAPI examples support with robust normalization and safer HTTP method handling. Examples are merged into JSON Schema `examples` with order-insensitive de-dup, and non-JSON values (including non-JSON primitives) are safely dropped; `@utcp/sdk` exposes this field, and OAS 3.1 array-form examples are preserved.

- **New Features**
  - Normalize `example`/`examples` from parameters, media types, and schemas (OAS2 body, OAS3 requestBody/responses, OAS 3.1 array-form) into de-duplicated `examples` arrays with raw keys stripped.
  - Add `examples?: JsonType[]` to `JsonSchema` and its zod schema in `@utcp/sdk`.

- **Bug Fixes**
  - Validate methods in `_createTool` against `GET|POST|PUT|DELETE|PATCH`; warn and skip `options/head/trace` (warning path now reachable).
  - Make example de-dup order-insensitive and type-aware; drop non-JSON values and primitives (`NaN`/`Infinity`/`bigint`/`symbol`/`function`) to prevent crashes.
  - Preserve JSON Schema/OpenAPI 3.1 array-form `examples`.

<sup>Written for commit ec186a60f69e134c6e564dbd656f2e39bbd0b725. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/universal-tool-calling-protocol/typescript-utcp/pull/28?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

