### PR TITLE
fix(openapi): robust example de-dup and tolerate non-JSON example values

### DIFF
--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@utcp/http",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "description": "HTTP utilities for UTCP",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/packages/http/src/openapi_converter.ts
+++ b/packages/http/src/openapi_converter.ts
@@ -325,6 +325,41 @@ export class OpenApiConverter {
   }
 
   /**
+   * Whether a value is representable as JSON (and therefore as a valid JsonType
+   * once it reaches JsonSchemaSchema.parse). Non-finite numbers (NaN/Infinity)
+   * and `undefined` are not, and would otherwise make the zod parse throw and
+   * abort the entire conversion. Such example values are dropped instead.
+   */
+  private _isJsonSafe(value: any): boolean {
+    if (value === undefined) return false;
+    if (typeof value === 'number') return Number.isFinite(value);
+    if (Array.isArray(value)) return value.every(v => this._isJsonSafe(v));
+    if (value !== null && typeof value === 'object') {
+      return Object.values(value).every(v => this._isJsonSafe(v));
+    }
+    return true; // string, boolean, null, finite number
+  }
+
+  /**
+   * Order-insensitive, type-aware canonical key for de-duplicating example
+   * values: object keys are sorted recursively before serialization, so
+   * `{a:1,b:2}` and `{b:2,a:1}` collapse, while `true`/`1` stay distinct.
+   */
+  private _exampleKey(value: JsonType): string {
+    const canon = (v: any): any => {
+      if (Array.isArray(v)) return v.map(canon);
+      if (v !== null && typeof v === 'object') {
+        return Object.keys(v).sort().reduce((acc: Record<string, any>, k) => {
+          acc[k] = canon(v[k]);
+          return acc;
+        }, {});
+      }
+      return v;
+    };
+    return JSON.stringify(canon(value));
+  }
+
+  /**
    * Collects and de-duplicates examples from several OpenAPI objects, preserving order.
    *
    * Used to combine examples that can appear at more than one level for the
@@ -332,12 +367,17 @@ export class OpenApiConverter {
    */
   private _mergeExamples(...objs: Array<Record<string, any> | undefined | null>): JsonType[] | undefined {
     const merged: JsonType[] = [];
+    const seen = new Set<string>();
     for (const obj of objs) {
       const extracted = this._extractExamples(obj);
       if (!extracted) continue;
       for (const ex of extracted) {
-        const key = JSON.stringify(ex);
-        if (!merged.some(m => JSON.stringify(m) === key)) {
+        // Drop values that aren't valid JSON so a single bad example can't make
+        // JsonSchemaSchema.parse throw and abort the whole conversion.
+        if (!this._isJsonSafe(ex)) continue;
+        const key = this._exampleKey(ex);
+        if (!seen.has(key)) {
+          seen.add(key);
           merged.push(ex);
         }
       }

--- a/packages/http/tests/openapi_converter.test.ts
+++ b/packages/http/tests/openapi_converter.test.ts
@@ -203,6 +203,88 @@ describe('OpenApiConverter examples', () => {
     expect(tool.outputs.examples).toEqual(['ok', 'done']);
   });
 
+  test('de-dups examples order-insensitively but keeps distinct types', () => {
+    const spec = {
+      openapi: '3.0.0',
+      info: { title: 'Test API', version: '1.0.0' },
+      paths: {
+        '/items': {
+          post: {
+            operationId: 'createItem',
+            requestBody: {
+              content: {
+                'application/json': {
+                  // media-type example with one key order...
+                  examples: { e1: { value: { a: 1, b: 2 } } },
+                  schema: {
+                    type: 'object',
+                    // ...schema example with the other key order (should de-dup to one)
+                    examples: [{ b: 2, a: 1 }],
+                  },
+                },
+              },
+            },
+            responses: {
+              '200': {
+                description: 'ok',
+                content: {
+                  'application/json': {
+                    schema: {
+                      type: 'object',
+                      // true and 1 are distinct examples and must both survive
+                      examples: [true, 1, true],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const manual = new OpenApiConverter(spec).convert();
+    const tool = manual.tools.find(t => t.name === 'createItem')!;
+
+    // {a:1,b:2} and {b:2,a:1} are the same example -> collapsed to one
+    expect(tool.inputs.properties!.body.examples).toEqual([{ a: 1, b: 2 }]);
+    // true vs 1 kept distinct; duplicate true removed
+    expect(tool.outputs.examples).toEqual([true, 1]);
+  });
+
+  test('a non-JSON example value does not abort conversion', () => {
+    const spec = {
+      openapi: '3.1.0',
+      info: { title: 'Test API', version: '1.0.0' },
+      paths: {
+        '/calc': {
+          post: {
+            operationId: 'calc',
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'number',
+                    // NaN is not valid JSON; must be dropped, not throw
+                    examples: [NaN, 1.5],
+                  },
+                },
+              },
+            },
+            responses: { '200': { description: 'ok' } },
+          },
+        },
+      },
+    };
+
+    let manual!: ReturnType<OpenApiConverter['convert']>;
+    expect(() => { manual = new OpenApiConverter(spec).convert(); }).not.toThrow();
+    const tool = manual.tools.find(t => t.name === 'calc')!;
+    expect(tool).toBeDefined();
+    // NaN dropped, the valid example kept
+    expect(tool.inputs.properties!.body.examples).toEqual([1.5]);
+  });
+
   test('skips operations with unsupported HTTP methods', () => {
     const spec = {
       openapi: '3.0.0',


### PR DESCRIPTION
Two issues found in a cross-repo audit of the examples implementation.

## A — De-dup key order (P3, parity with Python)

`_mergeExamples` keyed de-dup on `JSON.stringify(ex)`, which depends on object key order. `{a:1,b:2}` and `{b:2,a:1}` were treated as distinct and both kept. Python had the opposite bug (`==` collapsed `true`/`1`).

**Fix:** a canonical key that recursively sorts object keys before serializing — order-insensitive and type-aware (`true` ≠ `1`). Both implementations now produce identical output.

## B — Non-JSON example aborts the whole conversion (P2, robustness, TS-only)

A non-JSON example value (`NaN`/`Infinity`, or an object with an `undefined`-valued key) flowed into `examples`, then `JsonSchemaSchema.parse()` threw a `ZodError` — which propagated out of `convert()` and killed **all** tools, not just the offending operation. Python tolerates these.

**Fix:** `_isJsonSafe` drops non-JSON values in `_mergeExamples`, so one bad example can't take down the conversion. The valid examples and the tool survive.

## Tests

- order-insensitive + type-aware de-dup (`{a:1,b:2}`/`{b:2,a:1}` collapse; `true`/`1` distinct)
- non-JSON example tolerance (`NaN` dropped, conversion does not throw)

Full converter suite: 6 pass. `tsup` builds clean. Bumps `@utcp/http` 1.1.9 → 1.1.10.

> Paired with python-utcp PR for the de-dup alignment. (No npm publish in this PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes OpenAPI example handling more robust. We now de-duplicate examples independent of object key order and ignore non-JSON values so one bad example can’t break conversion. Aligns output with the Python implementation.

- **Bug Fixes**
  - Order-insensitive, type-aware example de-dup (sorted object keys; `true` ≠ `1`).
  - Drop non-JSON example values (NaN/Infinity/undefined) to prevent converter crashes.

- **Dependencies**
  - Bump `@utcp/http` from 1.1.9 to 1.1.10.

<sup>Written for commit 8f33daef4e6d21fcc808303c38d500db337812f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/universal-tool-calling-protocol/typescript-utcp/pull/30?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

