### PR TITLE
fix(mcp): stop SSE notification-stream reconnect churn by default

### DIFF
--- a/packages/mcp/src/mcp_call_template.ts
+++ b/packages/mcp/src/mcp_call_template.ts
@@ -49,7 +49,7 @@ export interface McpHttpServer {
   timeout: number;
   sse_read_timeout: number;
   terminate_on_close: boolean;
-  sse_reconnect_max_retries: number;
+  notification_stream_max_retries: number;
 }
 
 /**
@@ -62,13 +62,14 @@ export const McpHttpServerSchema: z.ZodType<McpHttpServer> = z.object({
   timeout: z.number().optional().default(30).describe('Timeout for HTTP requests in seconds.'),
   sse_read_timeout: z.number().optional().default(300).describe('Read timeout for SSE connections in seconds (e.g., for `streamable-http` MCP servers).'),
   terminate_on_close: z.boolean().optional().default(true).describe('Whether to terminate the HTTP connection on client close.'),
-  sse_reconnect_max_retries: z.number().int().min(0).optional().default(0).describe(
-    'How many times the transport may reconnect a dropped SSE stream. Defaults to 0 (no ' +
-    'reconnection): UTCP tool calls are strictly request/response, and the MCP SDK resets its ' +
-    'retry counter whenever a stream closes GRACEFULLY — hosted servers close idle notification ' +
-    'streams every few seconds, so any nonzero value makes a long-lived cached session reconnect ' +
-    'forever, leaking an abort listener per attempt (issue #35). Raise this only for servers ' +
-    'whose server-initiated notifications you actually consume.',
+  notification_stream_max_retries: z.number().int().min(0).optional().default(0).describe(
+    'How many times the Streamable HTTP transport may reconnect its standalone GET notification ' +
+    'stream (the SSE-encoded channel for server-initiated messages) after it drops. Defaults to ' +
+    '0 (no reconnection): UTCP tool calls are strictly request/response, and the MCP SDK resets ' +
+    'its retry counter whenever a stream closes GRACEFULLY — hosted servers close idle ' +
+    'notification streams every few seconds, so any nonzero value makes a long-lived cached ' +
+    'session reconnect forever, leaking an abort listener per attempt (issue #35). Raise this ' +
+    'only for servers whose server-initiated notifications you actually consume.',
   ),
 }) as z.ZodType<McpHttpServer>;
 

--- a/packages/mcp/src/mcp_call_template.ts
+++ b/packages/mcp/src/mcp_call_template.ts
@@ -49,6 +49,7 @@ export interface McpHttpServer {
   timeout: number;
   sse_read_timeout: number;
   terminate_on_close: boolean;
+  sse_reconnect_max_retries: number;
 }
 
 /**
@@ -61,6 +62,14 @@ export const McpHttpServerSchema: z.ZodType<McpHttpServer> = z.object({
   timeout: z.number().optional().default(30).describe('Timeout for HTTP requests in seconds.'),
   sse_read_timeout: z.number().optional().default(300).describe('Read timeout for SSE connections in seconds (e.g., for `streamable-http` MCP servers).'),
   terminate_on_close: z.boolean().optional().default(true).describe('Whether to terminate the HTTP connection on client close.'),
+  sse_reconnect_max_retries: z.number().int().min(0).optional().default(0).describe(
+    'How many times the transport may reconnect a dropped SSE stream. Defaults to 0 (no ' +
+    'reconnection): UTCP tool calls are strictly request/response, and the MCP SDK resets its ' +
+    'retry counter whenever a stream closes GRACEFULLY — hosted servers close idle notification ' +
+    'streams every few seconds, so any nonzero value makes a long-lived cached session reconnect ' +
+    'forever, leaking an abort listener per attempt (issue #35). Raise this only for servers ' +
+    'whose server-initiated notifications you actually consume.',
+  ),
 }) as z.ZodType<McpHttpServer>;
 
 

--- a/packages/mcp/src/mcp_communication_protocol.ts
+++ b/packages/mcp/src/mcp_communication_protocol.ts
@@ -74,7 +74,7 @@ function ensureSecureMcpUrl(rawUrl: string, context: string): void {
       `internal services.`,
   );
 }
-import { McpCallTemplateSchema, McpHttpServer, McpServerConfig, McpStdioServer } from './mcp_call_template';
+import { McpCallTemplateSchema, McpHttpServer, McpHttpServerSchema, McpServerConfig, McpStdioServer } from './mcp_call_template';
 import { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import $RefParser from '@apidevtools/json-schema-ref-parser';
 
@@ -197,7 +197,13 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
       });
 
     } else if (serverConfig.transport === 'http') {
-      const httpConfig = serverConfig as McpHttpServer;
+      // PARSE, not cast: server entries travel as `z.any()` inside
+      // McpConfigSchema (official-MCP-config compatibility), so this is the
+      // one point where the per-field schema actually applies — defaults
+      // (notification_stream_max_retries: 0 among them) take effect and the
+      // documented rejections (negative/fractional retry caps) really reject
+      // instead of flowing into the transport.
+      const httpConfig: McpHttpServer = McpHttpServerSchema.parse(serverConfig);
       // Reject plain-HTTP non-loopback URLs and obvious SSRF targets
       // before any connection attempt. Matches the trust boundary
       // @utcp/http enforces for its own discovery / invocation URLs.
@@ -236,7 +242,7 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
         // (MaxListenersExceededWarning; issue #35). The delay values are
         // the SDK's own defaults — only the retry cap is configurable.
         reconnectionOptions: {
-          maxRetries: httpConfig.notification_stream_max_retries ?? 0,
+          maxRetries: httpConfig.notification_stream_max_retries,
           initialReconnectionDelay: 1000,
           reconnectionDelayGrowFactor: 1.5,
           maxReconnectionDelay: 30000,

--- a/packages/mcp/src/mcp_communication_protocol.ts
+++ b/packages/mcp/src/mcp_communication_protocol.ts
@@ -225,17 +225,18 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
 
       const transportOptions: StreamableHTTPClientTransportOptions = {
         requestInit: { headers: { ...(httpConfig.headers || {}), ...authHeader } },
-        // No SSE reconnection by default (`sse_reconnect_max_retries: 0`).
-        // The SDK maintains a standalone GET stream for server-initiated
-        // notifications and RESETS its retry counter whenever a stream
-        // closes gracefully — hosted MCP servers close idle streams every
-        // few seconds, so under the SDK defaults every cached session
+        // No notification-stream reconnection by default
+        // (`notification_stream_max_retries: 0`). The Streamable HTTP
+        // transport maintains a standalone GET stream (SSE-encoded) for
+        // server-initiated notifications and RESETS its retry counter
+        // whenever a stream closes gracefully — hosted servers close idle
+        // streams every few seconds, so under the SDK defaults every cached session
         // reconnects forever, and each attempt's fetch parks an abort
         // listener on the transport-lifetime signal until GC
         // (MaxListenersExceededWarning; issue #35). The delay values are
         // the SDK's own defaults — only the retry cap is configurable.
         reconnectionOptions: {
-          maxRetries: httpConfig.sse_reconnect_max_retries ?? 0,
+          maxRetries: httpConfig.notification_stream_max_retries ?? 0,
           initialReconnectionDelay: 1000,
           reconnectionDelayGrowFactor: 1.5,
           maxReconnectionDelay: 30000,

--- a/packages/mcp/src/mcp_communication_protocol.ts
+++ b/packages/mcp/src/mcp_communication_protocol.ts
@@ -224,7 +224,22 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
       }
 
       const transportOptions: StreamableHTTPClientTransportOptions = {
-        requestInit: { headers: { ...(httpConfig.headers || {}), ...authHeader } }
+        requestInit: { headers: { ...(httpConfig.headers || {}), ...authHeader } },
+        // No SSE reconnection by default (`sse_reconnect_max_retries: 0`).
+        // The SDK maintains a standalone GET stream for server-initiated
+        // notifications and RESETS its retry counter whenever a stream
+        // closes gracefully — hosted MCP servers close idle streams every
+        // few seconds, so under the SDK defaults every cached session
+        // reconnects forever, and each attempt's fetch parks an abort
+        // listener on the transport-lifetime signal until GC
+        // (MaxListenersExceededWarning; issue #35). The delay values are
+        // the SDK's own defaults — only the retry cap is configurable.
+        reconnectionOptions: {
+          maxRetries: httpConfig.sse_reconnect_max_retries ?? 0,
+          initialReconnectionDelay: 1000,
+          reconnectionDelayGrowFactor: 1.5,
+          maxReconnectionDelay: 30000,
+        },
       };
       transport = new StreamableHTTPClientTransport(new URL(httpConfig.url), transportOptions);
 

--- a/packages/mcp/tests/mcp_communication_protocol.test.ts
+++ b/packages/mcp/tests/mcp_communication_protocol.test.ts
@@ -266,6 +266,28 @@ describe("McpCommunicationProtocol", () => {
         ).rejects.toThrow("Invalid MCP tool name format: 'nonexistent_tool'. Expected 'manualName.serverName.toolName'.");
     }, 10000);
 
+    test("rejects an invalid notification_stream_max_retries at the transport boundary", async () => {
+      // Server entries travel as `z.any()` inside McpConfigSchema, so the
+      // per-field validation must fire where the transport is built — this
+      // exercises that path end to end, not the schema in isolation.
+      const badTemplate: McpCallTemplate = {
+        name: "bad_retry_manual",
+        call_template_type: "mcp",
+        config: {
+          mcpServers: {
+            bad_server: {
+              transport: 'http',
+              url: `http://localhost:${HTTP_PORT}/mcp`,
+              notification_stream_max_retries: -1,
+            }
+          }
+        }
+      };
+      const result = await protocol.registerManual(mockClient, badTemplate);
+      expect(result.success).toBe(false);
+      expect(result.errors.join(" ")).toContain("notification_stream_max_retries");
+    }, 10000);
+
     test("should throw an error if server name from tool is not in config", async () => {
         await expect(
             protocol.callTool(mockClient, "unknown_server.some_tool", {}, callTemplate)

--- a/packages/mcp/tests/mcp_communication_protocol.test.ts
+++ b/packages/mcp/tests/mcp_communication_protocol.test.ts
@@ -3,6 +3,7 @@ import { test, expect, beforeAll, afterAll, describe } from "bun:test";
 import { Subprocess } from "bun";
 import path from "path";
 import { McpCommunicationProtocol, McpCallTemplate } from "../src/index";
+import { McpHttpServerSchema } from "../src/mcp_call_template";
 import { IUtcpClient } from "@utcp/sdk";
 
 const HTTP_PORT = 9999;
@@ -140,6 +141,30 @@ afterAll(async () => {
   // Extra safety: wait a bit for ports to be released
   await new Promise(resolve => setTimeout(resolve, 300));
   console.log("Mock servers stopped.");
+});
+
+describe("McpHttpServer SSE reconnection config", () => {
+  test("defaults sse_reconnect_max_retries to 0 — no notification-stream reconnect churn", () => {
+    const parsed = McpHttpServerSchema.parse({ transport: "http", url: "https://example.com/mcp" });
+    expect(parsed.sse_reconnect_max_retries).toBe(0);
+  });
+
+  test("accepts an explicit retry cap for servers whose notifications are consumed", () => {
+    const parsed = McpHttpServerSchema.parse({
+      transport: "http",
+      url: "https://example.com/mcp",
+      sse_reconnect_max_retries: 3,
+    });
+    expect(parsed.sse_reconnect_max_retries).toBe(3);
+  });
+
+  test("rejects negative and fractional retry caps", () => {
+    for (const bad of [-1, 1.5]) {
+      expect(() =>
+        McpHttpServerSchema.parse({ transport: "http", url: "https://example.com/mcp", sse_reconnect_max_retries: bad }),
+      ).toThrow();
+    }
+  });
 });
 
 describe("McpCommunicationProtocol", () => {

--- a/packages/mcp/tests/mcp_communication_protocol.test.ts
+++ b/packages/mcp/tests/mcp_communication_protocol.test.ts
@@ -144,24 +144,24 @@ afterAll(async () => {
 });
 
 describe("McpHttpServer SSE reconnection config", () => {
-  test("defaults sse_reconnect_max_retries to 0 — no notification-stream reconnect churn", () => {
+  test("defaults notification_stream_max_retries to 0 — no notification-stream reconnect churn", () => {
     const parsed = McpHttpServerSchema.parse({ transport: "http", url: "https://example.com/mcp" });
-    expect(parsed.sse_reconnect_max_retries).toBe(0);
+    expect(parsed.notification_stream_max_retries).toBe(0);
   });
 
   test("accepts an explicit retry cap for servers whose notifications are consumed", () => {
     const parsed = McpHttpServerSchema.parse({
       transport: "http",
       url: "https://example.com/mcp",
-      sse_reconnect_max_retries: 3,
+      notification_stream_max_retries: 3,
     });
-    expect(parsed.sse_reconnect_max_retries).toBe(3);
+    expect(parsed.notification_stream_max_retries).toBe(3);
   });
 
   test("rejects negative and fractional retry caps", () => {
     for (const bad of [-1, 1.5]) {
       expect(() =>
-        McpHttpServerSchema.parse({ transport: "http", url: "https://example.com/mcp", sse_reconnect_max_retries: bad }),
+        McpHttpServerSchema.parse({ transport: "http", url: "https://example.com/mcp", notification_stream_max_retries: bad }),
       ).toThrow();
     }
   });


### PR DESCRIPTION
Fixes #35 (and removes the main accumulation path behind the warning in #34).

## What

- New per-server knob on the MCP HTTP config: `notification_stream_max_retries`, **default 0** — the transport is built with `reconnectionOptions.maxRetries` from it (delay values stay at the SDK's own defaults).
- With the default, the Streamable HTTP transport's standalone GET notification stream is opened once and never reconnected. UTCP tool calls are strictly request/response, so nothing consumes that stream; its reconnect loop was pure cost.

## Terminology note

This concerns the **Streamable HTTP** transport (the modern one), not the deprecated HTTP+SSE transport — "SSE" appears only as the event-stream *encoding* Streamable HTTP uses for its notification channel and streamed responses. The knob is named after the notification stream to avoid exactly that ambiguity.

## Why default 0 rather than exposing the SDK default

The SDK's retry cap (`maxRetries: 2`) never engages against well-behaved servers: `_handleSseStream` schedules reconnection with `attemptCount = 0` whenever a stream closes **gracefully**, and hosted MCP servers close idle notification streams every few seconds. A process-lifetime cached session therefore reconnects forever, and each attempt's `fetch` parks an abort listener on the transport-lifetime `AbortSignal` that undici releases only at GC — the `MaxListenersExceededWarning` climb documented in #35, reproduced with healthy, fully-authenticated sessions.

Deployments that genuinely consume server-initiated notifications can raise the knob per server.

## Behavior change

A genuinely dropped mid-call stream now fails the call instead of attempting resume. For request/response tool calling that is the more honest failure mode; raising `notification_stream_max_retries` restores resumption where wanted.

## Tests

Schema coverage for the default, an explicit cap, and rejection of negative/fractional values. Full mcp package suite green (12/12); the repo-wide stdio-transport failures on my machine are pre-existing (identical with this change stashed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)