### PR TITLE
mcp: close() drains instead of bricking the shared registry instance

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@utcp/mcp",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Model Context Protocol integration for UTCP",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/packages/mcp/src/mcp_communication_protocol.ts
+++ b/packages/mcp/src/mcp_communication_protocol.ts
@@ -1,7 +1,8 @@
 // packages/mcp/src/mcp_communication_protocol.ts
 import { Client as McpClient } from '@modelcontextprotocol/sdk/client/index.js';
+import { McpError } from '@modelcontextprotocol/sdk/types.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
-import { StreamableHTTPClientTransport, StreamableHTTPClientTransportOptions } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { StreamableHTTPClientTransport, StreamableHTTPClientTransportOptions, StreamableHTTPError } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import axios, { AxiosInstance } from 'axios';
 import { CommunicationProtocol } from '@utcp/sdk';
 import { RegisterManualResult } from '@utcp/sdk';
@@ -116,12 +117,23 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
   private _axiosInstance: AxiosInstance;
   private _mcpSessions: Map<string, McpClient> = new Map();
   /**
-   * Set at the start of `close()` and never cleared: the protocol is
-   * terminal once closed. Session creation checks it twice — before dialing
-   * and again after `connect()` resolves — so a call racing shutdown can
-   * neither start a new session nor land one that outlives `close()`.
+   * `close()` is a DRAIN, not a terminal state. This instance is registered
+   * once at module load (`index.ts`) into the process-wide
+   * `CommunicationProtocol.communicationProtocols` registry, and EVERY
+   * `UtcpClient` shares it — `UtcpClient.close()` closes the registered
+   * protocols, so one client closing must not brick MCP for every other
+   * client in the process (which is exactly what a sticky closed flag did).
+   *
+   * `_closing` is true only while a close's sweep runs — session creation
+   * refuses during that window. `_closeGeneration` increments at each
+   * close: creation captures it on entry and re-checks it before dialing
+   * (a close can land during the OAuth token fetch) and again after
+   * `connect()` resolves (the sweep snapshots the cache before an in-flight
+   * connect has landed, so a session caching itself afterwards would
+   * otherwise outlive the close with a live transport).
    */
-  private _closed = false;
+  private _closing = false;
+  private _closeGeneration = 0;
 
   constructor() {
     this._axiosInstance = axios.create({ timeout: 30000 });
@@ -234,9 +246,10 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
     // Worded without the transient markers ("closed", "disconnected") on
     // purpose, so `_withSession` does not classify shutdown as a transport
     // hiccup and spend a retry on it.
-    if (this._closed) {
-      throw new Error(`McpCommunicationProtocol has been shut down; refusing to create a session for '${sessionKey}'.`);
+    if (this._closing) {
+      throw new Error(`McpCommunicationProtocol is shutting down; refusing to create a session for '${sessionKey}'.`);
     }
+    const closeGenerationAtStart = this._closeGeneration;
 
     this._logInfo(`Creating new MCP session for '${sessionKey}'...`);
     let transport: Transport;
@@ -314,13 +327,19 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
       throw new Error(`Unsupported MCP transport: '${(serverConfig as any).transport}'`);
     }
 
+    // A close() that began during the async work above (the OAuth token
+    // fetch is an await) must abort BEFORE a connection is dialed at all.
+    if (this._closing || this._closeGeneration !== closeGenerationAtStart) {
+      throw new Error(`McpCommunicationProtocol was shut down while connecting '${sessionKey}'.`);
+    }
+
     const mcpClient = new McpClient({ name: `utcp-mcp-client-${sessionKey}`, version: '1.0.1' });
     try {
       await mcpClient.connect(transport);
-      if (this._closed) {
-        // `close()` began while we were connecting. Its sweep snapshotted the
-        // cache before this session existed, so caching it now would leave a
-        // live transport behind after shutdown returned.
+      if (this._closing || this._closeGeneration !== closeGenerationAtStart) {
+        // A close() intervened while we were connecting. Its sweep
+        // snapshotted the cache before this session existed, so caching it
+        // now would leave a live transport behind after that close returned.
         await mcpClient.close().catch(() => {});
         throw new Error(`McpCommunicationProtocol was shut down while connecting '${sessionKey}'.`);
       }
@@ -368,6 +387,22 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
    * could never succeed again.
    */
   private _classifySessionError(err: unknown): 'transient' | 'auth' | 'timeout' | null {
+    // Structured metadata first; the message heuristics below are the
+    // fallback for errors that arrive wrapped or stringified (and for SDK
+    // copies that fail an instanceof across duplicated installs).
+    if (err instanceof McpError) {
+      // A JSON-RPC-level error means the session DELIVERED a well-formed
+      // response — the transport is alive, whatever the error text says.
+      // Without this gate, a tool error that merely mentions authorization
+      // ("Authorization header missing for downstream API") would evict a
+      // healthy session and throw away a valid OAuth token. The single
+      // exception is the SDK's own request-timeout code: the request never
+      // completed and the session is suspect.
+      return err.code === -32001 ? 'timeout' : null;
+    }
+    if (err instanceof StreamableHTTPError && (err.code === 401 || err.code === 403)) {
+      return 'auth';
+    }
     const msg = String((err as any)?.message ?? err).toLowerCase();
     // Auth-class rejections — checked FIRST: transports often wrap an auth
     // failure in connection vocabulary ("connection closed: 401
@@ -591,11 +626,19 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
 
   public async close(): Promise<void> {
     this._logInfo("Closing all active MCP sessions.");
-    this._closed = true;
-    const cleanupPromises = Array.from(this._mcpSessions.keys()).map(key => this._cleanupSession(key));
-    await Promise.all(cleanupPromises);
-    this._oauthTokens.clear();
-    this._logInfo("MCP Communication Protocol closed and all resources cleaned up.");
+    this._closing = true;
+    this._closeGeneration += 1;
+    try {
+      const cleanupPromises = Array.from(this._mcpSessions.keys()).map(key => this._cleanupSession(key));
+      await Promise.all(cleanupPromises);
+      this._oauthTokens.clear();
+    } finally {
+      // Drain complete — the shared registry instance stays usable. This
+      // instance serves every UtcpClient in the process (see the field
+      // docs), so staying closed would take MCP away from all of them.
+      this._closing = false;
+    }
+    this._logInfo("MCP Communication Protocol drained all sessions and cleaned up.");
   }
   
   private _processMcpToolResult(result: any): any {

--- a/packages/mcp/src/mcp_communication_protocol.ts
+++ b/packages/mcp/src/mcp_communication_protocol.ts
@@ -409,7 +409,20 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
       // that gate, a tool error that merely mentions authorization
       // ("Authorization header missing for downstream API") would evict a
       // healthy session and throw away a valid OAuth token.
-      if (err.code === ErrorCode.ConnectionClosed) return 'transient';
+      //
+      // -32000 needs one more discriminator: JSON-RPC reserves the
+      // -32000..-32099 band for SERVER-defined errors, so a server can
+      // legitimately answer a tool call with -32000 — and that response
+      // arrives through a perfectly healthy session. The SDK's client-side
+      // ConnectionClosed is always constructed with the fixed text
+      // "Connection closed" (shared/protocol.js), while a server-relayed
+      // error carries the server's own message — so require both. A server
+      // that echoes the reserved code AND that exact phrase costs one
+      // spurious evict-and-retry; accepted, since the alternative (bare
+      // code) mis-evicts on every server-defined -32000.
+      if (err.code === ErrorCode.ConnectionClosed && /\bconnection closed\b/i.test(err.message)) {
+        return 'transient';
+      }
       if (err.code === ErrorCode.RequestTimeout) return 'timeout';
       return null;
     }

--- a/packages/mcp/src/mcp_communication_protocol.ts
+++ b/packages/mcp/src/mcp_communication_protocol.ts
@@ -1,6 +1,6 @@
 // packages/mcp/src/mcp_communication_protocol.ts
 import { Client as McpClient } from '@modelcontextprotocol/sdk/client/index.js';
-import { McpError } from '@modelcontextprotocol/sdk/types.js';
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { StreamableHTTPClientTransport, StreamableHTTPClientTransportOptions, StreamableHTTPError } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import axios, { AxiosInstance } from 'axios';
@@ -124,15 +124,21 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
    * protocols, so one client closing must not brick MCP for every other
    * client in the process (which is exactly what a sticky closed flag did).
    *
-   * `_closing` is true only while a close's sweep runs — session creation
-   * refuses during that window. `_closeGeneration` increments at each
+   * `_activeDrains` counts close() sweeps currently running — session
+   * creation refuses while ANY is in flight. A counter, not a boolean:
+   * two overlapping close() calls each clear a boolean on their own way
+   * out, so the faster one (a second close sees an already-emptied cache
+   * and finishes immediately) would reopen the gate while the first sweep
+   * is still awaiting a transport's close() — letting a new session dial
+   * and cache itself inside that outstanding close, which then returns
+   * with live resources behind it. `_closeGeneration` increments at each
    * close: creation captures it on entry and re-checks it before dialing
    * (a close can land during the OAuth token fetch) and again after
-   * `connect()` resolves (the sweep snapshots the cache before an in-flight
-   * connect has landed, so a session caching itself afterwards would
-   * otherwise outlive the close with a live transport).
+   * `connect()` resolves (the sweep snapshots the cache before an
+   * in-flight connect has landed, so a session caching itself afterwards
+   * would otherwise outlive the close with a live transport).
    */
-  private _closing = false;
+  private _activeDrains = 0;
   private _closeGeneration = 0;
 
   constructor() {
@@ -246,7 +252,7 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
     // Worded without the transient markers ("closed", "disconnected") on
     // purpose, so `_withSession` does not classify shutdown as a transport
     // hiccup and spend a retry on it.
-    if (this._closing) {
+    if (this._activeDrains > 0) {
       throw new Error(`McpCommunicationProtocol is shutting down; refusing to create a session for '${sessionKey}'.`);
     }
     const closeGenerationAtStart = this._closeGeneration;
@@ -329,14 +335,14 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
 
     // A close() that began during the async work above (the OAuth token
     // fetch is an await) must abort BEFORE a connection is dialed at all.
-    if (this._closing || this._closeGeneration !== closeGenerationAtStart) {
+    if (this._activeDrains > 0 || this._closeGeneration !== closeGenerationAtStart) {
       throw new Error(`McpCommunicationProtocol was shut down while connecting '${sessionKey}'.`);
     }
 
     const mcpClient = new McpClient({ name: `utcp-mcp-client-${sessionKey}`, version: '1.0.1' });
     try {
       await mcpClient.connect(transport);
-      if (this._closing || this._closeGeneration !== closeGenerationAtStart) {
+      if (this._activeDrains > 0 || this._closeGeneration !== closeGenerationAtStart) {
         // A close() intervened while we were connecting. Its sweep
         // snapshotted the cache before this session existed, so caching it
         // now would leave a live transport behind after that close returned.
@@ -391,14 +397,21 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
     // fallback for errors that arrive wrapped or stringified (and for SDK
     // copies that fail an instanceof across duplicated installs).
     if (err instanceof McpError) {
-      // A JSON-RPC-level error means the session DELIVERED a well-formed
-      // response — the transport is alive, whatever the error text says.
-      // Without this gate, a tool error that merely mentions authorization
+      // Two of the SDK's codes are raised CLIENT-side and describe the
+      // transport, not a server response:
+      //   - ConnectionClosed (-32000): the session dropped mid-request — the
+      //     same condition the "closed" substring used to classify, so it
+      //     stays transient (evict + one retry against a fresh dial).
+      //   - RequestTimeout (-32001): the request never completed; the
+      //     session is suspect, evict without retry.
+      // Every OTHER McpError is a well-formed JSON-RPC response from a live
+      // session — the transport works, whatever the error text says. Without
+      // that gate, a tool error that merely mentions authorization
       // ("Authorization header missing for downstream API") would evict a
-      // healthy session and throw away a valid OAuth token. The single
-      // exception is the SDK's own request-timeout code: the request never
-      // completed and the session is suspect.
-      return err.code === -32001 ? 'timeout' : null;
+      // healthy session and throw away a valid OAuth token.
+      if (err.code === ErrorCode.ConnectionClosed) return 'transient';
+      if (err.code === ErrorCode.RequestTimeout) return 'timeout';
+      return null;
     }
     if (err instanceof StreamableHTTPError && (err.code === 401 || err.code === 403)) {
       return 'auth';
@@ -626,7 +639,7 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
 
   public async close(): Promise<void> {
     this._logInfo("Closing all active MCP sessions.");
-    this._closing = true;
+    this._activeDrains += 1;
     this._closeGeneration += 1;
     try {
       const cleanupPromises = Array.from(this._mcpSessions.keys()).map(key => this._cleanupSession(key));
@@ -636,7 +649,10 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
       // Drain complete — the shared registry instance stays usable. This
       // instance serves every UtcpClient in the process (see the field
       // docs), so staying closed would take MCP away from all of them.
-      this._closing = false;
+      // Decrement, not reset: an overlapping close() that finished faster
+      // must not reopen the gate while this sweep is still closing
+      // transports.
+      this._activeDrains -= 1;
     }
     this._logInfo("MCP Communication Protocol drained all sessions and cleaned up.");
   }

--- a/packages/mcp/tests/mcp_communication_protocol.test.ts
+++ b/packages/mcp/tests/mcp_communication_protocol.test.ts
@@ -616,6 +616,26 @@ describe("McpCommunicationProtocol", () => {
       expect(client.closed).toBe(1); // the dropped session was evicted
     });
 
+    test("a SERVER-defined -32000 tool error keeps the healthy session — no eviction, no retry", async () => {
+      // JSON-RPC reserves -32000..-32099 for implementation-defined SERVER
+      // errors, so -32000 in a tool response is legal and arrives through a
+      // live session. Only the SDK's client-side ConnectionClosed (fixed
+      // message "Connection closed") means the transport dropped; a bare
+      // code check would evict a healthy session and burn a retry on every
+      // such call.
+      const protocol = new McpCommunicationProtocol();
+      let calls = 0;
+      const client = seed(protocol, () => {
+        calls += 1;
+        return Promise.reject(new McpError(-32000, "insufficient credits for this tool"));
+      });
+
+      await expect(run(protocol, client)).rejects.toThrow("insufficient credits");
+      expect(calls).toBe(1); // no retry
+      expect(client.closed).toBe(0);
+      expect((protocol as any)._mcpSessions.get(KEY)).toBe(client);
+    });
+
     test("overlapping close() calls keep the gate shut until the slowest sweep finishes", async () => {
       // A boolean gate is cleared by whichever close() finishes first — and a
       // second close() finds an already-emptied cache and finishes

--- a/packages/mcp/tests/mcp_communication_protocol.test.ts
+++ b/packages/mcp/tests/mcp_communication_protocol.test.ts
@@ -6,6 +6,8 @@ import { McpCommunicationProtocol, McpCallTemplate } from "../src/index";
 import { McpHttpServerSchema } from "../src/mcp_call_template";
 import { IUtcpClient } from "@utcp/sdk";
 import { Client as McpSdkClient } from "@modelcontextprotocol/sdk/client/index.js";
+import { McpError } from "@modelcontextprotocol/sdk/types.js";
+import { StreamableHTTPError } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 
 const HTTP_PORT = 9999;
 let stdioServerProcess: Subprocess | null = null;
@@ -512,11 +514,96 @@ describe("McpCommunicationProtocol", () => {
       }
     });
 
-    test("refuses to create a session after close()", async () => {
+    test("close() drains sessions but the shared registry instance stays usable", async () => {
+      // index.ts registers ONE McpCommunicationProtocol into the process-wide
+      // registry, shared by every UtcpClient — and UtcpClient.close() closes
+      // the registered protocols. A terminal close therefore bricked MCP for
+      // every other client in the process the moment any one client closed.
+      const originalConnect = McpSdkClient.prototype.connect;
+      McpSdkClient.prototype.connect = function () { return Promise.resolve(); } as any;
+      try {
+        const protocol = new McpCommunicationProtocol();
+        const live = { closed: 0, close() { this.closed += 1; return Promise.resolve(); } };
+        (protocol as any)._mcpSessions.set(KEY, live);
+
+        await protocol.close();
+        expect(live.closed).toBe(1); // the drain really drained
+        expect((protocol as any)._mcpSessions.size).toBe(0);
+
+        // A NEW client's session creation must succeed after the drain.
+        const created = await (protocol as any)._getOrCreateSession("s", CONFIG);
+        expect(created).toBeDefined();
+        expect((protocol as any)._mcpSessions.size).toBe(1);
+      } finally {
+        McpSdkClient.prototype.connect = originalConnect;
+      }
+    });
+
+    test("a close() landing during the OAuth token fetch aborts before dialing", async () => {
+      // The pre-dial \_closing check runs before the token fetch, which is an
+      // await — a close() arriving inside it used to let the code dial a
+      // brand-new connection after close() had already returned.
+      const originalConnect = McpSdkClient.prototype.connect;
+      let connectCalls = 0;
+      McpSdkClient.prototype.connect = function () { connectCalls += 1; return Promise.resolve(); } as any;
+      try {
+        const protocol = new McpCommunicationProtocol();
+        let releaseToken!: (v: any) => void;
+        (protocol as any)._axiosInstance = {
+          post: () => new Promise((res) => { releaseToken = res; }),
+        };
+        const cfg = { transport: "http" as const, url: "https://example.com/mcp" };
+        const auth = { auth_type: "oauth2", client_id: "cid", client_secret: "s", token_url: "https://example.com/token" };
+
+        const creating = (protocol as any)._getOrCreateSession("late", cfg, auth);
+        await protocol.close(); // lands mid-token-fetch
+        releaseToken({ data: { access_token: "tok", expires_in: 3600 } });
+
+        await expect(creating).rejects.toThrow("shut down");
+        expect(connectCalls).toBe(0); // never dialed
+        expect((protocol as any)._mcpSessions.size).toBe(0);
+      } finally {
+        McpSdkClient.prototype.connect = originalConnect;
+      }
+    });
+
+    test("a structured JSON-RPC error mentioning authorization keeps the session AND the token", async () => {
+      // The substring heuristics alone would read this tool-level error as a
+      // transport auth failure — evicting a healthy session and discarding a
+      // valid OAuth token. An McpError is a well-formed response from a live
+      // session; only its -32001 timeout code says anything about health.
       const protocol = new McpCommunicationProtocol();
-      await protocol.close();
-      await expect((protocol as any)._getOrCreateSession("s", CONFIG)).rejects.toThrow("shut down");
-      expect((protocol as any)._mcpSessions.size).toBe(0);
+      (protocol as any)._oauthTokens.set("cid", { accessToken: "valid", expiresAt: Date.now() + 3600_000 });
+      const auth = { auth_type: "oauth2", client_id: "cid", client_secret: "s", token_url: "https://x/token" };
+      const client = seed(protocol, () =>
+        Promise.reject(new McpError(-32602, "Authorization header missing for downstream API")));
+
+      await expect(
+        (protocol as any)._withSession("s", CONFIG, auth, () => client.op())
+      ).rejects.toThrow("Authorization");
+      expect(client.closed).toBe(0);
+      expect((protocol as any)._mcpSessions.get(KEY)).toBe(client);
+      expect((protocol as any)._oauthTokens.has("cid")).toBe(true);
+    });
+
+    test("a structured HTTP 401 classifies as auth without relying on message text", async () => {
+      const protocol = new McpCommunicationProtocol();
+      const client = seed(protocol, () =>
+        Promise.reject(new StreamableHTTPError(401, "nope")));
+
+      await expect(run(protocol, client)).rejects.toThrow("nope");
+      expect(client.closed).toBe(1);
+      expect((protocol as any)._mcpSessions.has(KEY)).toBe(false);
+    });
+
+    test("a structured McpError -32001 still evicts as a timeout", async () => {
+      const protocol = new McpCommunicationProtocol();
+      const client = seed(protocol, () =>
+        Promise.reject(new McpError(-32001, "Request timed out")));
+
+      await expect(run(protocol, client)).rejects.toThrow("-32001");
+      expect(client.closed).toBe(1);
+      expect((protocol as any)._mcpSessions.has(KEY)).toBe(false);
     });
   });
 

--- a/packages/mcp/tests/mcp_communication_protocol.test.ts
+++ b/packages/mcp/tests/mcp_communication_protocol.test.ts
@@ -6,7 +6,7 @@ import { McpCommunicationProtocol, McpCallTemplate } from "../src/index";
 import { McpHttpServerSchema } from "../src/mcp_call_template";
 import { IUtcpClient } from "@utcp/sdk";
 import { Client as McpSdkClient } from "@modelcontextprotocol/sdk/client/index.js";
-import { McpError } from "@modelcontextprotocol/sdk/types.js";
+import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
 import { StreamableHTTPError } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 
 const HTTP_PORT = 9999;
@@ -594,6 +594,61 @@ describe("McpCommunicationProtocol", () => {
       await expect(run(protocol, client)).rejects.toThrow("nope");
       expect(client.closed).toBe(1);
       expect((protocol as any)._mcpSessions.has(KEY)).toBe(false);
+    });
+
+    test("a structured ConnectionClosed (-32000) stays transient: evict + one retry", async () => {
+      // -32000 is raised CLIENT-side by the SDK when the session drops
+      // mid-request — the exact condition the old "closed" substring
+      // classified as transient. The structured gate must not demote it to
+      // an operation-level error, or the dead transport stays cached with
+      // no retry.
+      const protocol = new McpCommunicationProtocol();
+      let calls = 0;
+      const client = seed(protocol, () => {
+        calls += 1;
+        return calls === 1
+          ? Promise.reject(new McpError(ErrorCode.ConnectionClosed, "Connection closed"))
+          : Promise.resolve("ok");
+      });
+
+      await expect(run(protocol, client)).resolves.toBe("ok");
+      expect(calls).toBe(2); // retried once against a fresh session
+      expect(client.closed).toBe(1); // the dropped session was evicted
+    });
+
+    test("overlapping close() calls keep the gate shut until the slowest sweep finishes", async () => {
+      // A boolean gate is cleared by whichever close() finishes first — and a
+      // second close() finds an already-emptied cache and finishes
+      // immediately, reopening creation while the first sweep still awaits a
+      // transport's close(). A session dialed in that window outlives the
+      // first close with live resources.
+      const originalConnect = McpSdkClient.prototype.connect;
+      McpSdkClient.prototype.connect = function () { return Promise.resolve(); } as any;
+      try {
+        const protocol = new McpCommunicationProtocol();
+        let releaseClose!: () => void;
+        const slow = {
+          close() { return new Promise<void>((res) => { releaseClose = res; }); },
+        };
+        (protocol as any)._mcpSessions.set(KEY, slow);
+
+        const drain1 = protocol.close();   // stuck awaiting slow.close()
+        const drain2 = protocol.close();   // sees an empty cache, finishes fast
+        await drain2;
+
+        // The first sweep is still running — creation must stay refused.
+        await expect((protocol as any)._getOrCreateSession("s", CONFIG))
+          .rejects.toThrow("shutting down");
+
+        releaseClose();
+        await drain1;
+
+        // Both drains done — the shared instance is usable again.
+        const created = await (protocol as any)._getOrCreateSession("s", CONFIG);
+        expect(created).toBeDefined();
+      } finally {
+        McpSdkClient.prototype.connect = originalConnect;
+      }
     });
 
     test("a structured McpError -32001 still evicts as a timeout", async () => {


### PR DESCRIPTION
Answers cubic's review of the dev→main merge (#38). All three findings were valid — the P1 shipped in 1.1.5 as a regression, so this should release as 1.1.6 promptly.

**P1 — shared instance bricked by one client's close.** `index.ts` registers one `McpCommunicationProtocol` into the process-wide registry and `UtcpClient.close()` closes registered protocols — so the terminal `_closed` flag meant the first client to close took MCP away from every other client in the process, permanently. In a server that builds a client per session, that's fatal on the first session teardown. `close()` is now a **drain**: `_closing` covers only the sweep, and a `_closeGeneration` counter preserves the shutdown-race guarantees for in-flight creations (a close intervening before dialing, or between connect and caching, still refuses/closes that session) while the instance stays usable afterward.

**P2 — dial after close during the token fetch.** The pre-dial check ran before the OAuth fetch (an await); the generation is re-checked after it, before any connection exists.

**P2 — substring auth classification.** Structured-first now: an `McpError` is a well-formed JSON-RPC response from a live session and never matches auth/transient heuristics whatever its text says (only its `-32001` timeout code evicts); a `StreamableHTTPError` 401/403 classifies as auth without message matching. Substrings remain as fallback for wrapped/stringified errors.

Five new tests, each verified to fail pre-fix; 30/30 passing. Version bumped to **1.1.6**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)