### PR TITLE
fix(openapi): _isJsonSafe must whitelist JSON primitives

### DIFF
--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@utcp/http",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "description": "HTTP utilities for UTCP",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/packages/http/src/openapi_converter.ts
+++ b/packages/http/src/openapi_converter.ts
@@ -331,13 +331,21 @@ export class OpenApiConverter {
    * abort the entire conversion. Such example values are dropped instead.
    */
   private _isJsonSafe(value: any): boolean {
-    if (value === undefined) return false;
-    if (typeof value === 'number') return Number.isFinite(value);
+    if (value === null) return true;
     if (Array.isArray(value)) return value.every(v => this._isJsonSafe(v));
-    if (value !== null && typeof value === 'object') {
-      return Object.values(value).every(v => this._isJsonSafe(v));
+    switch (typeof value) {
+      case 'string':
+      case 'boolean':
+        return true;
+      case 'number':
+        return Number.isFinite(value); // reject NaN / Infinity
+      case 'object':
+        return Object.values(value).every(v => this._isJsonSafe(v));
+      default:
+        // undefined, bigint, symbol, function: not representable as JSON.
+        // (bigint would even throw inside JSON.stringify during de-dup.)
+        return false;
     }
-    return true; // string, boolean, null, finite number
   }
 
   /**

--- a/packages/http/tests/openapi_converter.test.ts
+++ b/packages/http/tests/openapi_converter.test.ts
@@ -285,6 +285,39 @@ describe('OpenApiConverter examples', () => {
     expect(tool.inputs.properties!.body.examples).toEqual([1.5]);
   });
 
+  test('non-JSON primitive examples (bigint/symbol) are dropped, not crash', () => {
+    const spec = {
+      openapi: '3.1.0',
+      info: { title: 'Test API', version: '1.0.0' },
+      paths: {
+        '/p': {
+          post: {
+            operationId: 'p',
+            requestBody: {
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    // bigint would even throw inside JSON.stringify during de-dup;
+                    // symbol is not JSON either. Both must be dropped.
+                    examples: [10n as unknown as never, Symbol('x') as unknown as never, { ok: true }],
+                  },
+                },
+              },
+            },
+            responses: { '200': { description: 'ok' } },
+          },
+        },
+      },
+    };
+
+    let manual!: ReturnType<OpenApiConverter['convert']>;
+    expect(() => { manual = new OpenApiConverter(spec).convert(); }).not.toThrow();
+    const tool = manual.tools.find(t => t.name === 'p')!;
+    expect(tool).toBeDefined();
+    expect(tool.inputs.properties!.body.examples).toEqual([{ ok: true }]);
+  });
+
   test('skips operations with unsupported HTTP methods', () => {
     const spec = {
       openapi: '3.0.0',


### PR DESCRIPTION
## Problem (P1)

`_isJsonSafe` (added to stop non-JSON examples from crashing `convert()`) was a **blacklist**:

```ts
if (value === undefined) return false;
if (typeof value === 'number') return Number.isFinite(value);
if (Array.isArray(value)) return value.every(...);
if (value !== null && typeof value === 'object') return Object.values(value).every(...);
return true; // <- catches bigint, symbol, function too
```

The final `return true` accepts `bigint`, `symbol`, and `function` — none of which are JSON. A `bigint` example is the worst case: `JSON.stringify(1n)` **throws** inside `_exampleKey` during de-dup, i.e. the exact crash the guard was meant to prevent.

## Root cause

Blacklist logic (exclude a few known-bad) instead of a whitelist (allow only known-good JSON types). Any type not explicitly excluded fell through to `true`.

## Fix

Whitelist via `typeof` switch — only `string`, `boolean`, `null`, finite `number`, and recursively-safe arrays/objects pass; `undefined`/`bigint`/`symbol`/`function` are dropped.

## Tests

Adds a test with `bigint` and `symbol` examples: conversion does not throw and only the valid example survives. Full converter suite: 7 pass. `tsup` builds clean.

Bumps `@utcp/http` 1.1.10 → 1.1.11. (TS-only; Python's `_merge_examples` uses `json.dumps(default=str)` and has no equivalent hole.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix OpenAPI converter crash by whitelisting JSON-safe types in `_isJsonSafe`. Only JSON-representable values are kept; non-JSON primitives are dropped to prevent `convert()` from throwing.

- **Bug Fixes**
  - Rewrite `_isJsonSafe` to a whitelist: allow string, boolean, null, finite number, and recursively-safe arrays/objects.
  - Drop undefined, bigint, symbol, and function to avoid `JSON.stringify` errors during example de-dup.
  - Add tests with bigint/symbol examples to ensure no crash and only valid examples remain.

- **Dependencies**
  - Bump `@utcp/http` 1.1.10 → 1.1.11.

<sup>Written for commit 77d64775235b9678f0d8d9905bce6f6d7ba7dfa6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/universal-tool-calling-protocol/typescript-utcp/pull/32?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

