### PR TITLE
Implement SSE and Streamable HTTP protocols, fix CLI streaming

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -509,7 +509,7 @@ const result = await client.callTool('git_commit_push', {
 
 ## Limitations
 
-- **No Streaming Support**: The CLI protocol does not support streaming. All output is returned when the command completes.
+- **No Native Streaming**: The CLI protocol does not stream output incrementally. `callToolStreaming` works, but it runs the command to completion and yields the full result as a single chunk.
 - **Platform-Specific**: Commands must be written for the target platform (Windows/Unix).
 - **No Interactive Commands**: Interactive CLI tools (that require user input) are not supported.
 - **Fixed Timeouts**: Timeout durations are currently fixed (though generous).

--- a/packages/cli/src/cli_communication_protocol.ts
+++ b/packages/cli/src/cli_communication_protocol.ts
@@ -757,12 +757,15 @@ export class CliCommunicationProtocol implements CommunicationProtocol {
 
   /**
    * REQUIRED
-   * Streaming calls are not supported for the CLI protocol.
+   * Execute a tool call through the CLI transport streamingly.
    *
-   * @throws Error Always, as this functionality is not supported.
+   * The CLI protocol does not natively support streaming, so the command is
+   * executed to completion and the full result is yielded as a single chunk.
    */
   public async *callToolStreaming(caller: IUtcpClient, toolName: string, toolArgs: Record<string, any>, toolCallTemplate: CallTemplate): AsyncGenerator<any, void, unknown> {
-    throw new Error('Streaming is not supported by the CLI communication protocol.');
+    this._log_info(`CLI protocol does not inherently support streaming for '${toolName}'. Fetching full response as a single chunk.`);
+    const result = await this.callTool(caller, toolName, toolArgs, toolCallTemplate);
+    yield result;
   }
 
   public async close(): Promise<void> {

--- a/packages/cli/tests/cli_communication_protocol.test.ts
+++ b/packages/cli/tests/cli_communication_protocol.test.ts
@@ -41,6 +41,25 @@ describe('CliCommunicationProtocol (Multi-Command)', () => {
     expect(result.trim()).toBe('Step 2');
   });
 
+  test('should emit the full result as a single chunk when called in streaming mode', async () => {
+    const callTemplate: CliCallTemplate = CliCallTemplateSchema.parse({
+      name: 'streaming_test',
+      call_template_type: 'cli',
+      commands: [
+        { command: 'echo "Step 1"', append_to_final_output: false },
+        { command: 'echo "Step 2"' },
+      ],
+    });
+
+    const chunks: any[] = [];
+    for await (const chunk of cliProtocol.callToolStreaming(mockClient, 'test.workflow', {}, callTemplate)) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toHaveLength(1);
+    expect(String(chunks[0]).trim()).toBe('Step 2');
+  });
+
   test('should preserve state (current directory) between commands', async () => {
     const tempDir = await createTempDir('state_test_dir');
     const finalCommand = isWindows ? 'Write-Output (Get-Location).Path' : 'pwd';

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -132,7 +132,7 @@ Automatically converts OpenAPI specifications to UTCP tools:
 
 **SSE**
 - ✅ Real-time event streaming
-- ✅ Automatic reconnection (resumes with `Last-Event-ID`, at most 5 reconnects per call; a clean end of stream completes the call and initial connection/HTTP errors fail immediately)
+- ✅ Automatic reconnection (resumes with `Last-Event-ID`, at most 5 reconnects per call with the delay capped at 60 s; a failed reconnect handshake counts as an attempt; a clean end of stream completes the call and initial connection/HTTP errors fail immediately; the handshake is limited to 30 s)
 - ✅ Event type filtering
 - ✅ Server push updates
 - ❌ Unidirectional (server → client only)

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -62,8 +62,8 @@ interface SseCallTemplate {
   call_template_type: 'sse';
   url: string;
   event_type?: string;        // Filter specific event types
-  reconnect?: boolean;        // Auto-reconnect on disconnect
-  retry_timeout?: number;     // Reconnection timeout (ms)
+  reconnect?: boolean;        // Auto-reconnect if an established stream drops (default: true)
+  retry_timeout?: number;     // Delay before reconnecting (ms, default: 30000); a server "retry:" field overrides it
   headers?: Record<string, string>;
   body_field?: string;
   header_fields?: string[];
@@ -132,7 +132,7 @@ Automatically converts OpenAPI specifications to UTCP tools:
 
 **SSE**
 - ✅ Real-time event streaming
-- ✅ Automatic reconnection
+- ✅ Automatic reconnection (resumes with `Last-Event-ID`, at most 5 reconnects per call; a clean end of stream completes the call and initial connection/HTTP errors fail immediately)
 - ✅ Event type filtering
 - ✅ Server push updates
 - ❌ Unidirectional (server → client only)

--- a/packages/http/src/sse_communication_protocol.ts
+++ b/packages/http/src/sse_communication_protocol.ts
@@ -28,6 +28,17 @@ interface SseEvent {
 }
 
 /**
+ * The server violated the SSE wire format. Not a connection loss, so it is
+ * never retried.
+ */
+export class SseProtocolError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SseProtocolError';
+  }
+}
+
+/**
  * REQUIRED
  * SSE communication protocol implementation for UTCP client.
  *
@@ -45,6 +56,23 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
    * Keeps a tool call bounded even if the server keeps dropping the connection.
    */
   public static readonly MAX_RECONNECT_ATTEMPTS = 5;
+  /**
+   * Cap on the delay before a reconnect, whatever `retry_timeout` or a
+   * server-sent `retry:` field asks for. Together with MAX_RECONNECT_ATTEMPTS
+   * this bounds the total time a call can spend waiting to reconnect.
+   */
+  public static readonly MAX_RECONNECT_DELAY_MS = 60_000;
+  /**
+   * Time allowed for the SSE handshake, i.e. until response headers arrive.
+   * Reading the body is unbounded: an SSE stream may legitimately stay quiet.
+   */
+  public static readonly HANDSHAKE_TIMEOUT_MS = 30_000;
+  /**
+   * Largest partial event the parser buffers (in UTF-16 code units) before
+   * declaring the stream malformed. Guards against a server that streams
+   * data without ever sending the blank-line event delimiter.
+   */
+  public static readonly MAX_EVENT_BUFFER_CHARS = 16 * 1024 * 1024;
 
   private oauthTokens: Map<string, { access_token: string; expires_at?: number }> = new Map();
 
@@ -132,7 +160,7 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
     }
 
     if (provider.auth && 'token_url' in provider.auth) {
-      const token = await this._handleOAuth2(provider.auth as OAuth2Auth);
+      const token = await this._handleOAuth2(provider.auth as OAuth2Auth, SseCommunicationProtocol.HANDSHAKE_TIMEOUT_MS);
       headers['Authorization'] = `Bearer ${token}`;
     }
   }
@@ -326,7 +354,13 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
         attemptHeaders['Last-Event-ID'] = lastEventId;
       }
 
+      const delayMs = () => Math.min(retryDelayMs, SseCommunicationProtocol.MAX_RECONNECT_DELAY_MS);
+
       let response: Response;
+      // Bound the handshake only: the signal is dropped once headers arrive,
+      // so a quiet stream is never cut off.
+      const handshake = new AbortController();
+      const handshakeTimer = setTimeout(() => handshake.abort(), SseCommunicationProtocol.HANDSHAKE_TIMEOUT_MS);
       try {
         // ``redirect: 'error'`` -- see registerManual for rationale (GHSA-9qhg-99ww-9mqc).
         // ``keepalive: false`` -- do not take a pooled socket for the stream. Bun's
@@ -340,6 +374,7 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
           body,
           redirect: 'error',
           keepalive: false,
+          signal: handshake.signal,
         });
 
         if (!response.ok) {
@@ -352,10 +387,27 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
           throw new Error(`HTTP ${response.status}: ${response.statusText}${detail ? ` - ${detail.slice(0, 200)}` : ''}`);
         }
       } catch (error: any) {
-        // Failing to establish the connection (or a non-2xx status) is a
-        // definitive answer, not a connection loss: fail fast, no retry.
-        this._logError(`Error establishing SSE connection to '${providerName}': ${error.message}`);
-        throw error;
+        if (reconnectAttempts === 0) {
+          // The initial handshake failing (refused, timed out, non-2xx) is a
+          // definitive answer about the endpoint: fail fast, no retry.
+          this._logError(`Error establishing SSE connection to '${providerName}': ${error.message}`);
+          throw error;
+        }
+        // A reconnect handshake failing is part of the outage we are riding
+        // out (the server may still be restarting): count it and try again.
+        reconnectAttempts += 1;
+        if (reconnectAttempts > SseCommunicationProtocol.MAX_RECONNECT_ATTEMPTS) {
+          this._logError(`SSE reconnect to '${providerName}' failed and attempts are exhausted: ${error.message}`);
+          throw error;
+        }
+        this._logInfo(
+          `SSE reconnect to '${providerName}' failed (${error.message}); retrying in ${delayMs()} ms ` +
+          `(attempt ${reconnectAttempts}/${SseCommunicationProtocol.MAX_RECONNECT_ATTEMPTS})`
+        );
+        await new Promise<void>(resolve => setTimeout(resolve, delayMs()));
+        continue;
+      } finally {
+        clearTimeout(handshakeTimer);
       }
 
       try {
@@ -377,18 +429,23 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
         // The server ended the stream cleanly: the tool call is complete.
         return;
       } catch (error: any) {
+        if (error instanceof SseProtocolError) {
+          // A malformed stream is the server's doing, not a connection loss.
+          this._logError(`Malformed SSE stream from '${providerName}': ${error.message}`);
+          throw error;
+        }
         reconnectAttempts += 1;
         if (!reconnect || reconnectAttempts > SseCommunicationProtocol.MAX_RECONNECT_ATTEMPTS) {
           this._logError(`SSE connection to '${providerName}' lost and not reconnecting: ${error.message}`);
           throw error;
         }
         this._logInfo(
-          `SSE connection to '${providerName}' lost (${error.message}); reconnecting in ${retryDelayMs} ms ` +
+          `SSE connection to '${providerName}' lost (${error.message}); reconnecting in ${delayMs()} ms ` +
           `(attempt ${reconnectAttempts}/${SseCommunicationProtocol.MAX_RECONNECT_ATTEMPTS})`
         );
       }
 
-      await new Promise<void>(resolve => setTimeout(resolve, retryDelayMs));
+      await new Promise<void>(resolve => setTimeout(resolve, delayMs()));
     }
   }
 
@@ -418,13 +475,29 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
     const reader = body.getReader();
     const decoder = new TextDecoder('utf-8');
     let buffer = '';
+    // A "\r" that ended the previous chunk is held back until the next chunk
+    // shows whether a "\n" follows; otherwise a CRLF split across two reads
+    // would become two LFs and dispatch an event early.
+    let pendingCr = false;
+    const normalise = (chunk: string): string => {
+      let text = chunk;
+      if (pendingCr) {
+        text = '\r' + text;
+        pendingCr = false;
+      }
+      if (text.endsWith('\r')) {
+        text = text.slice(0, -1);
+        pendingCr = true;
+      }
+      // Normalise CRLF / CR line endings to LF so the event delimiter is always "\n\n".
+      return text.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+    };
 
     try {
       while (true) {
         const { done, value } = await reader.read();
         if (done) break;
-        // Normalise CRLF / CR line endings to LF so the event delimiter is always "\n\n".
-        buffer += decoder.decode(value, { stream: true }).replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+        buffer += normalise(decoder.decode(value, { stream: true }));
 
         let delimiterIndex: number;
         while ((delimiterIndex = buffer.indexOf('\n\n')) >= 0) {
@@ -435,10 +508,19 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
             yield event;
           }
         }
+
+        if (buffer.length > SseCommunicationProtocol.MAX_EVENT_BUFFER_CHARS) {
+          throw new SseProtocolError(
+            `SSE event exceeded ${SseCommunicationProtocol.MAX_EVENT_BUFFER_CHARS} characters without a blank-line delimiter`
+          );
+        }
       }
 
       // Flush a trailing event that was not terminated by a blank line.
-      buffer += decoder.decode();
+      buffer += normalise(decoder.decode());
+      if (pendingCr) {
+        buffer += '\n';
+      }
       const trailing = this._parseSseEvent(buffer);
       if (trailing) {
         yield trailing;
@@ -506,47 +588,64 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
 
   /**
    * Handles the OAuth2 client-credentials flow, trying credentials in the body
-   * first and then as a Basic Auth header. Tokens are cached per client_id.
+   * first and then as a Basic Auth header. Tokens are cached per full OAuth
+   * configuration (token URL, client id, secret, scope), never per client_id
+   * alone: two templates may share a client_id but point at different issuers.
+   * Each token request is bounded by `timeoutMs` so a stalled token endpoint
+   * cannot hang the tool call before its own timeout even starts.
    */
-  private async _handleOAuth2(authDetails: OAuth2Auth): Promise<string> {
+  private async _handleOAuth2(authDetails: OAuth2Auth, timeoutMs: number): Promise<string> {
     const clientId = authDetails.client_id;
-    const cached = this.oauthTokens.get(clientId);
+
+    // The token URL may come from an untrusted call template; validate it
+    // before the cache is consulted, so a template with a rejected URL never
+    // receives a token fetched on behalf of another (GHSA-8cp3-qxj6-px34).
+    ensureSecureUrl(authDetails.token_url, 'OAuth2 token URL');
+
+    const cacheKey = JSON.stringify([authDetails.token_url, clientId, authDetails.client_secret, authDetails.scope || '']);
+    const cached = this.oauthTokens.get(cacheKey);
     if (cached && (cached.expires_at === undefined || cached.expires_at > Date.now())) {
       return cached.access_token;
     }
-
-    // The token URL may come from an untrusted call template; validate it
-    // before posting credentials (GHSA-8cp3-qxj6-px34).
-    ensureSecureUrl(authDetails.token_url, 'OAuth2 token URL');
 
     const storeToken = (tokenData: any): string => {
       if (!tokenData || !tokenData.access_token) {
         throw new Error('Access token not found in response.');
       }
       const expiresIn = typeof tokenData.expires_in === 'number' ? tokenData.expires_in : 3600;
-      this.oauthTokens.set(clientId, { access_token: tokenData.access_token, expires_at: Date.now() + expiresIn * 1000 });
+      this.oauthTokens.set(cacheKey, { access_token: tokenData.access_token, expires_at: Date.now() + expiresIn * 1000 });
       return tokenData.access_token;
+    };
+
+    const requestToken = async (headers: Record<string, string>, form: Record<string, string>): Promise<string> => {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), timeoutMs);
+      try {
+        const response = await fetch(authDetails.token_url, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded', ...headers },
+          body: new URLSearchParams(form).toString(),
+          redirect: 'error',
+          signal: controller.signal,
+        });
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+        }
+        return storeToken(await response.json());
+      } finally {
+        clearTimeout(timer);
+      }
     };
 
     // Method 1: credentials in the request body
     try {
       this._logInfo(`Attempting OAuth2 token fetch for '${clientId}' with credentials in body.`);
-      const bodyData = new URLSearchParams({
+      return await requestToken({}, {
         grant_type: 'client_credentials',
         client_id: clientId,
         client_secret: authDetails.client_secret,
         scope: authDetails.scope || '',
       });
-      const response = await fetch(authDetails.token_url, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        body: bodyData.toString(),
-        redirect: 'error',
-      });
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-      }
-      return storeToken(await response.json());
     } catch (error: any) {
       this._logError(`OAuth2 with credentials in body failed for '${clientId}': ${error.message}. Trying Basic Auth header.`);
     }
@@ -554,24 +653,11 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
     // Method 2: credentials as a Basic Auth header
     try {
       this._logInfo(`Attempting OAuth2 token fetch for '${clientId}' with Basic Auth header.`);
-      const bodyData = new URLSearchParams({
+      const credentials = Buffer.from(`${clientId}:${authDetails.client_secret}`).toString('base64');
+      return await requestToken({ 'Authorization': `Basic ${credentials}` }, {
         grant_type: 'client_credentials',
         scope: authDetails.scope || '',
       });
-      const credentials = Buffer.from(`${clientId}:${authDetails.client_secret}`).toString('base64');
-      const response = await fetch(authDetails.token_url, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
-          'Authorization': `Basic ${credentials}`,
-        },
-        body: bodyData.toString(),
-        redirect: 'error',
-      });
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-      }
-      return storeToken(await response.json());
     } catch (error: any) {
       this._logError(`OAuth2 with Basic Auth header also failed for '${clientId}': ${error.message}`);
       throw new Error(`Failed to fetch OAuth2 token for client '${clientId}' after trying all methods. Details: ${error.message}`);
@@ -584,20 +670,26 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
    */
   private _buildUrlWithPathParams(urlTemplate: string, args: Record<string, any>): string {
     let url = urlTemplate;
-    const pathParams = urlTemplate.match(/\{([^}]+)\}/g) || [];
+    // Both the `{param}` form from the spec and the `${param}` form the
+    // package README documents.
+    const placeholders = urlTemplate.match(/\$?\{([^}]+)\}/g) || [];
+    const paramNames = Array.from(new Set(
+      placeholders.map(p => (p.startsWith('${') ? p.slice(2, -1) : p.slice(1, -1)))
+    ));
 
-    for (const param of pathParams) {
-      const paramName = param.slice(1, -1);
-      if (paramName in args) {
-        // URL-encode the parameter value to prevent path injection
-        url = url.replace(param, encodeURIComponent(String(args[paramName])));
-        delete args[paramName];
-      } else {
+    for (const paramName of paramNames) {
+      if (!(paramName in args)) {
         throw new Error(`Missing required path parameter: ${paramName}`);
       }
+      // URL-encode the value to prevent path injection, and replace every
+      // occurrence of either form (a template may repeat a parameter).
+      // `${x}` goes first so that replacing `{x}` never leaves a stray `$`.
+      const value = encodeURIComponent(String(args[paramName]));
+      url = url.split('${' + paramName + '}').join(value).split('{' + paramName + '}').join(value);
+      delete args[paramName];
     }
 
-    const remainingParams = url.match(/\{([^}]+)\}/g);
+    const remainingParams = url.match(/\$?\{([^}]+)\}/g);
     if (remainingParams && remainingParams.length > 0) {
       throw new Error(`Missing required path parameters in URL template: ${remainingParams.join(', ')}`);
     }

--- a/packages/http/src/sse_communication_protocol.ts
+++ b/packages/http/src/sse_communication_protocol.ts
@@ -145,6 +145,7 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
     headers: Record<string, string>,
     auth: { username: string; password: string } | undefined,
     cookies: Record<string, string>,
+    signal: AbortSignal,
   ): Promise<void> {
     if (auth) {
       const credentials = Buffer.from(`${auth.username}:${auth.password}`).toString('base64');
@@ -160,7 +161,7 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
     }
 
     if (provider.auth && 'token_url' in provider.auth) {
-      const token = await this._handleOAuth2(provider.auth as OAuth2Auth, SseCommunicationProtocol.HANDSHAKE_TIMEOUT_MS);
+      const token = await this._handleOAuth2(provider.auth as OAuth2Auth, signal);
       headers['Authorization'] = `Bearer ${token}`;
     }
   }
@@ -185,11 +186,14 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
 
     this._logInfo(`Discovering tools from '${provider.name}' (SSE) at ${url}`);
 
+    // One handshake-sized deadline for the whole discovery call, token fetch included.
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), SseCommunicationProtocol.HANDSHAKE_TIMEOUT_MS);
     try {
       const requestHeaders: Record<string, string> = provider.headers ? { ...provider.headers } : {};
       const queryParams: Record<string, any> = {};
       const { auth, cookies } = this._applyAuth(provider, requestHeaders, queryParams);
-      await this._finalizeAuthHeaders(provider, requestHeaders, auth, cookies);
+      await this._finalizeAuthHeaders(provider, requestHeaders, auth, cookies, controller.signal);
 
       // Build URL with query parameters
       const urlObj = new URL(url);
@@ -207,6 +211,7 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
         method: 'GET',
         headers: requestHeaders,
         redirect: 'error',
+        signal: controller.signal,
       });
 
       if (!response.ok) {
@@ -233,6 +238,8 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
         success: false,
         errors: [error.message || String(error)],
       };
+    } finally {
+      clearTimeout(timer);
     }
   }
 
@@ -310,9 +317,16 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
     // The rest of the arguments are query parameters
     const queryParams: Record<string, any> = { ...remainingArgs };
 
-    // Handle authentication
+    // Handle authentication. The token fetch (both credential methods) shares
+    // one handshake-sized deadline so a stalled token endpoint cannot hang the call.
     const { auth, cookies } = this._applyAuth(provider, requestHeaders, queryParams);
-    await this._finalizeAuthHeaders(provider, requestHeaders, auth, cookies);
+    const authController = new AbortController();
+    const authTimer = setTimeout(() => authController.abort(), SseCommunicationProtocol.HANDSHAKE_TIMEOUT_MS);
+    try {
+      await this._finalizeAuthHeaders(provider, requestHeaders, auth, cookies, authController.signal);
+    } finally {
+      clearTimeout(authTimer);
+    }
 
     const urlObj = new URL(url);
     Object.entries(queryParams).forEach(([key, value]) => {
@@ -591,10 +605,10 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
    * first and then as a Basic Auth header. Tokens are cached per full OAuth
    * configuration (token URL, client id, secret, scope), never per client_id
    * alone: two templates may share a client_id but point at different issuers.
-   * Each token request is bounded by `timeoutMs` so a stalled token endpoint
-   * cannot hang the tool call before its own timeout even starts.
+   * Both credential methods run under the caller's `signal`, which carries
+   * the call's own deadline, so the whole token flow can never exceed it.
    */
-  private async _handleOAuth2(authDetails: OAuth2Auth, timeoutMs: number): Promise<string> {
+  private async _handleOAuth2(authDetails: OAuth2Auth, signal: AbortSignal): Promise<string> {
     const clientId = authDetails.client_id;
 
     // The token URL may come from an untrusted call template; validate it
@@ -618,23 +632,20 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
     };
 
     const requestToken = async (headers: Record<string, string>, form: Record<string, string>): Promise<string> => {
-      const controller = new AbortController();
-      const timer = setTimeout(() => controller.abort(), timeoutMs);
-      try {
-        const response = await fetch(authDetails.token_url, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/x-www-form-urlencoded', ...headers },
-          body: new URLSearchParams(form).toString(),
-          redirect: 'error',
-          signal: controller.signal,
-        });
-        if (!response.ok) {
-          throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-        }
-        return storeToken(await response.json());
-      } finally {
-        clearTimeout(timer);
+      if (signal.aborted) {
+        throw new Error('Timed out before the token request could start.');
       }
+      const response = await fetch(authDetails.token_url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded', ...headers },
+        body: new URLSearchParams(form).toString(),
+        redirect: 'error',
+        signal,
+      });
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+      return storeToken(await response.json());
     };
 
     // Method 1: credentials in the request body

--- a/packages/http/src/sse_communication_protocol.ts
+++ b/packages/http/src/sse_communication_protocol.ts
@@ -1,6 +1,6 @@
 /**
  * Server-Sent Events (SSE) Communication Protocol for UTCP.
- * 
+ *
  * Handles Server-Sent Events based tool providers with streaming capabilities.
  */
 // packages/http/src/sse_communication_protocol.ts
@@ -13,16 +13,39 @@ import { BasicAuth } from '@utcp/sdk';
 import { OAuth2Auth } from '@utcp/sdk';
 import { OAuth2UserAuth } from '@utcp/sdk';
 import { IUtcpClient } from '@utcp/sdk';
-import { SseCallTemplate } from './sse_call_template';
+import { SseCallTemplate, SseCallTemplateSchema } from './sse_call_template';
 import { ensureSecureUrl, assertNoCrlf } from './_security';
+
+/**
+ * A single parsed Server-Sent Event.
+ */
+interface SseEvent {
+  event?: string;
+  id?: string;
+  retry?: number;
+  /** Joined data lines. Absent for blocks that only carry id/retry/event fields. */
+  data?: string;
+}
 
 /**
  * REQUIRED
  * SSE communication protocol implementation for UTCP client.
- * 
+ *
  * Handles Server-Sent Events based tool providers with streaming capabilities.
+ *
+ * Each SSE event's ``data`` payload is yielded as one chunk. Payloads that
+ * parse as JSON are yielded as the parsed value; otherwise the raw string is
+ * yielded. When ``event_type`` is set on the call template, only events whose
+ * ``event`` field matches are yielded.
  */
 export class SseCommunicationProtocol implements CommunicationProtocol {
+  /**
+   * Upper bound on reconnection attempts for a single tool call when the
+   * established stream drops and the call template has `reconnect` enabled.
+   * Keeps a tool call bounded even if the server keeps dropping the connection.
+   */
+  public static readonly MAX_RECONNECT_ATTEMPTS = 5;
+
   private oauthTokens: Map<string, { access_token: string; expires_at?: number }> = new Map();
 
   private _logInfo(message: string): void {
@@ -86,6 +109,35 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
   }
 
   /**
+   * Applies Basic auth, cookies and (if configured) an OAuth2 client-credentials
+   * bearer token to the request headers.
+   */
+  private async _finalizeAuthHeaders(
+    provider: SseCallTemplate,
+    headers: Record<string, string>,
+    auth: { username: string; password: string } | undefined,
+    cookies: Record<string, string>,
+  ): Promise<void> {
+    if (auth) {
+      const credentials = Buffer.from(`${auth.username}:${auth.password}`).toString('base64');
+      headers['Authorization'] = `Basic ${credentials}`;
+    }
+
+    if (Object.keys(cookies).length > 0) {
+      const cookieHeader = Object.entries(cookies)
+        .map(([k, v]) => `${k}=${v}`)
+        .join('; ');
+      assertNoCrlf(cookieHeader, 'Cookie');
+      headers['Cookie'] = headers['Cookie'] ? `${headers['Cookie']}; ${cookieHeader}` : cookieHeader;
+    }
+
+    if (provider.auth && 'token_url' in provider.auth) {
+      const token = await this._handleOAuth2(provider.auth as OAuth2Auth);
+      headers['Authorization'] = `Bearer ${token}`;
+    }
+  }
+
+  /**
    * REQUIRED
    * Register a manual and its tools from an SSE provider.
    */
@@ -97,7 +149,7 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
       throw new Error('SseCommunicationProtocol can only be used with SseCallTemplate');
     }
 
-    const provider = manualCallTemplate as SseCallTemplate;
+    const provider = SseCallTemplateSchema.parse(manualCallTemplate);
     const url = provider.url;
 
     // Security check: only HTTPS or loopback HTTP allowed for manual discovery.
@@ -109,6 +161,7 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
       const requestHeaders: Record<string, string> = provider.headers ? { ...provider.headers } : {};
       const queryParams: Record<string, any> = {};
       const { auth, cookies } = this._applyAuth(provider, requestHeaders, queryParams);
+      await this._finalizeAuthHeaders(provider, requestHeaders, auth, cookies);
 
       // Build URL with query parameters
       const urlObj = new URL(url);
@@ -116,40 +169,23 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
         urlObj.searchParams.append(key, String(value));
       });
 
-      // SSE requires Accept: text/event-stream
-      requestHeaders['Accept'] = 'text/event-stream';
-
-      // Build fetch options. ``redirect: 'error'`` refuses to follow
-      // 3xx responses on the SSE handshake -- the streaming response
-      // has to stay open for the lifetime of the tool call, which is
-      // incompatible with a per-hop revalidator, and SSE redirects
-      // are pathological in practice. Without this, an
-      // attacker-controlled endpoint could 302 the handshake into an
-      // internal service (GHSA-9qhg-99ww-9mqc).
-      const fetchOptions: RequestInit = {
+      // ``redirect: 'error'`` refuses to follow 3xx responses on the SSE
+      // handshake -- the streaming response has to stay open for the
+      // lifetime of the tool call, which is incompatible with a per-hop
+      // revalidator, and SSE redirects are pathological in practice.
+      // Without this, an attacker-controlled endpoint could 302 the
+      // handshake into an internal service (GHSA-9qhg-99ww-9mqc).
+      const response = await fetch(urlObj.toString(), {
         method: 'GET',
         headers: requestHeaders,
         redirect: 'error',
-      };
-
-      // Add basic auth if present
-      if (auth) {
-        const credentials = Buffer.from(`${auth.username}:${auth.password}`).toString('base64');
-        fetchOptions.headers = {
-          ...fetchOptions.headers as Record<string, string>,
-          'Authorization': `Basic ${credentials}`,
-        };
-      }
-
-      // Make discovery request
-      const response = await fetch(urlObj.toString(), fetchOptions);
+      });
 
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}: ${response.statusText}`);
       }
 
-      // For SSE discovery, we expect the first event to contain the manual
-      // This is a simplified implementation
+      // Discovery returns the manual as a plain JSON document.
       const responseText = await response.text();
       const utcpManual = new UtcpManualSerializer().validateDict(JSON.parse(responseText));
 
@@ -183,6 +219,8 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
   /**
    * REQUIRED
    * Call a tool using SSE (non-streaming).
+   *
+   * Consumes the whole event stream and returns every event payload as an array.
    */
   async callTool(
     caller: IUtcpClient,
@@ -190,8 +228,7 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
     toolArgs: Record<string, any>,
     toolCallTemplate: CallTemplate
   ): Promise<any> {
-    // For SSE, we collect all events and return them
-    const events: string[] = [];
+    const events: any[] = [];
     for await (const event of this.callToolStreaming(caller, toolName, toolArgs, toolCallTemplate)) {
       events.push(event);
     }
@@ -201,7 +238,7 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
   /**
    * REQUIRED
    * Call a tool using SSE streaming.
-   * Returns an async generator that yields SSE events.
+   * Returns an async generator that yields the payload of each SSE event.
    */
   async *callToolStreaming(
     caller: IUtcpClient,
@@ -209,14 +246,363 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
     toolArgs: Record<string, any>,
     toolCallTemplate: CallTemplate
   ): AsyncGenerator<any, void, unknown> {
-    const provider = toolCallTemplate as SseCallTemplate;
+    if ((toolCallTemplate as any).call_template_type !== 'sse') {
+      throw new Error('SseCommunicationProtocol can only be used with SseCallTemplate');
+    }
+    const provider = SseCallTemplateSchema.parse(toolCallTemplate);
 
-    // TODO: Implement actual SSE call logic
-    // This would involve connecting to the SSE endpoint and streaming events
-    this._logInfo(`Calling SSE tool '${toolName}' with args: ${JSON.stringify(toolArgs)}`);
-    
-    // Placeholder implementation
-    yield `SSE event for tool: ${toolName}`;
+    const requestHeaders: Record<string, string> = provider.headers ? { ...provider.headers } : {};
+    let bodyContent: any = undefined;
+    const remainingArgs: Record<string, any> = { ...toolArgs };
+    requestHeaders['Accept'] = 'text/event-stream';
+
+    if (provider.header_fields) {
+      for (const fieldName of provider.header_fields) {
+        if (fieldName in remainingArgs) {
+          assertNoCrlf(fieldName, 'header field name');
+          const value = String(remainingArgs[fieldName]);
+          assertNoCrlf(value, `header field '${fieldName}'`);
+          requestHeaders[fieldName] = value;
+          delete remainingArgs[fieldName];
+        }
+      }
+    }
+
+    if (provider.body_field && provider.body_field in remainingArgs) {
+      bodyContent = remainingArgs[provider.body_field];
+      delete remainingArgs[provider.body_field];
+    }
+
+    // Build the URL with path parameters substituted
+    const url = this._buildUrlWithPathParams(provider.url, remainingArgs);
+
+    // Security check: re-validate the resolved URL before each invocation.
+    ensureSecureUrl(url, 'tool invocation');
+
+    // The rest of the arguments are query parameters
+    const queryParams: Record<string, any> = { ...remainingArgs };
+
+    // Handle authentication
+    const { auth, cookies } = this._applyAuth(provider, requestHeaders, queryParams);
+    await this._finalizeAuthHeaders(provider, requestHeaders, auth, cookies);
+
+    const urlObj = new URL(url);
+    Object.entries(queryParams).forEach(([key, value]) => {
+      if (value === undefined || value === null) return;
+      urlObj.searchParams.append(key, typeof value === 'object' ? JSON.stringify(value) : String(value));
+    });
+
+    // Mirror the Python implementation: POST when a body is present, GET otherwise.
+    const method = bodyContent !== undefined ? 'POST' : 'GET';
+    let body: BodyInit | undefined = undefined;
+    if (bodyContent !== undefined) {
+      const contentTypeEntry = Object.entries(requestHeaders).find(([h]) => h.toLowerCase() === 'content-type');
+      if (!contentTypeEntry) {
+        requestHeaders['Content-Type'] = 'application/json';
+      }
+      const contentType = contentTypeEntry?.[1] || 'application/json';
+      if (contentType.includes('application/json')) {
+        body = JSON.stringify(bodyContent);
+      } else if (typeof bodyContent === 'string' || bodyContent instanceof Uint8Array || bodyContent instanceof ArrayBuffer) {
+        body = bodyContent as BodyInit;
+      } else {
+        body = JSON.stringify(bodyContent);
+      }
+    }
+
+    this._logInfo(`Executing SSE tool '${toolName}' with URL: ${urlObj.toString()} and method: ${method}`);
+
+    const providerName = provider.name || toolName;
+    const eventType = provider.event_type ?? undefined;
+    const reconnect = provider.reconnect !== false;
+    let retryDelayMs = provider.retry_timeout;
+    let lastEventId: string | undefined;
+    let reconnectAttempts = 0;
+
+    while (true) {
+      const attemptHeaders: Record<string, string> = { ...requestHeaders };
+      if (lastEventId !== undefined) {
+        // Let the server resume from where we left off (SSE spec).
+        attemptHeaders['Last-Event-ID'] = lastEventId;
+      }
+
+      let response: Response;
+      try {
+        // ``redirect: 'error'`` -- see registerManual for rationale (GHSA-9qhg-99ww-9mqc).
+        // ``keepalive: false`` -- do not take a pooled socket for the stream. Bun's
+        // fetch transparently re-issues a request when a reused keep-alive socket
+        // dies mid-response, which would bypass this reconnect logic (no
+        // Last-Event-ID, ``reconnect: false`` ignored, duplicated events). Node
+        // ignores the option. A fresh connection per streaming call is cheap.
+        response = await fetch(urlObj.toString(), {
+          method,
+          headers: attemptHeaders,
+          body,
+          redirect: 'error',
+          keepalive: false,
+        });
+
+        if (!response.ok) {
+          let detail = '';
+          try {
+            detail = await response.text();
+          } catch {
+            // ignore body read failures on error responses
+          }
+          throw new Error(`HTTP ${response.status}: ${response.statusText}${detail ? ` - ${detail.slice(0, 200)}` : ''}`);
+        }
+      } catch (error: any) {
+        // Failing to establish the connection (or a non-2xx status) is a
+        // definitive answer, not a connection loss: fail fast, no retry.
+        this._logError(`Error establishing SSE connection to '${providerName}': ${error.message}`);
+        throw error;
+      }
+
+      try {
+        for await (const event of this._iterSseEvents(response)) {
+          if (event.id !== undefined) {
+            lastEventId = event.id;
+          }
+          if (event.retry !== undefined) {
+            retryDelayMs = event.retry;
+          }
+          if (event.data === undefined) {
+            continue;
+          }
+          if (eventType && event.event !== eventType) {
+            continue;
+          }
+          yield this._parseEventData(event.data);
+        }
+        // The server ended the stream cleanly: the tool call is complete.
+        return;
+      } catch (error: any) {
+        reconnectAttempts += 1;
+        if (!reconnect || reconnectAttempts > SseCommunicationProtocol.MAX_RECONNECT_ATTEMPTS) {
+          this._logError(`SSE connection to '${providerName}' lost and not reconnecting: ${error.message}`);
+          throw error;
+        }
+        this._logInfo(
+          `SSE connection to '${providerName}' lost (${error.message}); reconnecting in ${retryDelayMs} ms ` +
+          `(attempt ${reconnectAttempts}/${SseCommunicationProtocol.MAX_RECONNECT_ATTEMPTS})`
+        );
+      }
+
+      await new Promise<void>(resolve => setTimeout(resolve, retryDelayMs));
+    }
+  }
+
+  /**
+   * Returns the JSON-decoded payload when possible, otherwise the raw string.
+   */
+  private _parseEventData(data: string): any {
+    try {
+      return JSON.parse(data);
+    } catch {
+      return data;
+    }
+  }
+
+  /**
+   * Parses the SSE wire format from the response body and yields one
+   * {@link SseEvent} per event block. Blocks that only carry id/retry fields
+   * are yielded too (without data) so the caller can track reconnection state.
+   * A read error (connection loss) propagates to the caller.
+   */
+  private async *_iterSseEvents(response: Response): AsyncGenerator<SseEvent, void, unknown> {
+    const body = response.body;
+    if (!body) {
+      return;
+    }
+
+    const reader = body.getReader();
+    const decoder = new TextDecoder('utf-8');
+    let buffer = '';
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        // Normalise CRLF / CR line endings to LF so the event delimiter is always "\n\n".
+        buffer += decoder.decode(value, { stream: true }).replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+
+        let delimiterIndex: number;
+        while ((delimiterIndex = buffer.indexOf('\n\n')) >= 0) {
+          const rawEvent = buffer.slice(0, delimiterIndex);
+          buffer = buffer.slice(delimiterIndex + 2);
+          const event = this._parseSseEvent(rawEvent);
+          if (event) {
+            yield event;
+          }
+        }
+      }
+
+      // Flush a trailing event that was not terminated by a blank line.
+      buffer += decoder.decode();
+      const trailing = this._parseSseEvent(buffer);
+      if (trailing) {
+        yield trailing;
+      }
+    } finally {
+      // Release the connection if the consumer stopped early or an error occurred.
+      try {
+        await reader.cancel();
+      } catch {
+        // ignore
+      }
+    }
+  }
+
+  /**
+   * Parses one SSE event block (lines separated by "\n"). Returns undefined
+   * for blocks with no fields at all (blank / comment-only keep-alives).
+   */
+  private _parseSseEvent(rawEvent: string): SseEvent | undefined {
+    if (!rawEvent.trim()) {
+      return undefined;
+    }
+
+    const event: SseEvent = {};
+    const dataLines: string[] = [];
+
+    for (const line of rawEvent.split('\n')) {
+      if (line.startsWith(':')) {
+        continue; // comment
+      }
+      const colonIndex = line.indexOf(':');
+      let field: string;
+      let value: string;
+      if (colonIndex === -1) {
+        field = line;
+        value = '';
+      } else {
+        field = line.slice(0, colonIndex);
+        value = line.slice(colonIndex + 1);
+        if (value.startsWith(' ')) {
+          value = value.slice(1);
+        }
+      }
+
+      if (field === 'event') {
+        event.event = value;
+      } else if (field === 'data') {
+        dataLines.push(value);
+      } else if (field === 'id') {
+        event.id = value;
+      } else if (field === 'retry') {
+        const retry = parseInt(value, 10);
+        if (!Number.isNaN(retry)) {
+          event.retry = retry;
+        }
+      }
+    }
+
+    if (dataLines.length > 0) {
+      event.data = dataLines.join('\n');
+    }
+
+    return Object.keys(event).length > 0 ? event : undefined;
+  }
+
+  /**
+   * Handles the OAuth2 client-credentials flow, trying credentials in the body
+   * first and then as a Basic Auth header. Tokens are cached per client_id.
+   */
+  private async _handleOAuth2(authDetails: OAuth2Auth): Promise<string> {
+    const clientId = authDetails.client_id;
+    const cached = this.oauthTokens.get(clientId);
+    if (cached && (cached.expires_at === undefined || cached.expires_at > Date.now())) {
+      return cached.access_token;
+    }
+
+    // The token URL may come from an untrusted call template; validate it
+    // before posting credentials (GHSA-8cp3-qxj6-px34).
+    ensureSecureUrl(authDetails.token_url, 'OAuth2 token URL');
+
+    const storeToken = (tokenData: any): string => {
+      if (!tokenData || !tokenData.access_token) {
+        throw new Error('Access token not found in response.');
+      }
+      const expiresIn = typeof tokenData.expires_in === 'number' ? tokenData.expires_in : 3600;
+      this.oauthTokens.set(clientId, { access_token: tokenData.access_token, expires_at: Date.now() + expiresIn * 1000 });
+      return tokenData.access_token;
+    };
+
+    // Method 1: credentials in the request body
+    try {
+      this._logInfo(`Attempting OAuth2 token fetch for '${clientId}' with credentials in body.`);
+      const bodyData = new URLSearchParams({
+        grant_type: 'client_credentials',
+        client_id: clientId,
+        client_secret: authDetails.client_secret,
+        scope: authDetails.scope || '',
+      });
+      const response = await fetch(authDetails.token_url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: bodyData.toString(),
+        redirect: 'error',
+      });
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+      return storeToken(await response.json());
+    } catch (error: any) {
+      this._logError(`OAuth2 with credentials in body failed for '${clientId}': ${error.message}. Trying Basic Auth header.`);
+    }
+
+    // Method 2: credentials as a Basic Auth header
+    try {
+      this._logInfo(`Attempting OAuth2 token fetch for '${clientId}' with Basic Auth header.`);
+      const bodyData = new URLSearchParams({
+        grant_type: 'client_credentials',
+        scope: authDetails.scope || '',
+      });
+      const credentials = Buffer.from(`${clientId}:${authDetails.client_secret}`).toString('base64');
+      const response = await fetch(authDetails.token_url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'Authorization': `Basic ${credentials}`,
+        },
+        body: bodyData.toString(),
+        redirect: 'error',
+      });
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+      return storeToken(await response.json());
+    } catch (error: any) {
+      this._logError(`OAuth2 with Basic Auth header also failed for '${clientId}': ${error.message}`);
+      throw new Error(`Failed to fetch OAuth2 token for client '${clientId}' after trying all methods. Details: ${error.message}`);
+    }
+  }
+
+  /**
+   * Builds the URL by substituting {param} path parameters from args.
+   * Consumed parameters are removed from args so they are not sent as query parameters.
+   */
+  private _buildUrlWithPathParams(urlTemplate: string, args: Record<string, any>): string {
+    let url = urlTemplate;
+    const pathParams = urlTemplate.match(/\{([^}]+)\}/g) || [];
+
+    for (const param of pathParams) {
+      const paramName = param.slice(1, -1);
+      if (paramName in args) {
+        // URL-encode the parameter value to prevent path injection
+        url = url.replace(param, encodeURIComponent(String(args[paramName])));
+        delete args[paramName];
+      } else {
+        throw new Error(`Missing required path parameter: ${paramName}`);
+      }
+    }
+
+    const remainingParams = url.match(/\{([^}]+)\}/g);
+    if (remainingParams && remainingParams.length > 0) {
+      throw new Error(`Missing required path parameters in URL template: ${remainingParams.join(', ')}`);
+    }
+
+    return url;
   }
 
   /**

--- a/packages/http/src/streamable_http_communication_protocol.ts
+++ b/packages/http/src/streamable_http_communication_protocol.ts
@@ -1,6 +1,6 @@
 /**
  * Streamable HTTP Communication Protocol for UTCP.
- * 
+ *
  * Handles HTTP streaming with chunked transfer encoding for real-time data.
  */
 // packages/http/src/streamable_http_communication_protocol.ts
@@ -13,14 +13,19 @@ import { BasicAuth } from '@utcp/sdk';
 import { OAuth2Auth } from '@utcp/sdk';
 import { OAuth2UserAuth } from '@utcp/sdk';
 import { IUtcpClient } from '@utcp/sdk';
-import { StreamableHttpCallTemplate } from './streamable_http_call_template';
+import { StreamableHttpCallTemplate, StreamableHttpCallTemplateSchema } from './streamable_http_call_template';
 import { ensureSecureUrl, assertNoCrlf } from './_security';
 
 /**
  * REQUIRED
  * Streamable HTTP communication protocol implementation for UTCP client.
- * 
+ *
  * Handles HTTP streaming with chunked transfer encoding for real-time data.
+ *
+ * Chunks are yielded according to the response Content-Type:
+ *   - application/x-ndjson: one parsed JSON value per line (raw line on parse error)
+ *   - application/json: the whole body buffered and parsed as a single JSON value
+ *   - application/octet-stream and anything else: Buffer chunks of at most chunk_size bytes
  */
 export class StreamableHttpCommunicationProtocol implements CommunicationProtocol {
   private oauthTokens: Map<string, { access_token: string; expires_at?: number }> = new Map();
@@ -86,6 +91,35 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
   }
 
   /**
+   * Applies Basic auth, cookies and (if configured) an OAuth2 client-credentials
+   * bearer token to the request headers.
+   */
+  private async _finalizeAuthHeaders(
+    provider: StreamableHttpCallTemplate,
+    headers: Record<string, string>,
+    auth: { username: string; password: string } | undefined,
+    cookies: Record<string, string>,
+  ): Promise<void> {
+    if (auth) {
+      const credentials = Buffer.from(`${auth.username}:${auth.password}`).toString('base64');
+      headers['Authorization'] = `Basic ${credentials}`;
+    }
+
+    if (Object.keys(cookies).length > 0) {
+      const cookieHeader = Object.entries(cookies)
+        .map(([k, v]) => `${k}=${v}`)
+        .join('; ');
+      assertNoCrlf(cookieHeader, 'Cookie');
+      headers['Cookie'] = headers['Cookie'] ? `${headers['Cookie']}; ${cookieHeader}` : cookieHeader;
+    }
+
+    if (provider.auth && 'token_url' in provider.auth) {
+      const token = await this._handleOAuth2(provider.auth as OAuth2Auth);
+      headers['Authorization'] = `Bearer ${token}`;
+    }
+  }
+
+  /**
    * REQUIRED
    * Register a manual and its tools from a StreamableHttp provider.
    */
@@ -97,7 +131,7 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
       throw new Error('StreamableHttpCommunicationProtocol can only be used with StreamableHttpCallTemplate');
     }
 
-    const provider = manualCallTemplate as StreamableHttpCallTemplate;
+    const provider = StreamableHttpCallTemplateSchema.parse(manualCallTemplate);
     const url = provider.url;
 
     // Security check: only HTTPS or loopback HTTP allowed for manual discovery.
@@ -109,6 +143,7 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
       const requestHeaders: Record<string, string> = provider.headers ? { ...provider.headers } : {};
       const queryParams: Record<string, any> = {};
       const { auth, cookies } = this._applyAuth(provider, requestHeaders, queryParams);
+      await this._finalizeAuthHeaders(provider, requestHeaders, auth, cookies);
 
       // Build URL with query parameters
       const urlObj = new URL(url);
@@ -116,45 +151,38 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
         urlObj.searchParams.append(key, String(value));
       });
 
-      // Build fetch options. ``redirect: 'error'`` refuses to follow
-      // 3xx responses -- streaming handshakes shouldn't redirect, and
-      // doing so silently would let an attacker-controlled endpoint
-      // steer the stream into an internal service
-      // (GHSA-9qhg-99ww-9mqc).
-      const fetchOptions: RequestInit = {
-        method: provider.http_method || 'GET',
-        headers: requestHeaders,
-        redirect: 'error',
-      };
+      // ``redirect: 'error'`` refuses to follow 3xx responses -- streaming
+      // handshakes shouldn't redirect, and doing so silently would let an
+      // attacker-controlled endpoint steer the stream into an internal
+      // service (GHSA-9qhg-99ww-9mqc).
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), provider.timeout || 60000);
+      try {
+        const response = await fetch(urlObj.toString(), {
+          method: provider.http_method || 'GET',
+          headers: requestHeaders,
+          redirect: 'error',
+          signal: controller.signal,
+        });
 
-      // Add basic auth if present
-      if (auth) {
-        const credentials = Buffer.from(`${auth.username}:${auth.password}`).toString('base64');
-        fetchOptions.headers = {
-          ...fetchOptions.headers as Record<string, string>,
-          'Authorization': `Basic ${credentials}`,
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+        }
+
+        const responseText = await response.text();
+        const utcpManual = new UtcpManualSerializer().validateDict(JSON.parse(responseText));
+
+        this._logInfo(`Discovered ${utcpManual.tools.length} tools from '${provider.name}'`);
+
+        return {
+          manualCallTemplate: provider,
+          manual: utcpManual,
+          success: true,
+          errors: [],
         };
+      } finally {
+        clearTimeout(timer);
       }
-
-      // Make discovery request
-      const response = await fetch(urlObj.toString(), fetchOptions);
-
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-      }
-
-      // Read response body
-      const responseText = await response.text();
-      const utcpManual = new UtcpManualSerializer().validateDict(JSON.parse(responseText));
-
-      this._logInfo(`Discovered ${utcpManual.tools.length} tools from '${provider.name}'`);
-
-      return {
-        manualCallTemplate: provider,
-        manual: utcpManual,
-        success: true,
-        errors: [],
-      };
     } catch (error: any) {
       this._logError(`Error discovering tools from '${provider.name}': ${error.message}`);
       return {
@@ -177,6 +205,10 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
   /**
    * REQUIRED
    * Call a tool using HTTP (non-streaming).
+   *
+   * Collects every chunk produced by callToolStreaming. Binary chunks are
+   * concatenated into a single Buffer; parsed (JSON / NDJSON) chunks are
+   * returned as an array, mirroring the Python implementation.
    */
   async callTool(
     caller: IUtcpClient,
@@ -184,12 +216,19 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
     toolArgs: Record<string, any>,
     toolCallTemplate: CallTemplate
   ): Promise<any> {
-    // For streamable HTTP, we collect all chunks and return the complete result
-    const chunks: string[] = [];
+    const binaryChunks: Buffer[] = [];
+    const parsedChunks: any[] = [];
     for await (const chunk of this.callToolStreaming(caller, toolName, toolArgs, toolCallTemplate)) {
-      chunks.push(chunk);
+      if (Buffer.isBuffer(chunk) || chunk instanceof Uint8Array) {
+        binaryChunks.push(Buffer.from(chunk));
+      } else {
+        parsedChunks.push(chunk);
+      }
     }
-    return chunks.join('');
+    if (binaryChunks.length > 0) {
+      return Buffer.concat(binaryChunks);
+    }
+    return parsedChunks;
   }
 
   /**
@@ -203,14 +242,298 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
     toolArgs: Record<string, any>,
     toolCallTemplate: CallTemplate
   ): AsyncGenerator<any, void, unknown> {
-    const provider = toolCallTemplate as StreamableHttpCallTemplate;
+    if ((toolCallTemplate as any).call_template_type !== 'streamable_http') {
+      throw new Error('StreamableHttpCommunicationProtocol can only be used with StreamableHttpCallTemplate');
+    }
+    const provider = StreamableHttpCallTemplateSchema.parse(toolCallTemplate);
 
-    // TODO: Implement actual streaming call logic
-    // This would involve making an HTTP request and streaming the response in chunks
-    this._logInfo(`Calling streaming tool '${toolName}' with args: ${JSON.stringify(toolArgs)}`);
-    
-    // Placeholder implementation
-    yield `Streaming response for tool: ${toolName}`;
+    const requestHeaders: Record<string, string> = provider.headers ? { ...provider.headers } : {};
+    let bodyContent: any = undefined;
+    const remainingArgs: Record<string, any> = { ...toolArgs };
+
+    if (provider.header_fields) {
+      for (const fieldName of provider.header_fields) {
+        if (fieldName in remainingArgs) {
+          assertNoCrlf(fieldName, 'header field name');
+          const value = String(remainingArgs[fieldName]);
+          assertNoCrlf(value, `header field '${fieldName}'`);
+          requestHeaders[fieldName] = value;
+          delete remainingArgs[fieldName];
+        }
+      }
+    }
+
+    if (provider.body_field && provider.body_field in remainingArgs) {
+      bodyContent = remainingArgs[provider.body_field];
+      delete remainingArgs[provider.body_field];
+    }
+
+    // Build the URL with path parameters substituted
+    const url = this._buildUrlWithPathParams(provider.url, remainingArgs);
+
+    // Security check: re-validate the resolved URL before each invocation.
+    ensureSecureUrl(url, 'tool invocation');
+
+    // The rest of the arguments are query parameters
+    const queryParams: Record<string, any> = { ...remainingArgs };
+
+    // Handle authentication
+    const { auth, cookies } = this._applyAuth(provider, requestHeaders, queryParams);
+    await this._finalizeAuthHeaders(provider, requestHeaders, auth, cookies);
+
+    const urlObj = new URL(url);
+    Object.entries(queryParams).forEach(([key, value]) => {
+      if (value === undefined || value === null) return;
+      urlObj.searchParams.append(key, typeof value === 'object' ? JSON.stringify(value) : String(value));
+    });
+
+    let body: BodyInit | undefined = undefined;
+    if (bodyContent !== undefined) {
+      const hasContentType = Object.keys(requestHeaders).some(h => h.toLowerCase() === 'content-type');
+      if (!hasContentType) {
+        requestHeaders['Content-Type'] = provider.content_type;
+      }
+      const contentType = Object.entries(requestHeaders).find(([h]) => h.toLowerCase() === 'content-type')?.[1] || '';
+      if (contentType.includes('application/json')) {
+        body = JSON.stringify(bodyContent);
+      } else if (typeof bodyContent === 'string' || bodyContent instanceof Uint8Array || bodyContent instanceof ArrayBuffer) {
+        body = bodyContent as BodyInit;
+      } else {
+        body = JSON.stringify(bodyContent);
+      }
+    }
+
+    this._logInfo(`Executing streaming HTTP tool '${toolName}' with URL: ${urlObj.toString()} and method: ${provider.http_method}`);
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), provider.timeout || 60000);
+    try {
+      // ``redirect: 'error'`` -- see registerManual for rationale (GHSA-9qhg-99ww-9mqc).
+      // ``keepalive: false`` -- do not take a pooled socket for the stream. Bun's
+      // fetch transparently re-issues a request when a reused keep-alive socket
+      // dies mid-response, which would hand the consumer the partial chunks
+      // followed by a full replay. Node ignores the option.
+      const response = await fetch(urlObj.toString(), {
+        method: provider.http_method || 'GET',
+        headers: requestHeaders,
+        body,
+        redirect: 'error',
+        signal: controller.signal,
+        keepalive: false,
+      });
+
+      if (!response.ok) {
+        let detail = '';
+        try {
+          detail = await response.text();
+        } catch {
+          // ignore body read failures on error responses
+        }
+        throw new Error(`HTTP ${response.status}: ${response.statusText}${detail ? ` - ${detail.slice(0, 200)}` : ''}`);
+      }
+
+      for await (const chunk of this._processHttpStream(response, provider.chunk_size, provider.name || toolName)) {
+        yield chunk;
+      }
+    } catch (error: any) {
+      this._logError(`Error during HTTP stream for '${provider.name || toolName}': ${error.message}`);
+      throw error;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  /**
+   * Processes the HTTP response body and yields chunks based on content type.
+   */
+  private async *_processHttpStream(
+    response: Response,
+    chunkSize: number | undefined,
+    providerName: string,
+  ): AsyncGenerator<any, void, unknown> {
+    const contentType = response.headers.get('content-type') || '';
+    const body = response.body;
+
+    if (!body) {
+      // No body (e.g. 204). Nothing to yield.
+      return;
+    }
+
+    const reader = body.getReader();
+    try {
+      if (contentType.includes('application/x-ndjson')) {
+        const decoder = new TextDecoder('utf-8');
+        let buffer = '';
+        const parseLine = (line: string): any => {
+          try {
+            return JSON.parse(line);
+          } catch {
+            this._logError(`Error parsing NDJSON line for '${providerName}': ${line.slice(0, 100)}`);
+            return line; // Yield raw line on error
+          }
+        };
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          buffer += decoder.decode(value, { stream: true });
+          let newlineIndex: number;
+          while ((newlineIndex = buffer.indexOf('\n')) >= 0) {
+            const line = buffer.slice(0, newlineIndex).replace(/\r$/, '');
+            buffer = buffer.slice(newlineIndex + 1);
+            if (line.trim()) {
+              yield parseLine(line);
+            }
+          }
+        }
+        buffer += decoder.decode();
+        if (buffer.trim()) {
+          yield parseLine(buffer.replace(/\r$/, ''));
+        }
+      } else if (contentType.includes('application/json')) {
+        // Buffer the entire response for a single JSON object
+        const parts: Buffer[] = [];
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          parts.push(Buffer.from(value));
+        }
+        const buffer = Buffer.concat(parts);
+        if (buffer.length > 0) {
+          const text = buffer.toString('utf-8');
+          try {
+            yield JSON.parse(text);
+          } catch {
+            this._logError(`Error parsing JSON response for '${providerName}': ${text.slice(0, 100)}`);
+            yield buffer; // Yield raw buffer on error
+          }
+        }
+      } else {
+        // Binary chunk streaming for application/octet-stream and unknown content types.
+        // Re-chunk the network reads so each yielded Buffer is at most chunkSize bytes.
+        const size = chunkSize && chunkSize > 0 ? chunkSize : 8192;
+        let pending = Buffer.alloc(0);
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          pending = pending.length === 0 ? Buffer.from(value) : Buffer.concat([pending, Buffer.from(value)]);
+          while (pending.length >= size) {
+            yield pending.subarray(0, size);
+            pending = pending.subarray(size);
+          }
+        }
+        if (pending.length > 0) {
+          yield pending;
+        }
+      }
+    } finally {
+      // Release the connection if the consumer stopped early or an error occurred.
+      try {
+        await reader.cancel();
+      } catch {
+        // ignore
+      }
+    }
+  }
+
+  /**
+   * Handles the OAuth2 client-credentials flow, trying credentials in the body
+   * first and then as a Basic Auth header. Tokens are cached per client_id.
+   */
+  private async _handleOAuth2(authDetails: OAuth2Auth): Promise<string> {
+    const clientId = authDetails.client_id;
+    const cached = this.oauthTokens.get(clientId);
+    if (cached && (cached.expires_at === undefined || cached.expires_at > Date.now())) {
+      return cached.access_token;
+    }
+
+    // The token URL may come from an untrusted call template; validate it
+    // before posting credentials (GHSA-8cp3-qxj6-px34).
+    ensureSecureUrl(authDetails.token_url, 'OAuth2 token URL');
+
+    const storeToken = (tokenData: any): string => {
+      if (!tokenData || !tokenData.access_token) {
+        throw new Error('Access token not found in response.');
+      }
+      const expiresIn = typeof tokenData.expires_in === 'number' ? tokenData.expires_in : 3600;
+      this.oauthTokens.set(clientId, { access_token: tokenData.access_token, expires_at: Date.now() + expiresIn * 1000 });
+      return tokenData.access_token;
+    };
+
+    // Method 1: credentials in the request body
+    try {
+      this._logInfo(`Attempting OAuth2 token fetch for '${clientId}' with credentials in body.`);
+      const bodyData = new URLSearchParams({
+        grant_type: 'client_credentials',
+        client_id: clientId,
+        client_secret: authDetails.client_secret,
+        scope: authDetails.scope || '',
+      });
+      const response = await fetch(authDetails.token_url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: bodyData.toString(),
+        redirect: 'error',
+      });
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+      return storeToken(await response.json());
+    } catch (error: any) {
+      this._logError(`OAuth2 with credentials in body failed for '${clientId}': ${error.message}. Trying Basic Auth header.`);
+    }
+
+    // Method 2: credentials as a Basic Auth header
+    try {
+      this._logInfo(`Attempting OAuth2 token fetch for '${clientId}' with Basic Auth header.`);
+      const bodyData = new URLSearchParams({
+        grant_type: 'client_credentials',
+        scope: authDetails.scope || '',
+      });
+      const credentials = Buffer.from(`${clientId}:${authDetails.client_secret}`).toString('base64');
+      const response = await fetch(authDetails.token_url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'Authorization': `Basic ${credentials}`,
+        },
+        body: bodyData.toString(),
+        redirect: 'error',
+      });
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+      return storeToken(await response.json());
+    } catch (error: any) {
+      this._logError(`OAuth2 with Basic Auth header also failed for '${clientId}': ${error.message}`);
+      throw new Error(`Failed to fetch OAuth2 token for client '${clientId}' after trying all methods. Details: ${error.message}`);
+    }
+  }
+
+  /**
+   * Builds the URL by substituting {param} path parameters from args.
+   * Consumed parameters are removed from args so they are not sent as query parameters.
+   */
+  private _buildUrlWithPathParams(urlTemplate: string, args: Record<string, any>): string {
+    let url = urlTemplate;
+    const pathParams = urlTemplate.match(/\{([^}]+)\}/g) || [];
+
+    for (const param of pathParams) {
+      const paramName = param.slice(1, -1);
+      if (paramName in args) {
+        // URL-encode the parameter value to prevent path injection
+        url = url.replace(param, encodeURIComponent(String(args[paramName])));
+        delete args[paramName];
+      } else {
+        throw new Error(`Missing required path parameter: ${paramName}`);
+      }
+    }
+
+    const remainingParams = url.match(/\{([^}]+)\}/g);
+    if (remainingParams && remainingParams.length > 0) {
+      throw new Error(`Missing required path parameters in URL template: ${remainingParams.join(', ')}`);
+    }
+
+    return url;
   }
 
   /**

--- a/packages/http/src/streamable_http_communication_protocol.ts
+++ b/packages/http/src/streamable_http_communication_protocol.ts
@@ -298,38 +298,36 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
     // One deadline for the whole call: token fetch, request and stream.
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), provider.timeout || 60000);
+    // Everything from here on runs under the deadline, and the single
+    // finally below clears the timer on every exit path, including a throw
+    // while building the URL or serializing the body.
     try {
       await this._finalizeAuthHeaders(provider, requestHeaders, auth, cookies, controller.signal);
-    } catch (error) {
-      clearTimeout(timer);
-      throw error;
-    }
 
-    const urlObj = new URL(url);
-    Object.entries(queryParams).forEach(([key, value]) => {
-      if (value === undefined || value === null) return;
-      urlObj.searchParams.append(key, typeof value === 'object' ? JSON.stringify(value) : String(value));
-    });
+      const urlObj = new URL(url);
+      Object.entries(queryParams).forEach(([key, value]) => {
+        if (value === undefined || value === null) return;
+        urlObj.searchParams.append(key, typeof value === 'object' ? JSON.stringify(value) : String(value));
+      });
 
-    let body: BodyInit | undefined = undefined;
-    if (bodyContent !== undefined) {
-      const hasContentType = Object.keys(requestHeaders).some(h => h.toLowerCase() === 'content-type');
-      if (!hasContentType) {
-        requestHeaders['Content-Type'] = provider.content_type;
+      let body: BodyInit | undefined = undefined;
+      if (bodyContent !== undefined) {
+        const hasContentType = Object.keys(requestHeaders).some(h => h.toLowerCase() === 'content-type');
+        if (!hasContentType) {
+          requestHeaders['Content-Type'] = provider.content_type;
+        }
+        const contentType = Object.entries(requestHeaders).find(([h]) => h.toLowerCase() === 'content-type')?.[1] || '';
+        if (contentType.includes('application/json')) {
+          body = JSON.stringify(bodyContent);
+        } else if (typeof bodyContent === 'string' || bodyContent instanceof Uint8Array || bodyContent instanceof ArrayBuffer) {
+          body = bodyContent as BodyInit;
+        } else {
+          body = JSON.stringify(bodyContent);
+        }
       }
-      const contentType = Object.entries(requestHeaders).find(([h]) => h.toLowerCase() === 'content-type')?.[1] || '';
-      if (contentType.includes('application/json')) {
-        body = JSON.stringify(bodyContent);
-      } else if (typeof bodyContent === 'string' || bodyContent instanceof Uint8Array || bodyContent instanceof ArrayBuffer) {
-        body = bodyContent as BodyInit;
-      } else {
-        body = JSON.stringify(bodyContent);
-      }
-    }
 
-    this._logInfo(`Executing streaming HTTP tool '${toolName}' with URL: ${urlObj.toString()} and method: ${provider.http_method}`);
+      this._logInfo(`Executing streaming HTTP tool '${toolName}' with URL: ${urlObj.toString()} and method: ${provider.http_method}`);
 
-    try {
       // ``redirect: 'error'`` -- see registerManual for rationale (GHSA-9qhg-99ww-9mqc).
       // ``keepalive: false`` -- do not take a pooled socket for the stream. Bun's
       // fetch transparently re-issues a request when a reused keep-alive socket

--- a/packages/http/src/streamable_http_communication_protocol.ts
+++ b/packages/http/src/streamable_http_communication_protocol.ts
@@ -114,7 +114,7 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
     }
 
     if (provider.auth && 'token_url' in provider.auth) {
-      const token = await this._handleOAuth2(provider.auth as OAuth2Auth);
+      const token = await this._handleOAuth2(provider.auth as OAuth2Auth, provider.timeout || 60000);
       headers['Authorization'] = `Bearer ${token}`;
     }
   }
@@ -266,6 +266,15 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
     if (provider.body_field && provider.body_field in remainingArgs) {
       bodyContent = remainingArgs[provider.body_field];
       delete remainingArgs[provider.body_field];
+    }
+
+    if (bodyContent !== undefined && (provider.http_method || 'GET').toUpperCase() === 'GET') {
+      // fetch() rejects a GET with a body before anything reaches the server;
+      // surface the misconfiguration as a clear error instead.
+      throw new Error(
+        `Tool '${toolName}': body_field '${provider.body_field}' was supplied but http_method is GET, ` +
+        `which cannot carry a request body. Set http_method to POST.`
+      );
     }
 
     // Build the URL with path parameters substituted
@@ -437,47 +446,64 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
 
   /**
    * Handles the OAuth2 client-credentials flow, trying credentials in the body
-   * first and then as a Basic Auth header. Tokens are cached per client_id.
+   * first and then as a Basic Auth header. Tokens are cached per full OAuth
+   * configuration (token URL, client id, secret, scope), never per client_id
+   * alone: two templates may share a client_id but point at different issuers.
+   * Each token request is bounded by `timeoutMs` so a stalled token endpoint
+   * cannot hang the tool call before its own timeout even starts.
    */
-  private async _handleOAuth2(authDetails: OAuth2Auth): Promise<string> {
+  private async _handleOAuth2(authDetails: OAuth2Auth, timeoutMs: number): Promise<string> {
     const clientId = authDetails.client_id;
-    const cached = this.oauthTokens.get(clientId);
+
+    // The token URL may come from an untrusted call template; validate it
+    // before the cache is consulted, so a template with a rejected URL never
+    // receives a token fetched on behalf of another (GHSA-8cp3-qxj6-px34).
+    ensureSecureUrl(authDetails.token_url, 'OAuth2 token URL');
+
+    const cacheKey = JSON.stringify([authDetails.token_url, clientId, authDetails.client_secret, authDetails.scope || '']);
+    const cached = this.oauthTokens.get(cacheKey);
     if (cached && (cached.expires_at === undefined || cached.expires_at > Date.now())) {
       return cached.access_token;
     }
-
-    // The token URL may come from an untrusted call template; validate it
-    // before posting credentials (GHSA-8cp3-qxj6-px34).
-    ensureSecureUrl(authDetails.token_url, 'OAuth2 token URL');
 
     const storeToken = (tokenData: any): string => {
       if (!tokenData || !tokenData.access_token) {
         throw new Error('Access token not found in response.');
       }
       const expiresIn = typeof tokenData.expires_in === 'number' ? tokenData.expires_in : 3600;
-      this.oauthTokens.set(clientId, { access_token: tokenData.access_token, expires_at: Date.now() + expiresIn * 1000 });
+      this.oauthTokens.set(cacheKey, { access_token: tokenData.access_token, expires_at: Date.now() + expiresIn * 1000 });
       return tokenData.access_token;
+    };
+
+    const requestToken = async (headers: Record<string, string>, form: Record<string, string>): Promise<string> => {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), timeoutMs);
+      try {
+        const response = await fetch(authDetails.token_url, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded', ...headers },
+          body: new URLSearchParams(form).toString(),
+          redirect: 'error',
+          signal: controller.signal,
+        });
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+        }
+        return storeToken(await response.json());
+      } finally {
+        clearTimeout(timer);
+      }
     };
 
     // Method 1: credentials in the request body
     try {
       this._logInfo(`Attempting OAuth2 token fetch for '${clientId}' with credentials in body.`);
-      const bodyData = new URLSearchParams({
+      return await requestToken({}, {
         grant_type: 'client_credentials',
         client_id: clientId,
         client_secret: authDetails.client_secret,
         scope: authDetails.scope || '',
       });
-      const response = await fetch(authDetails.token_url, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        body: bodyData.toString(),
-        redirect: 'error',
-      });
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-      }
-      return storeToken(await response.json());
     } catch (error: any) {
       this._logError(`OAuth2 with credentials in body failed for '${clientId}': ${error.message}. Trying Basic Auth header.`);
     }
@@ -485,24 +511,11 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
     // Method 2: credentials as a Basic Auth header
     try {
       this._logInfo(`Attempting OAuth2 token fetch for '${clientId}' with Basic Auth header.`);
-      const bodyData = new URLSearchParams({
+      const credentials = Buffer.from(`${clientId}:${authDetails.client_secret}`).toString('base64');
+      return await requestToken({ 'Authorization': `Basic ${credentials}` }, {
         grant_type: 'client_credentials',
         scope: authDetails.scope || '',
       });
-      const credentials = Buffer.from(`${clientId}:${authDetails.client_secret}`).toString('base64');
-      const response = await fetch(authDetails.token_url, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
-          'Authorization': `Basic ${credentials}`,
-        },
-        body: bodyData.toString(),
-        redirect: 'error',
-      });
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-      }
-      return storeToken(await response.json());
     } catch (error: any) {
       this._logError(`OAuth2 with Basic Auth header also failed for '${clientId}': ${error.message}`);
       throw new Error(`Failed to fetch OAuth2 token for client '${clientId}' after trying all methods. Details: ${error.message}`);
@@ -515,20 +528,26 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
    */
   private _buildUrlWithPathParams(urlTemplate: string, args: Record<string, any>): string {
     let url = urlTemplate;
-    const pathParams = urlTemplate.match(/\{([^}]+)\}/g) || [];
+    // Both the `{param}` form from the spec and the `${param}` form the
+    // package README documents.
+    const placeholders = urlTemplate.match(/\$?\{([^}]+)\}/g) || [];
+    const paramNames = Array.from(new Set(
+      placeholders.map(p => (p.startsWith('${') ? p.slice(2, -1) : p.slice(1, -1)))
+    ));
 
-    for (const param of pathParams) {
-      const paramName = param.slice(1, -1);
-      if (paramName in args) {
-        // URL-encode the parameter value to prevent path injection
-        url = url.replace(param, encodeURIComponent(String(args[paramName])));
-        delete args[paramName];
-      } else {
+    for (const paramName of paramNames) {
+      if (!(paramName in args)) {
         throw new Error(`Missing required path parameter: ${paramName}`);
       }
+      // URL-encode the value to prevent path injection, and replace every
+      // occurrence of either form (a template may repeat a parameter).
+      // `${x}` goes first so that replacing `{x}` never leaves a stray `$`.
+      const value = encodeURIComponent(String(args[paramName]));
+      url = url.split('${' + paramName + '}').join(value).split('{' + paramName + '}').join(value);
+      delete args[paramName];
     }
 
-    const remainingParams = url.match(/\{([^}]+)\}/g);
+    const remainingParams = url.match(/\$?\{([^}]+)\}/g);
     if (remainingParams && remainingParams.length > 0) {
       throw new Error(`Missing required path parameters in URL template: ${remainingParams.join(', ')}`);
     }

--- a/packages/http/src/streamable_http_communication_protocol.ts
+++ b/packages/http/src/streamable_http_communication_protocol.ts
@@ -99,6 +99,7 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
     headers: Record<string, string>,
     auth: { username: string; password: string } | undefined,
     cookies: Record<string, string>,
+    signal: AbortSignal,
   ): Promise<void> {
     if (auth) {
       const credentials = Buffer.from(`${auth.username}:${auth.password}`).toString('base64');
@@ -114,7 +115,7 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
     }
 
     if (provider.auth && 'token_url' in provider.auth) {
-      const token = await this._handleOAuth2(provider.auth as OAuth2Auth, provider.timeout || 60000);
+      const token = await this._handleOAuth2(provider.auth as OAuth2Auth, signal);
       headers['Authorization'] = `Bearer ${token}`;
     }
   }
@@ -139,11 +140,14 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
 
     this._logInfo(`Discovering tools from '${provider.name}' (HTTP Stream) at ${url}`);
 
+    // One deadline for the whole discovery call, token fetch included.
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), provider.timeout || 60000);
     try {
       const requestHeaders: Record<string, string> = provider.headers ? { ...provider.headers } : {};
       const queryParams: Record<string, any> = {};
       const { auth, cookies } = this._applyAuth(provider, requestHeaders, queryParams);
-      await this._finalizeAuthHeaders(provider, requestHeaders, auth, cookies);
+      await this._finalizeAuthHeaders(provider, requestHeaders, auth, cookies, controller.signal);
 
       // Build URL with query parameters
       const urlObj = new URL(url);
@@ -155,8 +159,6 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
       // handshakes shouldn't redirect, and doing so silently would let an
       // attacker-controlled endpoint steer the stream into an internal
       // service (GHSA-9qhg-99ww-9mqc).
-      const controller = new AbortController();
-      const timer = setTimeout(() => controller.abort(), provider.timeout || 60000);
       try {
         const response = await fetch(urlObj.toString(), {
           method: provider.http_method || 'GET',
@@ -184,6 +186,7 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
         clearTimeout(timer);
       }
     } catch (error: any) {
+      clearTimeout(timer);
       this._logError(`Error discovering tools from '${provider.name}': ${error.message}`);
       return {
         manualCallTemplate: provider,
@@ -263,12 +266,15 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
       }
     }
 
-    if (provider.body_field && provider.body_field in remainingArgs) {
+    // "Supplied" means the caller passed the field, whatever its value; a
+    // field already mapped to a header above is no longer in remainingArgs.
+    const bodyFieldSupplied = !!provider.body_field && provider.body_field in remainingArgs;
+    if (provider.body_field && bodyFieldSupplied) {
       bodyContent = remainingArgs[provider.body_field];
       delete remainingArgs[provider.body_field];
     }
 
-    if (bodyContent !== undefined && (provider.http_method || 'GET').toUpperCase() === 'GET') {
+    if (bodyFieldSupplied && (provider.http_method || 'GET').toUpperCase() === 'GET') {
       // fetch() rejects a GET with a body before anything reaches the server;
       // surface the misconfiguration as a clear error instead.
       throw new Error(
@@ -288,7 +294,16 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
 
     // Handle authentication
     const { auth, cookies } = this._applyAuth(provider, requestHeaders, queryParams);
-    await this._finalizeAuthHeaders(provider, requestHeaders, auth, cookies);
+
+    // One deadline for the whole call: token fetch, request and stream.
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), provider.timeout || 60000);
+    try {
+      await this._finalizeAuthHeaders(provider, requestHeaders, auth, cookies, controller.signal);
+    } catch (error) {
+      clearTimeout(timer);
+      throw error;
+    }
 
     const urlObj = new URL(url);
     Object.entries(queryParams).forEach(([key, value]) => {
@@ -314,8 +329,6 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
 
     this._logInfo(`Executing streaming HTTP tool '${toolName}' with URL: ${urlObj.toString()} and method: ${provider.http_method}`);
 
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), provider.timeout || 60000);
     try {
       // ``redirect: 'error'`` -- see registerManual for rationale (GHSA-9qhg-99ww-9mqc).
       // ``keepalive: false`` -- do not take a pooled socket for the stream. Bun's
@@ -449,10 +462,10 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
    * first and then as a Basic Auth header. Tokens are cached per full OAuth
    * configuration (token URL, client id, secret, scope), never per client_id
    * alone: two templates may share a client_id but point at different issuers.
-   * Each token request is bounded by `timeoutMs` so a stalled token endpoint
-   * cannot hang the tool call before its own timeout even starts.
+   * Both credential methods run under the caller's `signal`, which carries
+   * the call's own deadline, so the whole token flow can never exceed it.
    */
-  private async _handleOAuth2(authDetails: OAuth2Auth, timeoutMs: number): Promise<string> {
+  private async _handleOAuth2(authDetails: OAuth2Auth, signal: AbortSignal): Promise<string> {
     const clientId = authDetails.client_id;
 
     // The token URL may come from an untrusted call template; validate it
@@ -476,23 +489,20 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
     };
 
     const requestToken = async (headers: Record<string, string>, form: Record<string, string>): Promise<string> => {
-      const controller = new AbortController();
-      const timer = setTimeout(() => controller.abort(), timeoutMs);
-      try {
-        const response = await fetch(authDetails.token_url, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/x-www-form-urlencoded', ...headers },
-          body: new URLSearchParams(form).toString(),
-          redirect: 'error',
-          signal: controller.signal,
-        });
-        if (!response.ok) {
-          throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-        }
-        return storeToken(await response.json());
-      } finally {
-        clearTimeout(timer);
+      if (signal.aborted) {
+        throw new Error('Timed out before the token request could start.');
       }
+      const response = await fetch(authDetails.token_url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded', ...headers },
+        body: new URLSearchParams(form).toString(),
+        redirect: 'error',
+        signal,
+      });
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+      return storeToken(await response.json());
     };
 
     // Method 1: credentials in the request body

--- a/packages/http/tests/sse_communication_protocol.test.ts
+++ b/packages/http/tests/sse_communication_protocol.test.ts
@@ -3,7 +3,7 @@ import { test, expect, describe, beforeAll, afterAll } from "bun:test";
 import express, { Express } from 'express';
 import { Server } from 'http';
 // Import from package index to trigger auto-registration
-import { SseCommunicationProtocol, SseCallTemplate } from "@utcp/http";
+import { SseCommunicationProtocol, SseCallTemplate, SseProtocolError } from "@utcp/http";
 import { IUtcpClient } from "@utcp/sdk";
 
 // --- Test Server Setup ---
@@ -19,6 +19,10 @@ function resetFlaky(alwaysDrop = false) {
   flaky.lastEventIds = [];
   flaky.alwaysDrop = alwaysDrop;
 }
+const flaky503 = { connections: 0 };
+const hugeRetry = { connections: 0 };
+// Responses deliberately left without headers; ended by the test that opened them.
+const hanging: express.Response[] = [];
 
 function sseHeaders(res: express.Response) {
   res.setHeader('Content-Type', 'text/event-stream');
@@ -112,6 +116,67 @@ beforeAll(async () => {
     }
     res.write("id: 2\ndata: {\"seq\":2}\n\n");
     res.write("id: 3\ndata: {\"seq\":3}\n\n");
+    res.end();
+  });
+
+  // One multi-line CRLF event whose CRLF is split across two writes.
+  app.get("/events-crlf-split", (req, res) => {
+    sseHeaders(res);
+    res.write("data: line1\r");
+    setTimeout(() => {
+      res.write("\ndata: line2\r\n\r\n");
+      res.end();
+    }, 50);
+  });
+
+  // Streams data lines without ever sending the blank-line delimiter.
+  app.get("/events-no-delimiter", (req, res) => {
+    sseHeaders(res);
+    for (let i = 0; i < 20; i++) {
+      res.write("data: " + "x".repeat(500) + "\n");
+    }
+    res.end();
+  });
+
+  // Drops after the first event, answers the first reconnect with a 503,
+  // then serves the rest on the second reconnect.
+  app.get("/flaky-503", (req, res) => {
+    flaky503.connections += 1;
+    if (flaky503.connections === 2) {
+      res.status(503).send("restarting");
+      return;
+    }
+    sseHeaders(res);
+    if (flaky503.connections === 1) {
+      res.write("id: 1\ndata: {\"seq\":1}\n\n");
+      setTimeout(() => req.socket.destroy(), 10);
+      return;
+    }
+    res.write("id: 2\ndata: {\"seq\":2}\n\nid: 3\ndata: {\"seq\":3}\n\n");
+    res.end();
+  });
+
+  // Accepts the connection but never sends response headers.
+  app.get("/never-responds", (req, res) => {
+    hanging.push(res);
+  });
+
+  // First connection asks for a 100 s retry delay, then drops.
+  app.get("/huge-retry", (req, res) => {
+    hugeRetry.connections += 1;
+    sseHeaders(res);
+    if (hugeRetry.connections === 1) {
+      res.write("id: 1\nretry: 100000\ndata: {\"seq\":1}\n\n");
+      setTimeout(() => req.socket.destroy(), 10);
+      return;
+    }
+    res.write("id: 2\ndata: {\"seq\":2}\n\n");
+    res.end();
+  });
+
+  app.get("/pair/:a/:b", (req, res) => {
+    sseHeaders(res);
+    res.write(`data: ${JSON.stringify(req.params)}\n\n`);
     res.end();
   });
 
@@ -255,6 +320,79 @@ describe("SseCommunicationProtocol", () => {
       }));
       await expect(gen).rejects.toBeDefined();
       expect(flaky.connections).toBe(1 + SseCommunicationProtocol.MAX_RECONNECT_ATTEMPTS);
+    });
+  });
+
+  describe("framing robustness and bounded reconnects", () => {
+    test("a CRLF split across chunks does not end the event early", async () => {
+      const result = await protocol.callTool(mockClient, "sse_server.t", {}, template({ url: `http://localhost:${serverPort}/events-crlf-split` }));
+      expect(result).toEqual(["line1\nline2"]);
+    });
+
+    test("a stream that never sends the event delimiter is rejected, not buffered forever", async () => {
+      const original = SseCommunicationProtocol.MAX_EVENT_BUFFER_CHARS;
+      (SseCommunicationProtocol as any).MAX_EVENT_BUFFER_CHARS = 1000;
+      try {
+        const call = protocol.callTool(mockClient, "sse_server.t", {}, template({
+          url: `http://localhost:${serverPort}/events-no-delimiter`,
+          reconnect: true,
+          retry_timeout: 1,
+        }));
+        await expect(call).rejects.toBeInstanceOf(SseProtocolError);
+      } finally {
+        (SseCommunicationProtocol as any).MAX_EVENT_BUFFER_CHARS = original;
+      }
+    });
+
+    test("a failed reconnect handshake is retried, unlike the initial handshake", async () => {
+      flaky503.connections = 0;
+      const result = await protocol.callTool(mockClient, "sse_server.t", {}, template({
+        url: `http://localhost:${serverPort}/flaky-503`,
+        reconnect: true,
+        retry_timeout: 10,
+      }));
+      expect(result).toEqual([{ seq: 1 }, { seq: 2 }, { seq: 3 }]);
+      expect(flaky503.connections).toBe(3);
+    });
+
+    test("a server that accepts the connection but never sends headers cannot hang the call", async () => {
+      const original = SseCommunicationProtocol.HANDSHAKE_TIMEOUT_MS;
+      (SseCommunicationProtocol as any).HANDSHAKE_TIMEOUT_MS = 300;
+      try {
+        const started = Date.now();
+        const call = protocol.callTool(mockClient, "sse_server.t", {}, template({ url: `http://localhost:${serverPort}/never-responds` }));
+        await expect(call).rejects.toBeDefined();
+        expect(Date.now() - started).toBeLessThan(3000);
+      } finally {
+        (SseCommunicationProtocol as any).HANDSHAKE_TIMEOUT_MS = original;
+        for (const r of hanging.splice(0)) r.end();
+      }
+    });
+
+    test("a server-sent retry of 100 s cannot stall the reconnect past MAX_RECONNECT_DELAY_MS", async () => {
+      const original = SseCommunicationProtocol.MAX_RECONNECT_DELAY_MS;
+      (SseCommunicationProtocol as any).MAX_RECONNECT_DELAY_MS = 50;
+      hugeRetry.connections = 0;
+      try {
+        const started = Date.now();
+        const result = await protocol.callTool(mockClient, "sse_server.t", {}, template({
+          url: `http://localhost:${serverPort}/huge-retry`,
+          reconnect: true,
+          retry_timeout: 10,
+        }));
+        expect(result).toEqual([{ seq: 1 }, { seq: 2 }]);
+        expect(hugeRetry.connections).toBe(2);
+        expect(Date.now() - started).toBeLessThan(3000);
+      } finally {
+        (SseCommunicationProtocol as any).MAX_RECONNECT_DELAY_MS = original;
+      }
+    });
+
+    test("repeated and ${param}-style path parameters are all substituted", async () => {
+      const result = await protocol.callTool(mockClient, "sse_server.t", { id: "x" }, template({
+        url: `http://localhost:${serverPort}/pair/{id}/\${id}`,
+      }));
+      expect(result).toEqual([{ a: "x", b: "x" }]);
     });
   });
 });

--- a/packages/http/tests/sse_communication_protocol.test.ts
+++ b/packages/http/tests/sse_communication_protocol.test.ts
@@ -1,0 +1,260 @@
+// packages/http/tests/sse_communication_protocol.test.ts
+import { test, expect, describe, beforeAll, afterAll } from "bun:test";
+import express, { Express } from 'express';
+import { Server } from 'http';
+// Import from package index to trigger auto-registration
+import { SseCommunicationProtocol, SseCallTemplate } from "@utcp/http";
+import { IUtcpClient } from "@utcp/sdk";
+
+// --- Test Server Setup ---
+let app: Express;
+let server: Server;
+let serverPort: number;
+
+const mockClient = {} as IUtcpClient;
+
+const flaky = { connections: 0, lastEventIds: [] as (string | undefined)[], alwaysDrop: false };
+function resetFlaky(alwaysDrop = false) {
+  flaky.connections = 0;
+  flaky.lastEventIds = [];
+  flaky.alwaysDrop = alwaysDrop;
+}
+
+function sseHeaders(res: express.Response) {
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+  // Keep-alive on purpose: earlier tests leave pooled sockets behind, and the
+  // reconnection tests must still see exact hit counts. The protocol opts out
+  // of socket reuse for streams (keepalive: false) so Bun's transparent
+  // request replay on a dead pooled socket cannot bypass its reconnect logic.
+  res.setHeader('Connection', 'keep-alive');
+}
+
+beforeAll(async () => {
+  app = express();
+  app.use(express.json());
+
+  app.get("/utcp", (req, res) => {
+    res.json({
+      utcp_version: "1.0.1",
+      manual_version: "1.0.0",
+      tools: [{
+        name: "sse_tool",
+        description: "An SSE test tool",
+        tool_call_template: {
+          name: "sse_server",
+          call_template_type: 'sse',
+          url: `http://localhost:${serverPort}/events`,
+        }
+      }]
+    });
+  });
+
+  // Emits: a comment, a JSON "message" event, a multi-line "update" event,
+  // a plain-text event with an id and a retry, then closes.
+  app.get("/events", (req, res) => {
+    sseHeaders(res);
+    res.write(": keep-alive comment\n\n");
+    res.write(`event: message\ndata: ${JSON.stringify({ seq: 1, query: req.query })}\n\n`);
+    setTimeout(() => {
+      res.write("event: update\ndata: {\"seq\":\ndata: 2}\n\n");
+      setTimeout(() => {
+        res.write("id: 3\nretry: 1000\ndata: plain text payload\n\n");
+        res.end();
+      }, 10);
+    }, 10);
+  });
+
+  // CRLF line endings and a final event without trailing blank line.
+  app.get("/events-crlf", (req, res) => {
+    sseHeaders(res);
+    res.write("data: {\"a\":1}\r\n\r\n");
+    res.write("data: {\"a\":2}");
+    res.end();
+  });
+
+  app.post("/events-echo", (req, res) => {
+    sseHeaders(res);
+    res.write(`data: ${JSON.stringify({ body: req.body, header: req.headers['x-custom'] ?? null, accept: req.headers['accept'] })}\n\n`);
+    res.end();
+  });
+
+  app.get("/topics/:topic/events", (req, res) => {
+    sseHeaders(res);
+    res.write(`data: ${JSON.stringify({ topic: req.params.topic, query: req.query })}\n\n`);
+    res.end();
+  });
+
+  app.get("/auth", (req, res) => {
+    if (req.headers.authorization !== `Basic ${Buffer.from("user:pass").toString("base64")}`) {
+      return res.status(401).json({ error: "unauthorized" });
+    }
+    sseHeaders(res);
+    res.write("data: {\"ok\":true}\n\n");
+    res.end();
+  });
+
+  app.get("/error", (req, res) => {
+    res.status(500).json({ error: "Internal Server Error" });
+  });
+
+  // Serves the first event then drops the TCP connection on the first connection
+  // (or on every connection when alwaysDrop is set). A reconnecting client is
+  // served the remaining events and a clean end of stream.
+  app.get("/flaky", (req, res) => {
+    flaky.connections += 1;
+    flaky.lastEventIds.push(req.headers['last-event-id'] as string | undefined);
+    sseHeaders(res);
+    if (flaky.alwaysDrop || flaky.connections === 1) {
+      res.write("id: 1\nretry: 20\ndata: {\"seq\":1}\n\n");
+      setTimeout(() => req.socket.destroy(), 10);
+      return;
+    }
+    res.write("id: 2\ndata: {\"seq\":2}\n\n");
+    res.write("id: 3\ndata: {\"seq\":3}\n\n");
+    res.end();
+  });
+
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, () => {
+      serverPort = (server.address() as any).port;
+      resolve();
+    });
+  });
+});
+
+afterAll(() => {
+  return new Promise<void>((resolve) => {
+    server.close(() => resolve());
+  });
+});
+
+const template = (overrides: Partial<SseCallTemplate> & { url: string }): SseCallTemplate => ({
+  name: "sse_server",
+  call_template_type: "sse",
+  reconnect: true,
+  retry_timeout: 30000,
+  ...overrides,
+});
+
+describe("SseCommunicationProtocol", () => {
+  const protocol = new SseCommunicationProtocol();
+
+  test("registerManual discovers tools from a manual endpoint", async () => {
+    const result = await protocol.registerManual(mockClient, template({ url: `http://localhost:${serverPort}/utcp` }));
+    expect(result.success).toBe(true);
+    expect(result.manual.tools).toHaveLength(1);
+    expect(result.manual.tools[0]?.name).toBe("sse_tool");
+  });
+
+  test("callToolStreaming yields each event payload, parsing JSON where possible", async () => {
+    const chunks: any[] = [];
+    for await (const chunk of protocol.callToolStreaming(mockClient, "sse_server.sse_tool", { q: "x" }, template({ url: `http://localhost:${serverPort}/events` }))) {
+      chunks.push(chunk);
+    }
+    expect(chunks).toEqual([
+      { seq: 1, query: { q: "x" } },
+      { seq: 2 },
+      "plain text payload",
+    ]);
+  });
+
+  test("callTool collects all event payloads into an array", async () => {
+    const result = await protocol.callTool(mockClient, "sse_server.sse_tool", {}, template({ url: `http://localhost:${serverPort}/events` }));
+    expect(Array.isArray(result)).toBe(true);
+    expect(result).toHaveLength(3);
+    expect(result[0].seq).toBe(1);
+  });
+
+  test("event_type filters events", async () => {
+    const result = await protocol.callTool(mockClient, "sse_server.sse_tool", {}, template({
+      url: `http://localhost:${serverPort}/events`,
+      event_type: "update",
+    }));
+    expect(result).toEqual([{ seq: 2 }]);
+  });
+
+  test("handles CRLF delimiters and a trailing unterminated event", async () => {
+    const result = await protocol.callTool(mockClient, "sse_server.sse_tool", {}, template({ url: `http://localhost:${serverPort}/events-crlf` }));
+    expect(result).toEqual([{ a: 1 }, { a: 2 }]);
+  });
+
+  test("body_field switches to POST with a JSON body, header_fields become headers, Accept is set", async () => {
+    const result = await protocol.callTool(mockClient, "sse_server.echo", { payload: { n: 42 }, "x-custom": "hdr" }, template({
+      url: `http://localhost:${serverPort}/events-echo`,
+      body_field: "payload",
+      header_fields: ["x-custom"],
+    }));
+    expect(result).toEqual([{ body: { n: 42 }, header: "hdr", accept: "text/event-stream" }]);
+  });
+
+  test("path parameters are substituted and the rest become query params", async () => {
+    const result = await protocol.callTool(mockClient, "sse_server.topic", { topic: "news", limit: 5 }, template({
+      url: `http://localhost:${serverPort}/topics/{topic}/events`,
+    }));
+    expect(result).toEqual([{ topic: "news", query: { limit: "5" } }]);
+  });
+
+  test("Basic auth is applied", async () => {
+    const result = await protocol.callTool(mockClient, "sse_server.auth", {}, template({
+      url: `http://localhost:${serverPort}/auth`,
+      auth: { auth_type: "basic", username: "user", password: "pass" } as any,
+    }));
+    expect(result).toEqual([{ ok: true }]);
+  });
+
+  test("non-2xx responses reject", async () => {
+    const gen = protocol.callToolStreaming(mockClient, "sse_server.err", {}, template({ url: `http://localhost:${serverPort}/error` }));
+    await expect(gen.next()).rejects.toThrow(/HTTP 500/);
+  });
+
+  test("wrong call template type is rejected", async () => {
+    const gen = protocol.callToolStreaming(mockClient, "x", {}, { name: "x", call_template_type: "http" } as any);
+    await expect(gen.next()).rejects.toThrow(/SseCallTemplate/);
+  });
+
+  describe("reconnection", () => {
+    test("resumes a dropped stream with Last-Event-ID and yields every event once", async () => {
+      resetFlaky();
+      const result = await protocol.callTool(mockClient, "sse_server.flaky", {}, template({
+        url: `http://localhost:${serverPort}/flaky`,
+        reconnect: true,
+        retry_timeout: 1000, // overridden by the server's "retry: 20"
+      }));
+      expect(result).toEqual([{ seq: 1 }, { seq: 2 }, { seq: 3 }]);
+      expect(flaky.connections).toBe(2);
+      expect(flaky.lastEventIds).toEqual([undefined, "1"]);
+    });
+
+    test("with reconnect disabled a dropped stream surfaces as an error after the events received so far", async () => {
+      resetFlaky();
+      const received: any[] = [];
+      let error: any;
+      try {
+        for await (const chunk of protocol.callToolStreaming(mockClient, "sse_server.flaky", {}, template({
+          url: `http://localhost:${serverPort}/flaky`,
+          reconnect: false,
+          retry_timeout: 10,
+        }))) {
+          received.push(chunk);
+        }
+      } catch (e) {
+        error = e;
+      }
+      expect(error).toBeDefined();
+      expect(received).toEqual([{ seq: 1 }]);
+      expect(flaky.connections).toBe(1);
+    });
+
+    test("gives up after MAX_RECONNECT_ATTEMPTS so a tool call cannot hang forever", async () => {
+      resetFlaky(true);
+      const gen = protocol.callTool(mockClient, "sse_server.flaky", {}, template({
+        url: `http://localhost:${serverPort}/flaky`,
+        reconnect: true,
+        retry_timeout: 10,
+      }));
+      await expect(gen).rejects.toBeDefined();
+      expect(flaky.connections).toBe(1 + SseCommunicationProtocol.MAX_RECONNECT_ATTEMPTS);
+    });
+  });
+});

--- a/packages/http/tests/streamable_http_communication_protocol.test.ts
+++ b/packages/http/tests/streamable_http_communication_protocol.test.ts
@@ -14,6 +14,9 @@ let serverPort: number;
 const mockClient = {} as IUtcpClient;
 
 const BINARY_PAYLOAD = Buffer.alloc(10_000, 7); // 10,000 bytes of 0x07
+const tokenHits = { a: 0, b: 0 };
+// Token responses deliberately left unanswered; ended by the test that opened them.
+const hangingToken: express.Response[] = [];
 
 beforeAll(async () => {
   app = express();
@@ -85,6 +88,28 @@ beforeAll(async () => {
 
   app.get("/error", (req, res) => {
     res.status(500).json({ error: "Internal Server Error" });
+  });
+
+  app.post("/token-a", (req, res) => {
+    tokenHits.a += 1;
+    res.json({ access_token: "token-a", expires_in: 3600 });
+  });
+  app.post("/token-b", (req, res) => {
+    tokenHits.b += 1;
+    res.json({ access_token: "token-b", expires_in: 3600 });
+  });
+  app.post("/token-hang", (req, res) => {
+    hangingToken.push(res);
+  });
+  app.get("/whoami", (req, res) => {
+    res.setHeader('Content-Type', 'application/x-ndjson');
+    res.write(JSON.stringify({ auth: req.headers.authorization ?? null }) + "\n");
+    res.end();
+  });
+  app.get("/pair/:a/:b", (req, res) => {
+    res.setHeader('Content-Type', 'application/x-ndjson');
+    res.write(JSON.stringify(req.params) + "\n");
+    res.end();
   });
 
   await new Promise<void>((resolve) => {
@@ -202,5 +227,56 @@ describe("StreamableHttpCommunicationProtocol", () => {
   test("wrong call template type is rejected", async () => {
     const gen = protocol.callToolStreaming(mockClient, "x", {}, { name: "x", call_template_type: "http" } as any);
     await expect(gen.next()).rejects.toThrow(/StreamableHttpCallTemplate/);
+  });
+
+  describe("review follow-ups", () => {
+    test("GET with a body_field fails with a clear error instead of a fetch TypeError", async () => {
+      const gen = protocol.callToolStreaming(mockClient, "stream_server.t", { payload: { n: 1 } }, template({
+        url: `http://localhost:${serverPort}/ndjson`,
+        http_method: "GET",
+        body_field: "payload",
+      }));
+      await expect(gen.next()).rejects.toThrow(/http_method is GET/);
+    });
+
+    test("OAuth2 tokens are cached per token endpoint, not per client_id", async () => {
+      tokenHits.a = 0;
+      tokenHits.b = 0;
+      const oauth = (tokenUrl: string) => ({
+        auth_type: "oauth2",
+        token_url: tokenUrl,
+        client_id: "shared-id",
+        client_secret: "s",
+      } as any);
+      const whoami = (tokenUrl: string) =>
+        protocol.callTool(mockClient, "stream_server.t", {}, template({ url: `http://localhost:${serverPort}/whoami`, auth: oauth(tokenUrl) }));
+
+      expect(await whoami(`http://localhost:${serverPort}/token-a`)).toEqual([{ auth: "Bearer token-a" }]);
+      expect(await whoami(`http://localhost:${serverPort}/token-b`)).toEqual([{ auth: "Bearer token-b" }]);
+      expect(await whoami(`http://localhost:${serverPort}/token-a`)).toEqual([{ auth: "Bearer token-a" }]);
+      expect(tokenHits).toEqual({ a: 1, b: 1 });
+    });
+
+    test("a stalled OAuth2 token endpoint is bounded by the call timeout", async () => {
+      const started = Date.now();
+      const call = protocol.callTool(mockClient, "stream_server.t", {}, template({
+        url: `http://localhost:${serverPort}/whoami`,
+        timeout: 300,
+        auth: { auth_type: "oauth2", token_url: `http://localhost:${serverPort}/token-hang`, client_id: "c", client_secret: "s" } as any,
+      }));
+      try {
+        await expect(call).rejects.toThrow(/Failed to fetch OAuth2 token/);
+        expect(Date.now() - started).toBeLessThan(3000);
+      } finally {
+        for (const r of hangingToken.splice(0)) r.end();
+      }
+    });
+
+    test("repeated and ${param}-style path parameters are all substituted", async () => {
+      const result = await protocol.callTool(mockClient, "stream_server.t", { id: "x" }, template({
+        url: `http://localhost:${serverPort}/pair/{id}/\${id}`,
+      }));
+      expect(result).toEqual([{ a: "x", b: "x" }]);
+    });
   });
 });

--- a/packages/http/tests/streamable_http_communication_protocol.test.ts
+++ b/packages/http/tests/streamable_http_communication_protocol.test.ts
@@ -239,6 +239,15 @@ describe("StreamableHttpCommunicationProtocol", () => {
       await expect(gen.next()).rejects.toThrow(/http_method is GET/);
     });
 
+    test("GET with a body_field supplied as undefined is still rejected, not silently dropped", async () => {
+      const gen = protocol.callToolStreaming(mockClient, "stream_server.t", { payload: undefined }, template({
+        url: `http://localhost:${serverPort}/ndjson`,
+        http_method: "GET",
+        body_field: "payload",
+      }));
+      await expect(gen.next()).rejects.toThrow(/http_method is GET/);
+    });
+
     test("OAuth2 tokens are cached per token endpoint, not per client_id", async () => {
       tokenHits.a = 0;
       tokenHits.b = 0;
@@ -257,16 +266,18 @@ describe("StreamableHttpCommunicationProtocol", () => {
       expect(tokenHits).toEqual({ a: 1, b: 1 });
     });
 
-    test("a stalled OAuth2 token endpoint is bounded by the call timeout", async () => {
+    test("a stalled OAuth2 token endpoint is bounded by the call timeout, once, not per credential method", async () => {
       const started = Date.now();
       const call = protocol.callTool(mockClient, "stream_server.t", {}, template({
         url: `http://localhost:${serverPort}/whoami`,
-        timeout: 300,
+        timeout: 800,
         auth: { auth_type: "oauth2", token_url: `http://localhost:${serverPort}/token-hang`, client_id: "c", client_secret: "s" } as any,
       }));
       try {
         await expect(call).rejects.toThrow(/Failed to fetch OAuth2 token/);
-        expect(Date.now() - started).toBeLessThan(3000);
+        // Two credential methods with a fresh 800 ms budget each would take
+        // about 1600 ms; a single shared deadline finishes just after 800 ms.
+        expect(Date.now() - started).toBeLessThan(1300);
       } finally {
         for (const r of hangingToken.splice(0)) r.end();
       }

--- a/packages/http/tests/streamable_http_communication_protocol.test.ts
+++ b/packages/http/tests/streamable_http_communication_protocol.test.ts
@@ -1,0 +1,206 @@
+// packages/http/tests/streamable_http_communication_protocol.test.ts
+import { test, expect, describe, beforeAll, afterAll } from "bun:test";
+import express, { Express } from 'express';
+import { Server } from 'http';
+// Import from package index to trigger auto-registration
+import { StreamableHttpCommunicationProtocol, StreamableHttpCallTemplate } from "@utcp/http";
+import { IUtcpClient } from "@utcp/sdk";
+
+// --- Test Server Setup ---
+let app: Express;
+let server: Server;
+let serverPort: number;
+
+const mockClient = {} as IUtcpClient;
+
+const BINARY_PAYLOAD = Buffer.alloc(10_000, 7); // 10,000 bytes of 0x07
+
+beforeAll(async () => {
+  app = express();
+  app.use(express.json());
+
+  app.get("/utcp", (req, res) => {
+    res.json({
+      utcp_version: "1.0.1",
+      manual_version: "1.0.0",
+      tools: [{
+        name: "stream_tool",
+        description: "A streaming test tool",
+        tool_call_template: {
+          name: "stream_server",
+          call_template_type: 'streamable_http',
+          url: `http://localhost:${serverPort}/ndjson`,
+          http_method: 'GET',
+        }
+      }]
+    });
+  });
+
+  app.get("/ndjson", (req, res) => {
+    res.setHeader('Content-Type', 'application/x-ndjson');
+    res.setHeader('Transfer-Encoding', 'chunked');
+    res.write(JSON.stringify({ seq: 1, query: req.query }) + "\n");
+    setTimeout(() => {
+      res.write(JSON.stringify({ seq: 2 }) + "\n");
+      setTimeout(() => {
+        res.write(JSON.stringify({ seq: 3 }) + "\n");
+        res.end();
+      }, 10);
+    }, 10);
+  });
+
+  app.post("/ndjson-echo", (req, res) => {
+    res.setHeader('Content-Type', 'application/x-ndjson');
+    res.write(JSON.stringify({ body: req.body, header: req.headers['x-custom'] ?? null }) + "\n");
+    res.end();
+  });
+
+  app.get("/json", (req, res) => {
+    res.json({ hello: "world", query: req.query });
+  });
+
+  app.get("/binary", (req, res) => {
+    res.setHeader('Content-Type', 'application/octet-stream');
+    // Write in a few pieces to exercise re-chunking.
+    res.write(BINARY_PAYLOAD.subarray(0, 3000));
+    res.write(BINARY_PAYLOAD.subarray(3000, 7500));
+    res.write(BINARY_PAYLOAD.subarray(7500));
+    res.end();
+  });
+
+  app.get("/items/:id/detail", (req, res) => {
+    res.setHeader('Content-Type', 'application/x-ndjson');
+    res.write(JSON.stringify({ id: req.params.id, query: req.query }) + "\n");
+    res.end();
+  });
+
+  app.get("/auth", (req, res) => {
+    if (req.headers['x-api-key'] !== 'secret') {
+      return res.status(401).json({ error: "unauthorized" });
+    }
+    res.setHeader('Content-Type', 'application/x-ndjson');
+    res.write(JSON.stringify({ ok: true }) + "\n");
+    res.end();
+  });
+
+  app.get("/error", (req, res) => {
+    res.status(500).json({ error: "Internal Server Error" });
+  });
+
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, () => {
+      serverPort = (server.address() as any).port;
+      resolve();
+    });
+  });
+});
+
+afterAll(() => {
+  return new Promise<void>((resolve) => {
+    server.close(() => resolve());
+  });
+});
+
+const template = (overrides: Partial<StreamableHttpCallTemplate> & { url: string }): StreamableHttpCallTemplate => ({
+  name: "stream_server",
+  call_template_type: "streamable_http",
+  http_method: "GET",
+  content_type: "application/json",
+  chunk_size: 4096,
+  timeout: 5000,
+  ...overrides,
+});
+
+describe("StreamableHttpCommunicationProtocol", () => {
+  const protocol = new StreamableHttpCommunicationProtocol();
+
+  test("registerManual discovers tools from a manual endpoint", async () => {
+    const result = await protocol.registerManual(mockClient, template({ url: `http://localhost:${serverPort}/utcp` }));
+    expect(result.success).toBe(true);
+    expect(result.manual.tools).toHaveLength(1);
+    expect(result.manual.tools[0]?.name).toBe("stream_tool");
+  });
+
+  test("callToolStreaming yields one parsed object per NDJSON line", async () => {
+    const chunks: any[] = [];
+    for await (const chunk of protocol.callToolStreaming(mockClient, "stream_server.stream_tool", { q: "x" }, template({ url: `http://localhost:${serverPort}/ndjson` }))) {
+      chunks.push(chunk);
+    }
+    expect(chunks).toHaveLength(3);
+    expect(chunks[0]).toEqual({ seq: 1, query: { q: "x" } });
+    expect(chunks[1]).toEqual({ seq: 2 });
+    expect(chunks[2]).toEqual({ seq: 3 });
+  });
+
+  test("callTool collects NDJSON chunks into an array", async () => {
+    const result = await protocol.callTool(mockClient, "stream_server.stream_tool", {}, template({ url: `http://localhost:${serverPort}/ndjson` }));
+    expect(Array.isArray(result)).toBe(true);
+    expect(result.map((c: any) => c.seq)).toEqual([1, 2, 3]);
+  });
+
+  test("application/json responses are yielded as a single parsed value", async () => {
+    const chunks: any[] = [];
+    for await (const chunk of protocol.callToolStreaming(mockClient, "stream_server.json_tool", { a: "1" }, template({ url: `http://localhost:${serverPort}/json` }))) {
+      chunks.push(chunk);
+    }
+    expect(chunks).toEqual([{ hello: "world", query: { a: "1" } }]);
+  });
+
+  test("binary responses are re-chunked to chunk_size and concatenated by callTool", async () => {
+    const chunks: Buffer[] = [];
+    for await (const chunk of protocol.callToolStreaming(mockClient, "stream_server.bin", {}, template({ url: `http://localhost:${serverPort}/binary`, chunk_size: 4096 }))) {
+      expect(Buffer.isBuffer(chunk)).toBe(true);
+      expect(chunk.length).toBeLessThanOrEqual(4096);
+      chunks.push(chunk);
+    }
+    expect(Buffer.concat(chunks).equals(BINARY_PAYLOAD)).toBe(true);
+    // 10,000 bytes at 4096 per chunk -> 4096, 4096, 1808
+    expect(chunks.map(c => c.length)).toEqual([4096, 4096, 1808]);
+
+    const full = await protocol.callTool(mockClient, "stream_server.bin", {}, template({ url: `http://localhost:${serverPort}/binary` }));
+    expect(Buffer.isBuffer(full)).toBe(true);
+    expect((full as Buffer).equals(BINARY_PAYLOAD)).toBe(true);
+  });
+
+  test("POST sends body_field as JSON body and header_fields as headers", async () => {
+    const result = await protocol.callTool(mockClient, "stream_server.echo", { payload: { n: 42 }, "x-custom": "hdr" }, template({
+      url: `http://localhost:${serverPort}/ndjson-echo`,
+      http_method: "POST",
+      body_field: "payload",
+      header_fields: ["x-custom"],
+    }));
+    expect(result).toEqual([{ body: { n: 42 }, header: "hdr" }]);
+  });
+
+  test("path parameters are substituted and the rest become query params", async () => {
+    const result = await protocol.callTool(mockClient, "stream_server.detail", { id: "abc/1", limit: 5 }, template({
+      url: `http://localhost:${serverPort}/items/{id}/detail`,
+    }));
+    expect(result).toEqual([{ id: "abc/1", query: { limit: "5" } }]);
+  });
+
+  test("missing path parameters throw", async () => {
+    const gen = protocol.callToolStreaming(mockClient, "stream_server.detail", {}, template({
+      url: `http://localhost:${serverPort}/items/{id}/detail`,
+    }));
+    await expect(gen.next()).rejects.toThrow(/Missing required path parameter/);
+  });
+
+  test("API key auth in header is applied", async () => {
+    const result = await protocol.callTool(mockClient, "stream_server.auth", {}, template({
+      url: `http://localhost:${serverPort}/auth`,
+      auth: { auth_type: "api_key", api_key: "secret", var_name: "x-api-key", location: "header" } as any,
+    }));
+    expect(result).toEqual([{ ok: true }]);
+  });
+
+  test("non-2xx responses reject", async () => {
+    const gen = protocol.callToolStreaming(mockClient, "stream_server.err", {}, template({ url: `http://localhost:${serverPort}/error` }));
+    await expect(gen.next()).rejects.toThrow(/HTTP 500/);
+  });
+
+  test("wrong call template type is rejected", async () => {
+    const gen = protocol.callToolStreaming(mockClient, "x", {}, { name: "x", call_template_type: "http" } as any);
+    await expect(gen.next()).rejects.toThrow(/StreamableHttpCallTemplate/);
+  });
+});


### PR DESCRIPTION
## Summary

Makes `callTool` and `callToolStreaming` work for every protocol in the repo. Companion to universal-tool-calling-protocol/python-utcp#100.

**CLI**
- `callToolStreaming` threw on every call. It now runs the command and yields the full result as a single chunk, like the HTTP protocol. README limitation note updated.

**Streamable HTTP and SSE were placeholder stubs.** Both were registered in the package index but yielded a fake string such as `"SSE event for tool: name"` and never contacted the server. They are now real implementations ported from python-utcp:
- Path parameter substitution, `header_fields`, `body_field`, remaining args as query params.
- API key (header/query/cookie), Basic, OAuth2 client credentials with token caching, and OAuth2 user auth. Cookies are now actually sent; the old stubs computed them and dropped them.
- URL re-validation before each call, `redirect: 'error'`, timeout via AbortController (Streamable HTTP), and reader cancellation when the consumer stops early.

**Streamable HTTP** yields by response content type: NDJSON as one parsed object per line, JSON as a single value, everything else as `Buffer` chunks re-sliced to `chunk_size`. `callTool` concatenates binary chunks into one Buffer or returns parsed chunks as an array, matching Python.

**SSE** parses the wire format incrementally (comments, multi-line data, id, retry, CRLF, trailing unterminated event), JSON-parses each payload when possible, filters by `event_type`, and implements the `reconnect` / `retry_timeout` fields:
- When an established stream drops, wait `retry_timeout` ms (overridden by a server `retry:` field), reconnect with `Last-Event-ID`, give up after `MAX_RECONNECT_ATTEMPTS` (5) per call.
- A clean end of stream completes the call and never reconnects. Connection or HTTP errors on the initial request fail immediately.

**Runtime note.** Streaming fetches pass `keepalive: false`. Bun's fetch transparently re-issues a request when a reused pooled socket dies mid-response, even after part of the body arrived. That bypassed the reconnect logic (no `Last-Event-ID`, `reconnect: false` ignored) and could hand consumers partial chunks followed by a full replay. Opting streams out of the pool fixes it; Node ignores the option. `Connection: close` was considered and rejected because under Node it makes an abrupt disconnect look like a clean end of stream.

## Test plan
- [x] New `sse_communication_protocol.test.ts` and `streamable_http_communication_protocol.test.ts` against real express servers: discovery, NDJSON/JSON/binary re-chunking, POST bodies, header fields, path params, auth, error statuses, event filtering, CRLF, reconnect resume with `Last-Event-ID`, `reconnect: false`, attempt cap
- [x] New CLI single-chunk streaming test
- [x] `bun test packages/http` 113 pass (3 runs), `bun test packages/cli` 7 pass
- [x] `bun run build` in packages/http succeeds including DTS
- [x] Built package exercised under Node 22.17 and Bun 1.2.22 with keep-alive sockets in the pool: all reconnect scenarios pass on both

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `callTool` and `callToolStreaming` work for every protocol: CLI streaming previously threw and now runs the command to completion and yields the full result as a single chunk, while the SSE and Streamable HTTP protocols replace placeholder stubs that never contacted the server with real implementations. Both handle path/header/body/query argument mapping, API key/Basic/OAuth2/OAuth2-user auth with real cookie sending, and URL re-validation with `redirect: 'error'`; streaming fetches pass `keepalive: false` because Bun's fetch would otherwise transparently re-issue a request when a pooled socket dies mid-response, bypassing reconnect logic and replaying partial chunks.

**SSE**
- Parses the wire format incrementally (comments, multi-line data, id, retry, CRLF, trailing events), filters by `event_type`, and JSON-parses payloads when possible.
- Reconnects a dropped established stream with `Last-Event-ID` after `retry_timeout` (or the server's `retry:` field), capped at 5 attempts per call; a clean end of stream completes the call and initial connection or HTTP errors fail immediately.
- Bounds the handshake and OAuth2 token fetch to 30 s, caps the reconnect delay at 60 s, counts failed reconnect handshakes as attempts, and treats an over-buffered stream without a delimiter as a non-retryable protocol error; a CRLF split across reads no longer ends an event early.

**Streamable HTTP**
- Yields one parsed object per NDJSON line, a single parsed value for JSON, or Buffers re-sliced to `chunk_size`; `callTool` concatenates binary chunks or returns parsed chunks as an array.
- One `AbortController` deadline covers the OAuth2 token fetch, request, and stream, and its timer is cleared even when URL/body construction throws; the reader is cancelled when the consumer stops early, and `body_field` on GET is rejected up front even when supplied as `undefined`.
- Caches OAuth2 tokens per token endpoint (not per `client_id`) and validates the token URL before consulting it.
- Substitutes every occurrence of `{param}` and `${param}` path parameters.

<sup>Written for commit c46ae1a8499624b951924c09e95f6983ca10233f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/universal-tool-calling-protocol/typescript-utcp/pull/41?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

