### PR TITLE
mcp: evict dead sessions on auth failures and operation timeouts

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@utcp/mcp",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Model Context Protocol integration for UTCP",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/packages/mcp/src/mcp_communication_protocol.ts
+++ b/packages/mcp/src/mcp_communication_protocol.ts
@@ -150,17 +150,47 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
     }
   }
 
-  private async _cleanupSession(sessionKey: string): Promise<void> {
-    const session = this._mcpSessions.get(sessionKey);
-    if (session) {
-      try {
-        await session.close();
-        this._logInfo(`Closed MCP session for '${sessionKey}'.`);
-      } catch (e: any) {
-        this._logError(`Error closing session for '${sessionKey}':`, e.message);
-      } finally {
-        this._mcpSessions.delete(sessionKey);
-      }
+  /**
+   * Close a session and drop it from the cache — identity-aware. Pass
+   * `expected` (the client the caller actually saw fail) so a concurrent
+   * caller's replacement session is never closed by mistake: if the cache no
+   * longer holds `expected`, only `expected` itself is closed and the cached
+   * entry is left alone.
+   *
+   * The cache delete happens BEFORE the `await close()`, not after it: with
+   * the delete in a `finally`, a concurrent `_getOrCreateSession` landing
+   * during the close would have its freshly cached session deleted out from
+   * under it.
+   */
+  private async _cleanupSession(sessionKey: string, expected?: McpClient): Promise<void> {
+    const cached = this._mcpSessions.get(sessionKey);
+    const target = expected ?? cached;
+    if (!target) return;
+    if (cached === target) {
+      this._mcpSessions.delete(sessionKey);
+    }
+    try {
+      await target.close();
+      this._logInfo(`Closed MCP session for '${sessionKey}'.`);
+    } catch (e: any) {
+      this._logError(`Error closing session for '${sessionKey}':`, e.message);
+    }
+  }
+
+  /**
+   * Drop a cached client-credentials OAuth token after the server rejected
+   * it. The cache trusts `expires_in`, but a token can be revoked server-side
+   * before its local expiry — without this, every post-eviction redial would
+   * resend the same rejected token until the TTL ran out, so evicting the
+   * session alone would fix nothing. `oauth2_user` tokens are provisioned
+   * out-of-band and never cached here, so there is nothing to invalidate for
+   * them.
+   */
+  private _invalidateOAuthToken(auth: Auth | undefined): void {
+    if (!auth || auth.auth_type === 'oauth2_user') return;
+    const clientId = (auth as OAuth2Auth).client_id;
+    if (clientId && this._oauthTokens.delete(clientId)) {
+      this._logInfo(`Dropped cached OAuth token for client '${clientId}' after an auth rejection.`);
     }
   }
 
@@ -277,45 +307,54 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
 
   /**
    * Classify an operation failure by what it says about the CACHED SESSION,
-   * which is the thing `_withSession` is responsible for. Three answers:
+   * which is the thing `_withSession` is responsible for. Four answers:
    *
    *   - `'transient'` — the transport broke in a way a fresh dial has a real
    *     chance of fixing right now (connection dropped, reset, stale
    *     handshake). Evict and retry once.
-   *   - `'broken'` — the session is dead weight, but an immediate redial
-   *     would almost certainly fail the same way: auth rejections (an
-   *     expired or revoked credential does not heal by reconnecting with
-   *     itself), and our own operation timeout (the session is wedged, and
-   *     closing its transport is also what aborts the still-in-flight
-   *     request). Evict, don't retry.
+   *   - `'auth'` — the server rejected the credential. Evict without
+   *     retrying (a rejected credential does not heal by redialing with
+   *     itself), and drop any cached OAuth token so the NEXT call fetches a
+   *     fresh one instead of resending the rejected token until its local
+   *     TTL runs out.
+   *   - `'timeout'` — ours or the SDK's request-level timeout. The session
+   *     is wedged with the request possibly still in flight; evict without
+   *     retrying — closing the transport is also what aborts that request.
    *   - `null` — the error is about the OPERATION, not the session (a
    *     JSON-RPC tool error such as invalid params). The session is healthy;
    *     keep it.
    *
-   * The `'broken'` class is what issue #34 was about: an auth failure never
+   * The auth class is what issue #34 was about: an auth failure never
    * matched the old transient allowlist, so the dead transport stayed cached
    * forever and every reuse parked one more abort listener on its
    * transport-lifetime signal — unbounded listener growth on a session that
    * could never succeed again.
    */
-  private _classifySessionError(err: unknown): 'transient' | 'broken' | null {
+  private _classifySessionError(err: unknown): 'transient' | 'auth' | 'timeout' | null {
     const msg = String((err as any)?.message ?? err).toLowerCase();
+    // Auth-class rejections — checked FIRST: transports often wrap an auth
+    // failure in connection vocabulary ("connection closed: 401
+    // Unauthorized"), and letting the transient markers win would retry a
+    // credential that cannot succeed. Matched loosely on purpose: transports
+    // stringify these differently ("Error POSTing to endpoint (HTTP 401)",
+    // "SSE error: 403 Forbidden", plain "Unauthorized"). A false positive
+    // costs one eviction and redial; a false negative resurrects issue #34.
+    if (/\b(?:http[ _-]?)?40[13]\b|unauthorized|forbidden|authentication|authorization|invalid[ _-]?token/.test(msg)) {
+      return 'auth';
+    }
+    // Timeouts that leave the session suspect with the request possibly
+    // still in flight: our own race ("timed out after Ns") and the MCP SDK's
+    // request-level timeout (McpError -32001, "Request timed out") — the SDK
+    // race usually fires first since we forward the same budget to it.
+    // Neither pattern matches the network-level 'etimedout' (no space),
+    // which stays transient below.
+    if (msg.includes('timed out') || msg.includes('-32001')) {
+      return 'timeout';
+    }
     if (msg.includes('closed') || msg.includes('disconnected') ||
         msg.includes('econnreset') || msg.includes('etimedout') ||
         msg.includes('already initialized')) {
       return 'transient';
-    }
-    // Auth-class rejections. Matched loosely on purpose: transports stringify
-    // these differently ("Error POSTing to endpoint (HTTP 401)", "SSE error:
-    // 403 Forbidden", plain "Unauthorized"). A false positive costs one
-    // eviction and redial; a false negative resurrects issue #34.
-    if (/\b(?:http[ _-]?)?40[13]\b|unauthorized|forbidden|authentication|authorization|invalid[ _-]?token/.test(msg)) {
-      return 'broken';
-    }
-    // Our own race timeout (distinct from the network-level 'etimedout'
-    // above). The operation may still be in flight against the session.
-    if (msg.includes('timed out after')) {
-      return 'broken';
     }
     return null;
   }
@@ -352,8 +391,12 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
   ): Promise<T> {
     const sessionKey = `${serverName}:${serverConfig.transport}`;
     const timeoutMs = this._getTimeoutMs(serverConfig);
+    // Hoisted so the catch arms can hand the SPECIFIC client that failed to
+    // `_cleanupSession` — a key-only eviction would close whatever a
+    // concurrent caller has cached under the key by then.
+    let client: McpClient | undefined;
     try {
-      const client = await this._getOrCreateSession(serverName, serverConfig, auth);
+      client = await this._getOrCreateSession(serverName, serverConfig, auth);
       return await this._runWithTimeout(sessionKey, timeoutMs, client, operation);
     } catch (e: any) {
       this._logError(`MCP operation on '${sessionKey}' failed:`, e.message);
@@ -361,25 +404,36 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
       const classification = this._classifySessionError(e);
       if (classification === 'transient') {
         this._logInfo(`Connection/initialization error detected on '${sessionKey}'. Cleaning up and retrying once...`);
-        await this._cleanupSession(sessionKey);
+        // `client` undefined means session CREATION failed — nothing of ours
+        // was cached, and a key-only cleanup here could close a concurrent
+        // caller's healthy session. Same guard on the arms below.
+        if (client) await this._cleanupSession(sessionKey, client);
+        let newClient: McpClient | undefined;
         try {
-          const newClient = await this._getOrCreateSession(serverName, serverConfig, auth);
+          newClient = await this._getOrCreateSession(serverName, serverConfig, auth);
           return await this._runWithTimeout(sessionKey, timeoutMs, newClient, operation);
         } catch (retryErr: any) {
           // The fresh session can be just as dead as the one it replaced
           // (server still down, credential still bad). Whatever the retry
           // cached must not outlive a session-class failure — leaving it is
           // exactly the accumulation vector of issue #34.
-          if (this._classifySessionError(retryErr) !== null) {
+          const retryClassification = this._classifySessionError(retryErr);
+          if (retryClassification !== null) {
             this._logInfo(`Retry on '${sessionKey}' failed with a session-class error. Evicting the retry's session.`);
-            await this._cleanupSession(sessionKey);
+            if (newClient) await this._cleanupSession(sessionKey, newClient);
+          }
+          if (retryClassification === 'auth') {
+            this._invalidateOAuthToken(auth);
           }
           throw retryErr;
         }
       }
-      if (classification === 'broken') {
+      if (classification === 'auth' || classification === 'timeout') {
         this._logInfo(`Session-fatal error on '${sessionKey}' (auth failure or operation timeout). Evicting so the next call dials fresh instead of reusing a dead transport.`);
-        await this._cleanupSession(sessionKey);
+        if (client) await this._cleanupSession(sessionKey, client);
+        if (classification === 'auth') {
+          this._invalidateOAuthToken(auth);
+        }
       }
 
       throw e;

--- a/packages/mcp/src/mcp_communication_protocol.ts
+++ b/packages/mcp/src/mcp_communication_protocol.ts
@@ -105,8 +105,23 @@ function isMcpToolsResponse(data: unknown): data is { tools: McpToolResponse[] }
  */
 export class McpCommunicationProtocol implements CommunicationProtocol {
   private _oauthTokens: Map<string, { accessToken: string; expiresAt: number }> = new Map();
+  /**
+   * Per-client invalidation counter. A token fetch captures the generation
+   * when it starts and only caches its result if nothing invalidated the
+   * client in the meantime — otherwise an in-flight fetch that began before
+   * a 401 would repopulate the cache right after `_invalidateOAuthToken`
+   * cleared it.
+   */
+  private _oauthGenerations: Map<string, number> = new Map();
   private _axiosInstance: AxiosInstance;
   private _mcpSessions: Map<string, McpClient> = new Map();
+  /**
+   * Set at the start of `close()` and never cleared: the protocol is
+   * terminal once closed. Session creation checks it twice — before dialing
+   * and again after `connect()` resolves — so a call racing shutdown can
+   * neither start a new session nor land one that outlives `close()`.
+   */
+  private _closed = false;
 
   constructor() {
     this._axiosInstance = axios.create({ timeout: 30000 });
@@ -189,9 +204,17 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
   private _invalidateOAuthToken(auth: Auth | undefined): void {
     if (!auth || auth.auth_type === 'oauth2_user') return;
     const clientId = (auth as OAuth2Auth).client_id;
-    if (clientId && this._oauthTokens.delete(clientId)) {
+    if (!clientId) return;
+    // Bump the generation whether or not a token was cached: a fetch may be
+    // in flight right now, and it must not cache what it brings back.
+    this._oauthGenerations.set(clientId, this._oauthGeneration(clientId) + 1);
+    if (this._oauthTokens.delete(clientId)) {
       this._logInfo(`Dropped cached OAuth token for client '${clientId}' after an auth rejection.`);
     }
+  }
+
+  private _oauthGeneration(clientId: string): number {
+    return this._oauthGenerations.get(clientId) ?? 0;
   }
 
   private async _getOrCreateSession(
@@ -206,6 +229,13 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
       const existingSession = this._mcpSessions.get(sessionKey)!;
       this._logInfo(`Reusing existing MCP session for '${sessionKey}'.`);
       return existingSession;
+    }
+
+    // Worded without the transient markers ("closed", "disconnected") on
+    // purpose, so `_withSession` does not classify shutdown as a transport
+    // hiccup and spend a retry on it.
+    if (this._closed) {
+      throw new Error(`McpCommunicationProtocol has been shut down; refusing to create a session for '${sessionKey}'.`);
     }
 
     this._logInfo(`Creating new MCP session for '${sessionKey}'...`);
@@ -287,6 +317,13 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
     const mcpClient = new McpClient({ name: `utcp-mcp-client-${sessionKey}`, version: '1.0.1' });
     try {
       await mcpClient.connect(transport);
+      if (this._closed) {
+        // `close()` began while we were connecting. Its sweep snapshotted the
+        // cache before this session existed, so caching it now would leave a
+        // live transport behind after shutdown returned.
+        await mcpClient.close().catch(() => {});
+        throw new Error(`McpCommunicationProtocol was shut down while connecting '${sessionKey}'.`);
+      }
       this._mcpSessions.set(sessionKey, mcpClient);
     } catch (e: any) {
       // If connection fails, don't cache the broken client
@@ -554,6 +591,7 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
 
   public async close(): Promise<void> {
     this._logInfo("Closing all active MCP sessions.");
+    this._closed = true;
     const cleanupPromises = Array.from(this._mcpSessions.keys()).map(key => this._cleanupSession(key));
     await Promise.all(cleanupPromises);
     this._oauthTokens.clear();
@@ -598,8 +636,14 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
     }
 
     this._logInfo(`Fetching new OAuth2 token for client: '${clientId}'`);
+    const generation = this._oauthGeneration(clientId);
 
     try {
+      // Only the WINNER of the race caches — previously each variant wrote
+      // the cache on its own success, so the slower one landed later and
+      // overwrote whatever was there, including an invalidation that
+      // happened in between. And even the winner only caches if nothing
+      // invalidated this client while the fetch was in flight.
       const token = await Promise.any([
         (async () => {
           const bodyData = new URLSearchParams({
@@ -609,8 +653,7 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
           const response = await this._axiosInstance.post(authDetails.token_url, bodyData.toString(), { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } });
           if (!response.data.access_token) throw new Error("Access token not found in response.");
           const expiresAt = Date.now() + ((response.data.expires_in || 3600) * 1000);
-          this._oauthTokens.set(clientId, { accessToken: response.data.access_token, expiresAt });
-          return response.data.access_token;
+          return { accessToken: response.data.access_token as string, expiresAt };
         })(),
         (async () => {
           const bodyData = new URLSearchParams({ 'grant_type': 'client_credentials', 'scope': authDetails.scope || '' });
@@ -620,11 +663,15 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
           });
           if (!response.data.access_token) throw new Error("Access token not found in response.");
           const expiresAt = Date.now() + ((response.data.expires_in || 3600) * 1000);
-          this._oauthTokens.set(clientId, { accessToken: response.data.access_token, expiresAt });
-          return response.data.access_token;
+          return { accessToken: response.data.access_token as string, expiresAt };
         })()
       ]);
-      return token;
+      if (this._oauthGeneration(clientId) === generation) {
+        this._oauthTokens.set(clientId, token);
+      } else {
+        this._logInfo(`OAuth token for client '${clientId}' was invalidated while a fetch was in flight; not caching the stale result.`);
+      }
+      return token.accessToken;
     } catch (aggregateError: any) {
       const errorMessages = aggregateError.errors?.map((e: Error) => e.message).join('; ') || String(aggregateError);
       throw new Error(`Failed to fetch OAuth2 token for client '${clientId}': ${errorMessages}`);

--- a/packages/mcp/src/mcp_communication_protocol.ts
+++ b/packages/mcp/src/mcp_communication_protocol.ts
@@ -275,6 +275,75 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
     return (serverConfig.timeout ?? 30) * 1000;
   }
 
+  /**
+   * Classify an operation failure by what it says about the CACHED SESSION,
+   * which is the thing `_withSession` is responsible for. Three answers:
+   *
+   *   - `'transient'` — the transport broke in a way a fresh dial has a real
+   *     chance of fixing right now (connection dropped, reset, stale
+   *     handshake). Evict and retry once.
+   *   - `'broken'` — the session is dead weight, but an immediate redial
+   *     would almost certainly fail the same way: auth rejections (an
+   *     expired or revoked credential does not heal by reconnecting with
+   *     itself), and our own operation timeout (the session is wedged, and
+   *     closing its transport is also what aborts the still-in-flight
+   *     request). Evict, don't retry.
+   *   - `null` — the error is about the OPERATION, not the session (a
+   *     JSON-RPC tool error such as invalid params). The session is healthy;
+   *     keep it.
+   *
+   * The `'broken'` class is what issue #34 was about: an auth failure never
+   * matched the old transient allowlist, so the dead transport stayed cached
+   * forever and every reuse parked one more abort listener on its
+   * transport-lifetime signal — unbounded listener growth on a session that
+   * could never succeed again.
+   */
+  private _classifySessionError(err: unknown): 'transient' | 'broken' | null {
+    const msg = String((err as any)?.message ?? err).toLowerCase();
+    if (msg.includes('closed') || msg.includes('disconnected') ||
+        msg.includes('econnreset') || msg.includes('etimedout') ||
+        msg.includes('already initialized')) {
+      return 'transient';
+    }
+    // Auth-class rejections. Matched loosely on purpose: transports stringify
+    // these differently ("Error POSTing to endpoint (HTTP 401)", "SSE error:
+    // 403 Forbidden", plain "Unauthorized"). A false positive costs one
+    // eviction and redial; a false negative resurrects issue #34.
+    if (/\b(?:http[ _-]?)?40[13]\b|unauthorized|forbidden|authentication|authorization|invalid[ _-]?token/.test(msg)) {
+      return 'broken';
+    }
+    // Our own race timeout (distinct from the network-level 'etimedout'
+    // above). The operation may still be in flight against the session.
+    if (msg.includes('timed out after')) {
+      return 'broken';
+    }
+    return null;
+  }
+
+  /**
+   * Run `operation` bounded by the session's timeout. The timer is cleared
+   * whichever side wins — the old inline race left a live timer behind for
+   * the full timeout window on every successful call.
+   */
+  private async _runWithTimeout<T>(
+    sessionKey: string,
+    timeoutMs: number,
+    client: McpClient,
+    operation: (client: McpClient) => Promise<T>
+  ): Promise<T> {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      return await Promise.race([
+        operation(client),
+        new Promise<T>((_, reject) => {
+          timer = setTimeout(() => reject(new Error(`MCP operation on '${sessionKey}' timed out after ${timeoutMs / 1000}s.`)), timeoutMs);
+        })
+      ]);
+    } finally {
+      if (timer !== undefined) clearTimeout(timer);
+    }
+  }
+
   private async _withSession<T>(
     serverName: string,
     serverConfig: McpServerConfig,
@@ -285,22 +354,32 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
     const timeoutMs = this._getTimeoutMs(serverConfig);
     try {
       const client = await this._getOrCreateSession(serverName, serverConfig, auth);
-      return await Promise.race([
-        operation(client),
-        new Promise<T>((_, reject) => setTimeout(() => reject(new Error(`MCP operation on '${sessionKey}' timed out after ${timeoutMs / 1000}s.`)), timeoutMs))
-      ]);
+      return await this._runWithTimeout(sessionKey, timeoutMs, client, operation);
     } catch (e: any) {
       this._logError(`MCP operation on '${sessionKey}' failed:`, e.message);
 
-      const errorMsg = String((e as any)?.message ?? e).toLowerCase();
-      // Check for connection errors or "already initialized" errors
-      if (errorMsg.includes('closed') || errorMsg.includes('disconnected') ||
-          errorMsg.includes('econnreset') || errorMsg.includes('etimedout') ||
-          errorMsg.includes('already initialized')) {
+      const classification = this._classifySessionError(e);
+      if (classification === 'transient') {
         this._logInfo(`Connection/initialization error detected on '${sessionKey}'. Cleaning up and retrying once...`);
         await this._cleanupSession(sessionKey);
-        const newClient = await this._getOrCreateSession(serverName, serverConfig, auth);
-        return await Promise.race([operation(newClient), new Promise<T>((_, reject) => setTimeout(() => reject(new Error(`MCP operation on '${sessionKey}' timed out after ${timeoutMs / 1000}s.`)), timeoutMs))]);
+        try {
+          const newClient = await this._getOrCreateSession(serverName, serverConfig, auth);
+          return await this._runWithTimeout(sessionKey, timeoutMs, newClient, operation);
+        } catch (retryErr: any) {
+          // The fresh session can be just as dead as the one it replaced
+          // (server still down, credential still bad). Whatever the retry
+          // cached must not outlive a session-class failure — leaving it is
+          // exactly the accumulation vector of issue #34.
+          if (this._classifySessionError(retryErr) !== null) {
+            this._logInfo(`Retry on '${sessionKey}' failed with a session-class error. Evicting the retry's session.`);
+            await this._cleanupSession(sessionKey);
+          }
+          throw retryErr;
+        }
+      }
+      if (classification === 'broken') {
+        this._logInfo(`Session-fatal error on '${sessionKey}' (auth failure or operation timeout). Evicting so the next call dials fresh instead of reusing a dead transport.`);
+        await this._cleanupSession(sessionKey);
       }
 
       throw e;

--- a/packages/mcp/tests/mcp_communication_protocol.test.ts
+++ b/packages/mcp/tests/mcp_communication_protocol.test.ts
@@ -381,6 +381,66 @@ describe("McpCommunicationProtocol", () => {
       expect(client.closed).toBe(1);
       expect((protocol as any)._mcpSessions.has(KEY)).toBe(false);
     });
+
+    test("an auth failure dressed in connection vocabulary is not retried", async () => {
+      // Transports wrap auth rejections in transport language ("connection
+      // closed: 401") — the transient markers must not outrank the auth
+      // markers, or the dead credential gets a pointless immediate retry.
+      const protocol = new McpCommunicationProtocol();
+      let calls = 0;
+      const client = seed(protocol, () => {
+        calls += 1;
+        return Promise.reject(new Error("Connection closed: 401 Unauthorized"));
+      });
+
+      await expect(run(protocol, client)).rejects.toThrow("401");
+      expect(calls).toBe(1); // no retry
+      expect(client.closed).toBe(1);
+      expect((protocol as any)._mcpSessions.has(KEY)).toBe(false);
+    });
+
+    test("the SDK's request-level timeout (-32001) evicts the wedged session", async () => {
+      // We forward the same budget to the SDK, so its race usually fires
+      // before ours — its error must classify the same way ours does.
+      const protocol = new McpCommunicationProtocol();
+      const client = seed(protocol, () =>
+        Promise.reject(new Error("MCP error -32001: Request timed out")));
+
+      await expect(run(protocol, client)).rejects.toThrow("-32001");
+      expect(client.closed).toBe(1);
+      expect((protocol as any)._mcpSessions.has(KEY)).toBe(false);
+    });
+
+    test("eviction closes the session that failed, never a concurrent caller's replacement", async () => {
+      const protocol = new McpCommunicationProtocol();
+      const replacement = { closed: 0, close() { this.closed += 1; return Promise.resolve(); } };
+      const client = seed(protocol, () => {
+        // A concurrent caller replaced the cached session before our catch ran.
+        (protocol as any)._mcpSessions.set(KEY, replacement);
+        return Promise.reject(new Error("HTTP 401 Unauthorized"));
+      });
+
+      await expect(run(protocol, client)).rejects.toThrow("401");
+      expect(client.closed).toBe(1); // the failed session is closed
+      expect(replacement.closed).toBe(0); // the replacement is untouched
+      expect((protocol as any)._mcpSessions.get(KEY)).toBe(replacement); // and stays cached
+    });
+
+    test("an auth failure drops the cached OAuth token so the next dial fetches fresh", async () => {
+      // The token cache trusts expires_in, but a token can be revoked before
+      // its local expiry — evicting only the session would resend the same
+      // rejected token on every redial until the TTL ran out.
+      const protocol = new McpCommunicationProtocol();
+      (protocol as any)._oauthTokens.set("cid", { accessToken: "revoked", expiresAt: Date.now() + 3600_000 });
+      const auth = { auth_type: "oauth2", client_id: "cid", client_secret: "s", token_url: "https://x/token" };
+      const client = seed(protocol, () =>
+        Promise.reject(new Error("HTTP 401 Unauthorized")));
+
+      await expect(
+        (protocol as any)._withSession("s", CONFIG, auth, () => client.op())
+      ).rejects.toThrow("401");
+      expect((protocol as any)._oauthTokens.has("cid")).toBe(false);
+    });
   });
 
   describe("Timeout forwarding", () => {

--- a/packages/mcp/tests/mcp_communication_protocol.test.ts
+++ b/packages/mcp/tests/mcp_communication_protocol.test.ts
@@ -5,6 +5,7 @@ import path from "path";
 import { McpCommunicationProtocol, McpCallTemplate } from "../src/index";
 import { McpHttpServerSchema } from "../src/mcp_call_template";
 import { IUtcpClient } from "@utcp/sdk";
+import { Client as McpSdkClient } from "@modelcontextprotocol/sdk/client/index.js";
 
 const HTTP_PORT = 9999;
 let stdioServerProcess: Subprocess | null = null;
@@ -260,6 +261,7 @@ describe("McpCommunicationProtocol", () => {
       expect(result).toBe(25);
     }, 10000);
     
+
     test("should throw an error if tool name is not namespaced correctly", async () => {
         await expect(
             protocol.callTool(mockClient, "nonexistent_tool", {}, callTemplate)
@@ -440,6 +442,81 @@ describe("McpCommunicationProtocol", () => {
         (protocol as any)._withSession("s", CONFIG, auth, () => client.op())
       ).rejects.toThrow("401");
       expect((protocol as any)._oauthTokens.has("cid")).toBe(false);
+    });
+
+    test("a slower token-fetch variant cannot repopulate the cache after invalidation", async () => {
+      // _handleOAuth2 races two request shapes with Promise.any. Each used to
+      // write the cache on its own success, so the loser landed later and
+      // overwrote whatever was there — including an invalidation.
+      const protocol = new McpCommunicationProtocol();
+      let resolveSlow!: (v: any) => void;
+      const slow = new Promise<any>((res) => { resolveSlow = res; });
+      let n = 0;
+      (protocol as any)._axiosInstance = {
+        post: () => (++n === 1
+          ? Promise.resolve({ data: { access_token: "fast", expires_in: 3600 } })
+          : slow),
+      };
+      const auth = { auth_type: "oauth2", client_id: "cid", client_secret: "s", token_url: "https://x/token" };
+
+      await expect((protocol as any)._handleOAuth2(auth)).resolves.toBe("fast");
+      expect((protocol as any)._oauthTokens.get("cid")?.accessToken).toBe("fast");
+
+      (protocol as any)._invalidateOAuthToken(auth);
+      resolveSlow({ data: { access_token: "slow", expires_in: 3600 } });
+      await slow;
+      await new Promise((r) => setTimeout(r, 0));
+      expect((protocol as any)._oauthTokens.has("cid")).toBe(false);
+    });
+
+    test("a fetch already in flight when the token is invalidated does not cache its result", async () => {
+      const protocol = new McpCommunicationProtocol();
+      let resolveFetch!: (v: any) => void;
+      const pending = new Promise<any>((res) => { resolveFetch = res; });
+      (protocol as any)._axiosInstance = { post: () => pending };
+      const auth = { auth_type: "oauth2", client_id: "cid", client_secret: "s", token_url: "https://x/token" };
+
+      const fetching = (protocol as any)._handleOAuth2(auth);
+      (protocol as any)._invalidateOAuthToken(auth); // lands mid-flight
+      resolveFetch({ data: { access_token: "stale", expires_in: 3600 } });
+
+      // The in-flight attempt still gets its token — only the CACHE is guarded.
+      await expect(fetching).resolves.toBe("stale");
+      expect((protocol as any)._oauthTokens.has("cid")).toBe(false);
+    });
+
+    test("a session whose connect resolves after close() began is closed, not cached", async () => {
+      // close() snapshots the cache before an in-flight connect has landed.
+      // Without the post-connect check that session would be cached AFTER
+      // the sweep and outlive shutdown with a live transport. The SDK
+      // client's connect is held open with a deferred so the window is
+      // deterministic (and no real server is dialed).
+      const originalConnect = McpSdkClient.prototype.connect;
+      let releaseConnect!: () => void;
+      const connectGate = new Promise<void>((res) => { releaseConnect = res; });
+      let closedClients = 0;
+      const originalClose = McpSdkClient.prototype.close;
+      McpSdkClient.prototype.connect = function () { return connectGate; } as any;
+      McpSdkClient.prototype.close = async function () { closedClients += 1; } as any;
+      try {
+        const protocol = new McpCommunicationProtocol();
+        const creating = (protocol as any)._getOrCreateSession("late", CONFIG);
+        await protocol.close(); // begins while connect is in flight
+        releaseConnect();
+        await expect(creating).rejects.toThrow("shut down");
+        expect(closedClients).toBe(1); // the late session was closed, not leaked
+        expect((protocol as any)._mcpSessions.size).toBe(0);
+      } finally {
+        McpSdkClient.prototype.connect = originalConnect;
+        McpSdkClient.prototype.close = originalClose;
+      }
+    });
+
+    test("refuses to create a session after close()", async () => {
+      const protocol = new McpCommunicationProtocol();
+      await protocol.close();
+      await expect((protocol as any)._getOrCreateSession("s", CONFIG)).rejects.toThrow("shut down");
+      expect((protocol as any)._mcpSessions.size).toBe(0);
     });
   });
 

--- a/packages/mcp/tests/mcp_communication_protocol.test.ts
+++ b/packages/mcp/tests/mcp_communication_protocol.test.ts
@@ -295,6 +295,94 @@ describe("McpCommunicationProtocol", () => {
     }, 10000);
   });
 
+  describe("Session eviction on session-class failures (issue #34)", () => {
+    const CONFIG = { transport: "stdio" as const, command: "true", timeout: 60 };
+    const KEY = "s:stdio";
+
+    /** A fake cached session whose close() we can observe, wired into the
+     * protocol's private session map the way _getOrCreateSession would. */
+    function seed(protocol: McpCommunicationProtocol, behavior: (calls: number) => Promise<any>) {
+      let calls = 0;
+      const client = {
+        closed: 0,
+        close() { this.closed += 1; return Promise.resolve(); },
+        op: () => behavior((calls += 1)),
+      };
+      (protocol as any)._mcpSessions.set(KEY, client);
+      (protocol as any)._getOrCreateSession = () => {
+        (protocol as any)._mcpSessions.set(KEY, client);
+        return Promise.resolve(client);
+      };
+      return client;
+    }
+
+    function run(protocol: McpCommunicationProtocol, client: any) {
+      return (protocol as any)._withSession("s", CONFIG, undefined, () => client.op());
+    }
+
+    test("an auth failure evicts the dead session instead of caching it forever", async () => {
+      // The heart of #34: a 401 never matched the transient allowlist, so the
+      // dead transport was reused (and accumulated abort listeners) on every
+      // subsequent call, forever.
+      const protocol = new McpCommunicationProtocol();
+      const client = seed(protocol, () =>
+        Promise.reject(new Error("Error POSTing to endpoint (HTTP 401): Unauthorized")));
+
+      await expect(run(protocol, client)).rejects.toThrow("401");
+      expect(client.closed).toBe(1);
+      expect((protocol as any)._mcpSessions.has(KEY)).toBe(false);
+    });
+
+    test("a tool-level JSON-RPC error keeps the healthy session cached", async () => {
+      // Evicting on every error would tear down and re-dial per bad tool
+      // call — the session is fine, the arguments were not.
+      const protocol = new McpCommunicationProtocol();
+      const client = seed(protocol, () =>
+        Promise.reject(new Error("MCP error -32602: Invalid params")));
+
+      await expect(run(protocol, client)).rejects.toThrow("-32602");
+      expect(client.closed).toBe(0);
+      expect((protocol as any)._mcpSessions.get(KEY)).toBe(client);
+    });
+
+    test("a transient connection error still evicts and retries once", async () => {
+      const protocol = new McpCommunicationProtocol();
+      const client = seed(protocol, (calls) =>
+        calls === 1 ? Promise.reject(new Error("Connection closed")) : Promise.resolve("ok"));
+
+      await expect(run(protocol, client)).resolves.toBe("ok");
+      expect(client.closed).toBe(1); // the broken first session was closed
+    });
+
+    test("a retry that fails with a session-class error does not leave its session cached", async () => {
+      // Server is down for good: first attempt transient, retry hits auth.
+      // Pre-fix the retry path had no catch at all, so its dead session
+      // stayed cached — the same accumulation #34 reported, one hop later.
+      const protocol = new McpCommunicationProtocol();
+      const client = seed(protocol, (calls) =>
+        Promise.reject(calls === 1 ? new Error("Connection closed") : new Error("403 Forbidden")));
+
+      await expect(run(protocol, client)).rejects.toThrow("403");
+      expect(client.closed).toBe(2);
+      expect((protocol as any)._mcpSessions.has(KEY)).toBe(false);
+    });
+
+    test("an operation timeout evicts the wedged session", async () => {
+      // Closing the transport is also what aborts the still-in-flight
+      // request, releasing its abort listener — the raced timeout branch
+      // #34 asked to see released.
+      const protocol = new McpCommunicationProtocol();
+      const client = seed(protocol, () => new Promise(() => {}));
+      const config = { ...CONFIG, timeout: 1 }; // 1s
+
+      await expect(
+        (protocol as any)._withSession("s", config, undefined, () => client.op())
+      ).rejects.toThrow("timed out");
+      expect(client.closed).toBe(1);
+      expect((protocol as any)._mcpSessions.has(KEY)).toBe(false);
+    });
+  });
+
   describe("Timeout forwarding", () => {
     test("forwards configured timeout to listTools and callTool", async () => {
       const capturedOpts: any[] = [];


### PR DESCRIPTION
Fixes #34.

## Problem

`_withSession` only evicted the cached session for a substring allowlist of connection errors (`closed` / `disconnected` / `econnreset` / `etimedout` / `already initialized`). An auth rejection (HTTP 401/403) matched nothing, so the dead transport stayed cached indefinitely: every subsequent call reused it, failed again, and parked one more abort listener on the transport-lifetime `AbortSignal` — 1,779 of them in the report, growing without bound in a long-running server (`MaxListenersExceededWarning`).

## Fix

Failures are now classified by what they say about the **session** (`_classifySessionError`):

- **transient** (the old allowlist): evict + retry once, as before — but the retry is no longer bare: a retry that fails with a session-class error evicts the session it cached instead of leaving a second corpse behind.
- **broken** (auth-class rejections, and our own operation timeout): evict without retrying — an expired credential does not heal by redialing with itself, and closing a wedged session's transport is also what aborts its still-in-flight request (releasing that request's abort listener — the raced-branch resource the issue asked to see released).
- **operation-level** (JSON-RPC tool errors like invalid params): the session is healthy; keep it. Evicting on every error would tear down + re-dial per bad tool call.

Auth detection is deliberately loose (`http 401`/`403`/`unauthorized`/`forbidden`/`authentication`/`invalid token`, case-insensitive) because transports stringify these differently — a false positive costs one redial, a false negative resurrects the leak.

Also: the raced timeout timer is now cleared whichever side wins (`_runWithTimeout`); it used to stay live for the full timeout window after every successful call.

On the issue's third suggestion (short-TTL failure memoization): that's a policy call for the embedding application — with this change the library guarantees no dead session outlives the call that discovered it, which is the invariant memoization was compensating for.

## Tests

18/18 pass (13 existing + 5 new). Three of the new tests verified to fail against the previous source: auth-failure eviction, retry-session eviction, and timeout eviction. The other two pin existing behavior (tool-level errors keep the session; transient errors still retry once).

🤖 Generated with [Claude Code](https://claude.com/claude-code)