### PR TITLE
fix(mcp): circular-ref-safe schema deref, quiet child stderr, structuredContent fallback

### DIFF
--- a/packages/mcp/src/mcp_communication_protocol.ts
+++ b/packages/mcp/src/mcp_communication_protocol.ts
@@ -140,8 +140,13 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
         return schema as JsonSchema;
       }
       
-      // Dereference the schema (inlines all $refs and $defs)
-      const dereferenced = await $RefParser.dereference(schema as any);
+      // Dereference the schema (inlines all $refs and $defs). `circular:
+      // 'ignore'` keeps recursive schemas (e.g. self-referencing filter
+      // grammars) from throwing — the cycle is left as a live reference
+      // instead of failing the whole tool discovery.
+      const dereferenced = await $RefParser.dereference(schema as any, {
+        dereference: { circular: 'ignore' },
+      });
       return dereferenced as JsonSchema;
     } catch (error: any) {
       // If dereferencing fails, log a warning and return the original schema
@@ -194,6 +199,12 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
         args: stdioConfig.args || [],
         cwd: stdioConfig.cwd,
         env: combinedEnv,
+        // Default the child's stderr to 'ignore' so a chatty MCP server does
+        // not flood the host terminal during discovery. NOT 'pipe': with no
+        // reader attached the OS pipe buffer fills and a verbose child
+        // deadlocks. Set UTCP_MCP_CHILD_STDERR=inherit to see child stderr
+        // when debugging.
+        stderr: process.env.UTCP_MCP_CHILD_STDERR === 'inherit' ? 'inherit' : 'ignore',
       });
 
     } else if (serverConfig.transport === 'http') {
@@ -409,6 +420,13 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
     if (result && typeof result === 'object') {
       if ('structured_output' in result) {
         return result.structured_output;
+      }
+      // MCP servers may return only `structuredContent` (spec field) with an
+      // empty `content` array — without this fallback such results collapse
+      // to [] and the payload is silently lost.
+      const hasContent = Array.isArray(result.content) && result.content.length > 0;
+      if (!hasContent && result.structuredContent != null) {
+        return result.structuredContent;
       }
       if (Array.isArray(result.content)) {
         const processedList = result.content.map((item: any) => {


### PR DESCRIPTION
Three independent robustness fixes to `McpCommunicationProtocol`, all battle-tested for several weeks as a patch-package shim over `@utcp/mcp` 1.1.1→1.1.3 in a code-mode deployment federating 15+ MCP servers / 400+ tools.

## 1. Circular-reference-safe schema dereferencing

`$RefParser.dereference(schema)` throws on recursive JSON Schemas (e.g. self-referencing SOQL/SOSL filter grammars returned by Salesforce MCP servers). Because the error propagates before the per-schema try/catch can help every time the same schema is re-encountered, the affected manual's tool discovery degrades. Passing `{ dereference: { circular: 'ignore' } }` keeps the cycle as a live reference and discovery succeeds; acyclic schemas are byte-identical.

## 2. Child stderr: default `'ignore'`, opt-in `'inherit'`

`StdioClientTransport` is constructed without a `stderr` option, so every stdio MCP child inherits the host's stderr and floods the terminal during discovery (banners, telemetry notices, auth chatter — multiplied by N servers).

- Default is now `'ignore'`.
- `UTCP_MCP_CHILD_STDERR=inherit` restores the old behavior for debugging.
- Deliberately **not** `'pipe'`: with no reader attached the OS pipe buffer fills and a chatty child deadlocks.

## 3. `structuredContent` fallback in `_processMcpToolResult`

Some MCP servers return results with an **empty `content` array** and the payload only in `structuredContent` (an MCP spec field). Today that collapses to `[]` and the payload is silently lost. When `content` is empty and `structuredContent != null`, return `structuredContent`. Results that carry `content` are untouched, and the existing `structured_output` branch still wins.

## Notes

- One file changed: `packages/mcp/src/mcp_communication_protocol.ts`.
- The esbuild JS bundle builds clean with these changes. The `tsup` **dts** step currently fails on a clean checkout of `main` too (an `@types/node` resolution issue under bun's node_modules layout) — pre-existing and unrelated.
- Happy to split into three PRs if you prefer smaller reviews.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve MCP stability by handling circular JSON Schemas, quieting child stderr by default, and preserving results returned via structuredContent. Reduces discovery failures and terminal noise when federating many MCP servers.

- **Bug Fixes**
  - Schema deref: use `$RefParser.dereference(..., { dereference: { circular: 'ignore' } })` to safely handle recursive schemas without breaking discovery.
  - Child stderr: default to `'ignore'`; set `UTCP_MCP_CHILD_STDERR=inherit` to debug. Not `'pipe'` to avoid deadlocks.
  - Tool results: when `content` is empty and `structuredContent` exists, return `structuredContent` so payloads aren’t lost.

<sup>Written for commit 7df273b288c9ddafa24ce3d8404f170ad496b037. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/universal-tool-calling-protocol/typescript-utcp/pull/33?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

