### PR TITLE
fix(openapi): preserve array-form (JSON Schema / OAS 3.1) schema examples

### DIFF
--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@utcp/http",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "HTTP utilities for UTCP",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/packages/http/src/openapi_converter.ts
+++ b/packages/http/src/openapi_converter.ts
@@ -276,9 +276,15 @@ export class OpenApiConverter {
   /**
    * Extracts examples from an OpenAPI Parameter, Media Type, or Schema object.
    *
-   * Supports both `example` (single value) and `examples` (map of Example
-   * Objects). Returns a list of example values suitable for the JSON Schema
-   * `examples` keyword, or undefined when none are present.
+   * Handles all three shapes the spec allows:
+   *   - `example` (single value) — OpenAPI Parameter / Media Type / 3.0 Schema.
+   *   - `examples` as a map of named Example Objects — OpenAPI Parameter /
+   *     Media Type Object (each entry carries an inline `value`).
+   *   - `examples` as an array of literal values — JSON Schema / OpenAPI 3.1
+   *     Schema Object.
+   *
+   * Returns a list of example values suitable for the JSON Schema `examples`
+   * keyword, or undefined when none are present.
    */
   private _extractExamples(obj: Record<string, any> | undefined | null): JsonType[] | undefined {
     if (!obj || typeof obj !== 'object') {
@@ -292,18 +298,25 @@ export class OpenApiConverter {
       examples.push(obj.example);
     }
 
-    // Handle 'examples' map (OpenAPI 3.0+ Example Objects keyed by name)
-    if ('examples' in obj && obj.examples && typeof obj.examples === 'object' && !Array.isArray(obj.examples)) {
-      for (let exampleObj of Object.values(obj.examples) as any[]) {
-        if (exampleObj && typeof exampleObj === 'object' && '$ref' in exampleObj) {
-          exampleObj = this._resolveSchema(exampleObj) ?? {};
+    if ('examples' in obj && obj.examples) {
+      if (Array.isArray(obj.examples)) {
+        // JSON Schema / OpenAPI 3.1 Schema form: a plain array of example values.
+        for (const ex of obj.examples) {
+          examples.push(ex);
         }
-        if (exampleObj && typeof exampleObj === 'object') {
-          // Example Object can have 'value' or 'externalValue'
-          if ('value' in exampleObj) {
-            examples.push(exampleObj.value);
+      } else if (typeof obj.examples === 'object') {
+        // OpenAPI 3.0 form: a map of named Example Objects.
+        for (let exampleObj of Object.values(obj.examples) as any[]) {
+          if (exampleObj && typeof exampleObj === 'object' && '$ref' in exampleObj) {
+            exampleObj = this._resolveSchema(exampleObj) ?? {};
           }
-          // Note: externalValue is a URI reference, we skip it as it's not inline
+          if (exampleObj && typeof exampleObj === 'object') {
+            // Example Object can have 'value' or 'externalValue'
+            if ('value' in exampleObj) {
+              examples.push(exampleObj.value);
+            }
+            // Note: externalValue is a URI reference, we skip it as it's not inline
+          }
         }
       }
     }

--- a/packages/http/tests/openapi_converter.test.ts
+++ b/packages/http/tests/openapi_converter.test.ts
@@ -157,6 +157,52 @@ describe('OpenApiConverter examples', () => {
     expect(tool.outputs.examples).toEqual([{ id: 'w_1' }]);
   });
 
+  test('preserves array-form (JSON Schema / OAS 3.1) schema examples', () => {
+    const spec = {
+      openapi: '3.1.0',
+      info: { title: 'Test API', version: '1.0.0' },
+      paths: {
+        '/gadgets': {
+          post: {
+            operationId: 'createGadget',
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: { name: { type: 'string' } },
+                    // JSON Schema 'examples' keyword: an array of values
+                    examples: [{ name: 'Gadget A' }, { name: 'Gadget B' }],
+                  },
+                },
+              },
+            },
+            responses: {
+              '200': {
+                description: 'ok',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'string',
+                      examples: ['ok', 'done'],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const manual = new OpenApiConverter(spec).convert();
+    const tool = manual.tools.find(t => t.name === 'createGadget')!;
+
+    const body = tool.inputs.properties!.body;
+    expect(body.examples).toEqual([{ name: 'Gadget A' }, { name: 'Gadget B' }]);
+    expect(tool.outputs.examples).toEqual(['ok', 'done']);
+  });
+
   test('skips operations with unsupported HTTP methods', () => {
     const spec = {
       openapi: '3.0.0',


### PR DESCRIPTION
## Problem (P2)

Schema-level `examples` declared as a JSON Schema array were silently lost during conversion:

```jsonc
"schema": { "type": "string", "examples": ["ok", "done"] }   // -> dropped
```

## Root cause

`_extractExamples` only recognized `examples` as an OpenAPI **map** of named Example Objects (`!Array.isArray(...)`), so it returned nothing for the array form. Meanwhile `_schemaWithoutExampleKeys` (added when normalizing examples) strips `examples` from the schema before it is spread onto the property. Before that strip the array passed through raw; after it, the array is extracted as nothing **and** removed — net data loss. JSON Schema (and OpenAPI 3.1 schema objects) define `examples` as an array of values.

## Fix

`_extractExamples` now handles all three shapes:
- `example` (single value)
- `examples` as a map of Example Objects (OpenAPI 3.0) — `.value` per entry, `$ref` resolved
- `examples` as an array of literal values (JSON Schema / OAS 3.1) — pushed verbatim

The two forms can't collide: a media type object's `examples` is always a map, a schema's is always an array.

## Tests

New test covering array-form schema examples on both request body and response. Full converter suite: 4 pass.

Bumps `@utcp/http` 1.1.8 → 1.1.9. (No npm publish in this PR.)

> Note: the same bug exists in python-utcp (same root cause); fixing there separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes loss of schema-level examples when using the JSON Schema / OAS 3.1 array form. The converter now preserves array `examples` and keeps support for map and single-value forms.

- **Bug Fixes**
  - Preserve schema `examples` arrays (JSON Schema/OAS 3.1) by updating `_extractExamples` to handle array, map, and single `example` values.
  - Add tests for request and response schemas to prevent regressions.

- **Dependencies**
  - Bump `@utcp/http` from 1.1.8 to 1.1.9.

<sup>Written for commit bb3923672ba0a4f4f7c3de65495e86b14c0fb249. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/universal-tool-calling-protocol/typescript-utcp/pull/29?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

