### PR TITLE
Dev

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -509,7 +509,7 @@ const result = await client.callTool('git_commit_push', {
 
 ## Limitations
 
-- **No Streaming Support**: The CLI protocol does not support streaming. All output is returned when the command completes.
+- **No Native Streaming**: The CLI protocol does not stream output incrementally. `callToolStreaming` works, but it runs the command to completion and yields the full result as a single chunk.
 - **Platform-Specific**: Commands must be written for the target platform (Windows/Unix).
 - **No Interactive Commands**: Interactive CLI tools (that require user input) are not supported.
 - **Fixed Timeouts**: Timeout durations are currently fixed (though generous).

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@utcp/cli",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "CLI utilities for UTCP",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/packages/cli/src/cli_communication_protocol.ts
+++ b/packages/cli/src/cli_communication_protocol.ts
@@ -757,12 +757,15 @@ export class CliCommunicationProtocol implements CommunicationProtocol {
 
   /**
    * REQUIRED
-   * Streaming calls are not supported for the CLI protocol.
+   * Execute a tool call through the CLI transport streamingly.
    *
-   * @throws Error Always, as this functionality is not supported.
+   * The CLI protocol does not natively support streaming, so the command is
+   * executed to completion and the full result is yielded as a single chunk.
    */
   public async *callToolStreaming(caller: IUtcpClient, toolName: string, toolArgs: Record<string, any>, toolCallTemplate: CallTemplate): AsyncGenerator<any, void, unknown> {
-    throw new Error('Streaming is not supported by the CLI communication protocol.');
+    this._log_info(`CLI protocol does not inherently support streaming for '${toolName}'. Fetching full response as a single chunk.`);
+    const result = await this.callTool(caller, toolName, toolArgs, toolCallTemplate);
+    yield result;
   }
 
   public async close(): Promise<void> {

--- a/packages/cli/tests/cli_communication_protocol.test.ts
+++ b/packages/cli/tests/cli_communication_protocol.test.ts
@@ -41,6 +41,25 @@ describe('CliCommunicationProtocol (Multi-Command)', () => {
     expect(result.trim()).toBe('Step 2');
   });
 
+  test('should emit the full result as a single chunk when called in streaming mode', async () => {
+    const callTemplate: CliCallTemplate = CliCallTemplateSchema.parse({
+      name: 'streaming_test',
+      call_template_type: 'cli',
+      commands: [
+        { command: 'echo "Step 1"', append_to_final_output: false },
+        { command: 'echo "Step 2"' },
+      ],
+    });
+
+    const chunks: any[] = [];
+    for await (const chunk of cliProtocol.callToolStreaming(mockClient, 'test.workflow', {}, callTemplate)) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toHaveLength(1);
+    expect(String(chunks[0]).trim()).toBe('Step 2');
+  });
+
   test('should preserve state (current directory) between commands', async () => {
     const tempDir = await createTempDir('state_test_dir');
     const finalCommand = isWindows ? 'Write-Output (Get-Location).Path' : 'pwd';

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -132,7 +132,7 @@ Automatically converts OpenAPI specifications to UTCP tools:
 
 **SSE**
 - ✅ Real-time event streaming
-- ✅ Automatic reconnection (resumes with `Last-Event-ID`, at most 5 reconnects per call; a clean end of stream completes the call and initial connection/HTTP errors fail immediately)
+- ✅ Automatic reconnection (resumes with `Last-Event-ID`, at most 5 reconnects per call with the delay capped at 60 s; a failed reconnect handshake counts as an attempt; a clean end of stream completes the call and initial connection/HTTP errors fail immediately; the handshake is limited to 30 s)
 - ✅ Event type filtering
 - ✅ Server push updates
 - ❌ Unidirectional (server → client only)

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -62,8 +62,8 @@ interface SseCallTemplate {
   call_template_type: 'sse';
   url: string;
   event_type?: string;        // Filter specific event types
-  reconnect?: boolean;        // Auto-reconnect on disconnect
-  retry_timeout?: number;     // Reconnection timeout (ms)
+  reconnect?: boolean;        // Auto-reconnect if an established stream drops (default: true)
+  retry_timeout?: number;     // Delay before reconnecting (ms, default: 30000); a server "retry:" field overrides it
   headers?: Record<string, string>;
   body_field?: string;
   header_fields?: string[];
@@ -132,7 +132,7 @@ Automatically converts OpenAPI specifications to UTCP tools:
 
 **SSE**
 - ✅ Real-time event streaming
-- ✅ Automatic reconnection
+- ✅ Automatic reconnection (resumes with `Last-Event-ID`, at most 5 reconnects per call; a clean end of stream completes the call and initial connection/HTTP errors fail immediately)
 - ✅ Event type filtering
 - ✅ Server push updates
 - ❌ Unidirectional (server → client only)

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -44,7 +44,7 @@ interface StreamableHttpCallTemplate {
   http_method: 'GET' | 'POST';
   content_type?: string;
   chunk_size?: number;        // Default: 4096 bytes
-  timeout?: number;           // Default: 60000ms
+  timeout?: number;           // Default: 60000ms. One deadline for the whole call: token fetch, request and stream
   headers?: Record<string, string>;
   body_field?: string;
   header_fields?: string[];
@@ -61,7 +61,7 @@ interface SseCallTemplate {
   name: string;
   call_template_type: 'sse';
   url: string;
-  event_type?: string;        // Filter specific event types
+  event_type?: string;        // Filter specific event types; events without an `event:` field have the type "message"
   reconnect?: boolean;        // Auto-reconnect if an established stream drops (default: true)
   retry_timeout?: number;     // Delay before reconnecting (ms, default: 30000); a server "retry:" field overrides it
   headers?: Record<string, string>;
@@ -132,7 +132,7 @@ Automatically converts OpenAPI specifications to UTCP tools:
 
 **SSE**
 - ✅ Real-time event streaming
-- ✅ Automatic reconnection (resumes with `Last-Event-ID`, at most 5 reconnects per call with the delay capped at 60 s; a failed reconnect handshake counts as an attempt; a clean end of stream completes the call and initial connection/HTTP errors fail immediately; the handshake is limited to 30 s)
+- ✅ Automatic reconnection for GET streams (resumes with `Last-Event-ID`, at most 5 reconnects per call with the delay capped at 60 s; a failed reconnect handshake counts as an attempt; a clean end of stream completes the call and initial connection/HTTP errors fail immediately; the handshake is limited to 30 s). Calls that send a request body (`body_field`) are never re-issued, since that could re-execute a non-idempotent tool
 - ✅ Event type filtering
 - ✅ Server push updates
 - ❌ Unidirectional (server → client only)

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@utcp/http",
-  "version": "1.1.11",
+  "version": "1.1.12",
   "description": "HTTP utilities for UTCP",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/packages/http/src/_auth.ts
+++ b/packages/http/src/_auth.ts
@@ -1,0 +1,190 @@
+// packages/http/src/_auth.ts
+//
+// Authentication helpers shared by the fetch-based SSE and Streamable HTTP
+// protocols, so a security fix (token URL validation, cache keying, header
+// injection checks) lands in one place.
+import { Auth, ApiKeyAuth, BasicAuth, OAuth2Auth, OAuth2UserAuth } from '@utcp/sdk';
+import { ensureSecureUrl, assertNoCrlf } from './_security';
+
+export interface AuthLogger {
+  info(message: string): void;
+  error(message: string): void;
+}
+
+export interface BasicCredentials {
+  username: string;
+  password: string;
+}
+
+export type OAuthTokenCache = Map<string, { access_token: string; expires_at?: number }>;
+
+/**
+ * Apply a call template's auth to the request: API keys go to a header, the
+ * query string or a cookie; Basic credentials are returned for the caller to
+ * encode; a user-provisioned OAuth2 token goes to its header. OAuth2 client
+ * credentials are handled separately (async) by finalizeAuthHeaders.
+ */
+export function applyAuth(
+  auth: Auth | undefined,
+  headers: Record<string, string>,
+  queryParams: Record<string, any>,
+  log: AuthLogger,
+): { auth?: BasicCredentials; cookies: Record<string, string> } {
+  let basic: BasicCredentials | undefined;
+  const cookies: Record<string, string> = {};
+
+  if (auth) {
+    if ('api_key' in auth) {
+      const apiKeyAuth = auth as ApiKeyAuth;
+      if (apiKeyAuth.api_key) {
+        assertNoCrlf(apiKeyAuth.var_name, 'ApiKeyAuth.var_name');
+        // Default to 'header' if location is not specified
+        const location = apiKeyAuth.location || 'header';
+        if (location === 'header') {
+          headers[apiKeyAuth.var_name] = apiKeyAuth.api_key;
+        } else if (location === 'query') {
+          queryParams[apiKeyAuth.var_name] = apiKeyAuth.api_key;
+        } else if (location === 'cookie') {
+          cookies[apiKeyAuth.var_name] = apiKeyAuth.api_key;
+        }
+      } else {
+        log.error('API key not found for ApiKeyAuth.');
+        throw new Error('API key for ApiKeyAuth not found.');
+      }
+    } else if ('username' in auth && 'password' in auth) {
+      const basicAuth = auth as BasicAuth;
+      basic = { username: basicAuth.username, password: basicAuth.password };
+    } else if ('token_url' in auth) {
+      // OAuth2 client credentials are fetched asynchronously later.
+    } else if (auth.auth_type === 'oauth2_user') {
+      // Interactive (user-delegated) OAuth2: token provisioned out-of-band.
+      const userAuth = auth as OAuth2UserAuth;
+      if (!userAuth.access_token) {
+        throw new Error(
+          "access_token for oauth2_user auth is empty. Run an interactive " +
+            "login to provision it.",
+        );
+      }
+      const headerName = userAuth.var_name || 'Authorization';
+      const prefix = userAuth.prefix ?? 'Bearer ';
+      assertNoCrlf(headerName, 'OAuth2UserAuth.var_name');
+      assertNoCrlf(prefix, 'OAuth2UserAuth.prefix');
+      assertNoCrlf(userAuth.access_token, 'OAuth2UserAuth.access_token');
+      headers[headerName] = `${prefix}${userAuth.access_token}`;
+    }
+  }
+
+  return { auth: basic, cookies };
+}
+
+/**
+ * Apply Basic auth, cookies and (if configured) an OAuth2 client-credentials
+ * bearer token to the request headers. The token fetch runs under `signal`.
+ */
+export async function finalizeAuthHeaders(
+  auth: Auth | undefined,
+  headers: Record<string, string>,
+  basic: BasicCredentials | undefined,
+  cookies: Record<string, string>,
+  signal: AbortSignal,
+  tokenCache: OAuthTokenCache,
+  log: AuthLogger,
+): Promise<void> {
+  if (basic) {
+    const credentials = Buffer.from(`${basic.username}:${basic.password}`).toString('base64');
+    headers['Authorization'] = `Basic ${credentials}`;
+  }
+
+  if (Object.keys(cookies).length > 0) {
+    const cookieHeader = Object.entries(cookies)
+      .map(([k, v]) => `${k}=${v}`)
+      .join('; ');
+    assertNoCrlf(cookieHeader, 'Cookie');
+    headers['Cookie'] = headers['Cookie'] ? `${headers['Cookie']}; ${cookieHeader}` : cookieHeader;
+  }
+
+  if (auth && 'token_url' in auth) {
+    const token = await fetchOAuth2Token(auth as OAuth2Auth, signal, tokenCache, log);
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+}
+
+/**
+ * OAuth2 client-credentials flow: credentials in the body first, then as a
+ * Basic Auth header. Tokens are cached per full OAuth configuration (token
+ * URL, client id, secret, scope), never per client_id alone: two templates
+ * may share a client_id but point at different issuers. Both credential
+ * methods run under the caller's `signal`, which carries the call's own
+ * deadline, so the whole token flow can never exceed it.
+ */
+export async function fetchOAuth2Token(
+  authDetails: OAuth2Auth,
+  signal: AbortSignal,
+  tokenCache: OAuthTokenCache,
+  log: AuthLogger,
+): Promise<string> {
+  const clientId = authDetails.client_id;
+
+  // The token URL may come from an untrusted call template; validate it
+  // before the cache is consulted, so a template with a rejected URL never
+  // receives a token fetched on behalf of another (GHSA-8cp3-qxj6-px34).
+  ensureSecureUrl(authDetails.token_url, 'OAuth2 token URL');
+
+  const cacheKey = JSON.stringify([authDetails.token_url, clientId, authDetails.client_secret, authDetails.scope || '']);
+  const cached = tokenCache.get(cacheKey);
+  if (cached && (cached.expires_at === undefined || cached.expires_at > Date.now())) {
+    return cached.access_token;
+  }
+
+  const storeToken = (tokenData: any): string => {
+    if (!tokenData || !tokenData.access_token) {
+      throw new Error('Access token not found in response.');
+    }
+    const expiresIn = typeof tokenData.expires_in === 'number' ? tokenData.expires_in : 3600;
+    tokenCache.set(cacheKey, { access_token: tokenData.access_token, expires_at: Date.now() + expiresIn * 1000 });
+    return tokenData.access_token;
+  };
+
+  const requestToken = async (headers: Record<string, string>, form: Record<string, string>): Promise<string> => {
+    if (signal.aborted) {
+      throw new Error('Timed out before the token request could start.');
+    }
+    const response = await fetch(authDetails.token_url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded', ...headers },
+      body: new URLSearchParams(form).toString(),
+      redirect: 'error',
+      signal,
+    });
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    }
+    return storeToken(await response.json());
+  };
+
+  // Method 1: credentials in the request body
+  try {
+    log.info(`Attempting OAuth2 token fetch for '${clientId}' with credentials in body.`);
+    return await requestToken({}, {
+      grant_type: 'client_credentials',
+      client_id: clientId,
+      client_secret: authDetails.client_secret,
+      scope: authDetails.scope || '',
+    });
+  } catch (error: any) {
+    log.error(`OAuth2 with credentials in body failed for '${clientId}': ${error.message}. Trying Basic Auth header.`);
+  }
+
+  // Method 2: credentials as a Basic Auth header
+  try {
+    log.info(`Attempting OAuth2 token fetch for '${clientId}' with Basic Auth header.`);
+    const credentials = Buffer.from(`${clientId}:${authDetails.client_secret}`).toString('base64');
+    return await requestToken({ 'Authorization': `Basic ${credentials}` }, {
+      grant_type: 'client_credentials',
+      scope: authDetails.scope || '',
+    });
+  } catch (error: any) {
+    log.error(`OAuth2 with Basic Auth header also failed for '${clientId}': ${error.message}`);
+    throw new Error(`Failed to fetch OAuth2 token for client '${clientId}' after trying all methods. Details: ${error.message}`);
+  }
+}

--- a/packages/http/src/_auth.ts
+++ b/packages/http/src/_auth.ts
@@ -157,6 +157,12 @@ export async function fetchOAuth2Token(
       signal,
     });
     if (!response.ok) {
+      // Release the connection before the Basic-Auth retry.
+      try {
+        await response.body?.cancel();
+      } catch {
+        // ignore
+      }
       throw new Error(`HTTP ${response.status}: ${response.statusText}`);
     }
     return storeToken(await response.json());

--- a/packages/http/src/_text.ts
+++ b/packages/http/src/_text.ts
@@ -1,0 +1,29 @@
+// packages/http/src/_text.ts
+
+/**
+ * Truncate `text` to at most `maxCodePoints` Unicode code points, appending
+ * an ellipsis when anything was cut.
+ *
+ * Works by code point rather than UTF-16 unit so a surrogate pair on the
+ * boundary is dropped whole instead of leaving a lone surrogate. Walks the
+ * string with an iterator and stops at the cap, so a multi-megabyte error
+ * body costs O(cap) work and allocation rather than an array of every
+ * character in the body.
+ */
+export function truncateByCodePoint(text: string, maxCodePoints: number): string {
+  // A string of N UTF-16 units has at most N code points, so short strings
+  // need no walk at all.
+  if (text.length <= maxCodePoints) {
+    return text;
+  }
+  let kept = '';
+  let count = 0;
+  for (const codePoint of text) {
+    if (count === maxCodePoints) {
+      return `${kept}…`;
+    }
+    kept += codePoint;
+    count += 1;
+  }
+  return kept;
+}

--- a/packages/http/src/_text.ts
+++ b/packages/http/src/_text.ts
@@ -63,8 +63,10 @@ export async function readErrorDetail(response: Response, maxChars: number): Pro
     while (bytes < MAX_ERROR_BODY_READ_BYTES) {
       const { done, value } = await reader.read();
       if (done) break;
-      bytes += value.length;
-      text += decoder.decode(value, { stream: true });
+      // A single oversized chunk must not defeat the budget either.
+      const chunk = value.subarray(0, MAX_ERROR_BODY_READ_BYTES - bytes);
+      bytes += chunk.length;
+      text += decoder.decode(chunk, { stream: true });
     }
     text += decoder.decode();
   } catch {

--- a/packages/http/src/_text.ts
+++ b/packages/http/src/_text.ts
@@ -35,7 +35,8 @@ export function truncateByCodePoint(text: string, maxCodePoints: number): string
  * escape sequences.
  */
 export function collapseControlChars(text: string): string {
-  return text.replace(/[\u0000-\u001f\u007f]+/g, ' ').trim();
+  // C0 and C1 control ranges: C1 (U+0080..U+009F) carries escape introducers too.
+  return text.replace(/[\u0000-\u001f\u007f-\u009f]+/g, ' ').trim();
 }
 
 /**

--- a/packages/http/src/_text.ts
+++ b/packages/http/src/_text.ts
@@ -27,3 +27,54 @@ export function truncateByCodePoint(text: string, maxCodePoints: number): string
   }
   return kept;
 }
+
+/**
+ * Collapse control characters (newlines, carriage returns, ANSI escape
+ * introducers, NUL) into single spaces so server-controlled text folded into
+ * an error message or a log line cannot forge extra log records or terminal
+ * escape sequences.
+ */
+export function collapseControlChars(text: string): string {
+  return text.replace(/[\u0000-\u001f\u007f]+/g, ' ').trim();
+}
+
+/**
+ * How much of an error response body is read at all. Error responses can come
+ * from an attacker-controlled endpoint, so the read is bounded up front rather
+ * than buffered in full and truncated afterwards.
+ */
+export const MAX_ERROR_BODY_READ_BYTES = 64 * 1024;
+
+/**
+ * Read the start of an error response body (at most MAX_ERROR_BODY_READ_BYTES),
+ * release the connection, and return it cleaned and truncated to `maxChars`
+ * code points. Returns '' when the body is empty or cannot be read.
+ */
+export async function readErrorDetail(response: Response, maxChars: number): Promise<string> {
+  const body = response.body;
+  if (!body) {
+    return '';
+  }
+  const reader = body.getReader();
+  const decoder = new TextDecoder('utf-8');
+  let text = '';
+  let bytes = 0;
+  try {
+    while (bytes < MAX_ERROR_BODY_READ_BYTES) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      bytes += value.length;
+      text += decoder.decode(value, { stream: true });
+    }
+    text += decoder.decode();
+  } catch {
+    // Whatever was read so far is still the best detail available.
+  } finally {
+    try {
+      await reader.cancel();
+    } catch {
+      // ignore
+    }
+  }
+  return truncateByCodePoint(collapseControlChars(text), maxChars);
+}

--- a/packages/http/src/_url.ts
+++ b/packages/http/src/_url.ts
@@ -1,0 +1,35 @@
+// packages/http/src/_url.ts
+
+/**
+ * Substitute path parameters into a URL template.
+ *
+ * Accepts both the `{param}` form from the UTCP spec and the `${param}` form
+ * this package's README documents. Every occurrence of a parameter is
+ * replaced (a template may repeat one), values are URL-encoded to prevent
+ * path injection, and consumed parameters are removed from `args` so they are
+ * not also sent as query parameters. Throws when a parameter is missing.
+ */
+export function buildUrlWithPathParams(urlTemplate: string, args: Record<string, any>): string {
+  let url = urlTemplate;
+  const placeholders = urlTemplate.match(/\$?\{([^}]+)\}/g) || [];
+  const paramNames = Array.from(new Set(
+    placeholders.map(p => (p.startsWith('${') ? p.slice(2, -1) : p.slice(1, -1)))
+  ));
+
+  for (const paramName of paramNames) {
+    if (!(paramName in args)) {
+      throw new Error(`Missing required path parameter: ${paramName}`);
+    }
+    // `${x}` goes first so that replacing `{x}` never leaves a stray `$`.
+    const value = encodeURIComponent(String(args[paramName]));
+    url = url.split('${' + paramName + '}').join(value).split('{' + paramName + '}').join(value);
+    delete args[paramName];
+  }
+
+  const remainingParams = url.match(/\$?\{([^}]+)\}/g);
+  if (remainingParams && remainingParams.length > 0) {
+    throw new Error(`Missing required path parameters in URL template: ${remainingParams.join(', ')}`);
+  }
+
+  return url;
+}

--- a/packages/http/src/_url.ts
+++ b/packages/http/src/_url.ts
@@ -17,7 +17,9 @@ export function buildUrlWithPathParams(urlTemplate: string, args: Record<string,
   ));
 
   for (const paramName of paramNames) {
-    if (!(paramName in args)) {
+    // Own properties only: `in` would accept inherited names such as
+    // `constructor` and substitute a stringified function.
+    if (!Object.prototype.hasOwnProperty.call(args, paramName)) {
       throw new Error(`Missing required path parameter: ${paramName}`);
     }
     // `${x}` goes first so that replacing `{x}` never leaves a stray `$`.

--- a/packages/http/src/http_communication_protocol.ts
+++ b/packages/http/src/http_communication_protocol.ts
@@ -247,12 +247,18 @@ export class HttpCommunicationProtocol implements CommunicationProtocol {
     }
     const status = error.response.status;
     const data = error.response.data;
+    // Prefer a string `error` / `message` / `detail` field from the body; some
+    // APIs nest an OBJECT there (e.g. { error: { code, reason } }), so only use
+    // the candidate when it's actually a string — otherwise fall through to the
+    // full JSON so the real structure shows instead of "[object Object]".
+    const stringField = (...candidates: unknown[]): string | undefined =>
+      candidates.find((c): c is string => typeof c === 'string');
     const detail =
       typeof data === 'string'
         ? data
         : data == null
           ? error.message
-          : (data.error ?? data.message ?? data.detail ?? JSON.stringify(data));
+          : (stringField(data.error, data.message, data.detail) ?? JSON.stringify(data));
     const normalized = new Error(
       `HTTP ${status} calling tool '${toolName}': ${detail}`,
     ) as Error & { status: number; data: unknown };

--- a/packages/http/src/http_communication_protocol.ts
+++ b/packages/http/src/http_communication_protocol.ts
@@ -222,8 +222,44 @@ export class HttpCommunicationProtocol implements CommunicationProtocol {
       return response.data;
     } catch (error: any) {
       this._logError(`Error calling HTTP tool '${toolName}':`, error);
-      throw error;
+      throw this._normalizeToolError(toolName, error);
     }
+  }
+
+  /**
+   * Turn a raw axios error into one that actually carries the server's response.
+   *
+   * On a non-2xx, axios throws an `AxiosError` whose `.message` is the generic
+   * `"Request failed with status code 403"` — the response BODY (where servers
+   * put the real reason, e.g. `{ "error": "..." }`) sits on `error.response.data`
+   * and is otherwise lost to every caller that only reads `.message`. That body
+   * is also dropped entirely when the error is serialized across a boundary
+   * (e.g. JSON.stringify in an isolated-vm tool runner), because `Error.message`
+   * is non-enumerable and `AxiosError` doesn't serialize its `response`.
+   *
+   * This folds the status + body into the message AND attaches enumerable
+   * `status` / `data` fields, so the reason survives both `.message` readers and
+   * structured serialization. Non-HTTP errors (network, timeout) pass through.
+   */
+  private _normalizeToolError(toolName: string, error: any): Error {
+    if (!axios.isAxiosError(error) || !error.response) {
+      return error instanceof Error ? error : new Error(String(error));
+    }
+    const status = error.response.status;
+    const data = error.response.data;
+    const detail =
+      typeof data === 'string'
+        ? data
+        : data == null
+          ? error.message
+          : (data.error ?? data.message ?? data.detail ?? JSON.stringify(data));
+    const normalized = new Error(
+      `HTTP ${status} calling tool '${toolName}': ${detail}`,
+    ) as Error & { status: number; data: unknown };
+    // Enumerable so they survive JSON.stringify out of an isolated-vm runner.
+    normalized.status = status;
+    normalized.data = data;
+    return normalized;
   }
 
   /**

--- a/packages/http/src/http_communication_protocol.ts
+++ b/packages/http/src/http_communication_protocol.ts
@@ -15,6 +15,7 @@ import { HttpCallTemplateSchema, HttpCallTemplate } from './http_call_template';
 import { OpenApiConverter } from './openapi_converter';
 import { ensureSecureUrl, safeRequestWithRedirects, assertNoCrlf } from './_security';
 import { truncateByCodePoint } from './_text';
+import { buildUrlWithPathParams } from './_url';
 
 /**
  * HTTP communication protocol implementation for UTCP client.
@@ -248,10 +249,6 @@ export class HttpCommunicationProtocol implements CommunicationProtocol {
     }
     const status = error.response.status;
     const data = error.response.data;
-    // Prefer a string `error` / `message` / `detail` field from the body; some
-    // APIs nest an OBJECT there (e.g. { error: { code, reason } }), so only use
-    // the candidate when it's actually a string — otherwise fall through to the
-    // full JSON so the real structure shows instead of "[object Object]".
     // The first of `error` / `message` / `detail` that is present decides: a
     // non-blank string is the reason; anything else (an object, say) is a
     // structured error, so return undefined to fall through to the full JSON
@@ -401,7 +398,11 @@ export class HttpCommunicationProtocol implements CommunicationProtocol {
   private async _handleOAuth2(authDetails: OAuth2Auth): Promise<string> {
     const clientId = authDetails.client_id;
 
-    const cachedToken = this._oauthTokens.get(clientId);
+    // Cache per full OAuth configuration, never per client_id alone: two
+    // templates may share a client_id but point at different issuers, scopes
+    // or secrets, and must not receive each other's tokens.
+    const cacheKey = JSON.stringify([authDetails.token_url, clientId, authDetails.client_secret, authDetails.scope || '']);
+    const cachedToken = this._oauthTokens.get(cacheKey);
     if (cachedToken && cachedToken.expiresAt > Date.now()) {
       return cachedToken.accessToken;
     }
@@ -441,7 +442,7 @@ export class HttpCommunicationProtocol implements CommunicationProtocol {
             throw new Error("Access token not found in response.");
           }
           const expiresAt = Date.now() + (response.data.expires_in * 1000 || 3600 * 1000);
-          this._oauthTokens.set(clientId, { accessToken: response.data.access_token, expiresAt });
+          this._oauthTokens.set(cacheKey, { accessToken: response.data.access_token, expiresAt });
           this._logInfo(`OAuth2 token fetched via body for client: '${clientId}'.`);
           return response.data.access_token;
         } catch (error: any) {
@@ -474,7 +475,7 @@ export class HttpCommunicationProtocol implements CommunicationProtocol {
             throw new Error("Access token not found in response.");
           }
           const expiresAt = Date.now() + (response.data.expires_in * 1000 || 3600 * 1000);
-          this._oauthTokens.set(clientId, { accessToken: response.data.access_token, expiresAt });
+          this._oauthTokens.set(cacheKey, { accessToken: response.data.access_token, expiresAt });
           this._logInfo(`OAuth2 token fetched via Basic Auth header for client: '${clientId}'.`);
           return response.data.access_token;
         } catch (error: any) {
@@ -503,25 +504,8 @@ export class HttpCommunicationProtocol implements CommunicationProtocol {
    * @throws Error if a required path parameter is missing.
    */
   private _buildUrlWithPathParams(urlTemplate: string, args: Record<string, any>): string {
-    let url = urlTemplate;
-    const pathParams = urlTemplate.match(/\{([^}]+)\}/g) || [];
-
-    for (const param of pathParams) {
-      const paramName = param.slice(1, -1);
-      if (paramName in args) {
-        // URL-encode the parameter value to prevent path injection
-        url = url.replace(param, encodeURIComponent(String(args[paramName])));
-        delete args[paramName];
-      } else {
-        throw new Error(`Missing required path parameter: ${paramName}`);
-      }
-    }
-
-    const remainingParams = url.match(/\{([^}]+)\}/g);
-    if (remainingParams && remainingParams.length > 0) {
-      throw new Error(`Missing required path parameters in URL template: ${remainingParams.join(', ')}`);
-    }
-
-    return url;
+    // Shared with the SSE and Streamable HTTP protocols: every occurrence is
+    // replaced and both `{param}` and `${param}` forms are accepted.
+    return buildUrlWithPathParams(urlTemplate, args);
   }
 }

--- a/packages/http/src/http_communication_protocol.ts
+++ b/packages/http/src/http_communication_protocol.ts
@@ -13,7 +13,7 @@ import { OAuth2UserAuth } from '@utcp/sdk';
 import { IUtcpClient } from '@utcp/sdk';
 import { HttpCallTemplateSchema, HttpCallTemplate } from './http_call_template';
 import { OpenApiConverter } from './openapi_converter';
-import { ensureSecureUrl, safeRequestWithRedirects, assertNoCrlf } from './_security';
+import { ensureSecureUrl, safeRequestWithRedirects, assertNoCrlf, isLoopbackUrl } from './_security';
 import { truncateByCodePoint, collapseControlChars } from './_text';
 import { buildUrlWithPathParams } from './_url';
 
@@ -97,6 +97,7 @@ export class HttpCommunicationProtocol implements CommunicationProtocol {
       if (responseData && responseData.utcp_version && Array.isArray(responseData.tools)) {
         this._logInfo(`Detected UTCP manual from '${httpCallTemplate.name}'.`);
         utcpManual = UtcpManualSchema.parse(responseData);
+        this._rejectRemoteLoopbackToolUrls(httpCallTemplate.url, utcpManual);
       } else if (responseData && (responseData.openapi || responseData.swagger || responseData.paths)) {
         this._logInfo(`Assuming OpenAPI spec from '${httpCallTemplate.name}'. Converting to UTCP manual.`);
         const converter = new OpenApiConverter(responseData, {
@@ -400,6 +401,31 @@ export class HttpCommunicationProtocol implements CommunicationProtocol {
       }
     }
     return { cookies, authHeaderNames };
+  }
+
+  /**
+   * Reject a remotely-discovered manual that points tool calls at loopback.
+   *
+   * `ensureSecureUrl` deliberately permits loopback HTTP so local development
+   * works, which leaves one gap: a manual fetched from a remote (non-loopback)
+   * origin can still declare tool URLs on the agent's own loopback interface.
+   * The OpenAPI converter already closes this for specs it converts; hand-written
+   * UTCP manuals bypass the converter, so the same rule is applied here. A manual
+   * fetched from loopback (local dev) is exempt, exactly as the converter exempts
+   * a local spec.
+   */
+  private _rejectRemoteLoopbackToolUrls(discoveryUrl: string, manual: { tools?: Array<any> }): void {
+    if (isLoopbackUrl(discoveryUrl)) return;
+    for (const tool of manual.tools || []) {
+      const toolUrl = tool?.tool_call_template?.url;
+      if (typeof toolUrl === 'string' && isLoopbackUrl(toolUrl)) {
+        throw new Error(
+          `Security error during manual discovery: a manual fetched from ${JSON.stringify(discoveryUrl)} ` +
+          `declares a loopback tool URL (${JSON.stringify(toolUrl)}) for tool ${JSON.stringify(tool?.name)}. ` +
+          `A remote manual is not allowed to redirect tool calls at the agent's own loopback interface.`
+        );
+      }
+    }
   }
 
   /**

--- a/packages/http/src/http_communication_protocol.ts
+++ b/packages/http/src/http_communication_protocol.ts
@@ -128,7 +128,8 @@ export class HttpCommunicationProtocol implements CommunicationProtocol {
         manualCallTemplate: httpCallTemplate,
         manual: UtcpManualSchema.parse({ tools: [] }),
         success: false,
-        errors: [this._normalizeToolError(httpCallTemplate.name ?? '', error, `discovering tools from '${httpCallTemplate.name}'`).message]
+        // 200 characters, like the SSE and Streamable HTTP discovery errors.
+        errors: [this._normalizeToolError(httpCallTemplate.name ?? '', error, `discovering tools from '${httpCallTemplate.name}'`, 200).message]
       };
     }
   }
@@ -243,7 +244,12 @@ export class HttpCommunicationProtocol implements CommunicationProtocol {
    * `status` / `data` fields, so the reason survives both `.message` readers and
    * structured serialization. Non-HTTP errors (network, timeout) pass through.
    */
-  private _normalizeToolError(toolName: string, error: any, context: string = `calling tool '${toolName}'`): Error {
+  private _normalizeToolError(
+    toolName: string,
+    error: any,
+    context: string = `calling tool '${toolName}'`,
+    maxDetailChars: number = 2000,
+  ): Error {
     if (!axios.isAxiosError(error) || !error.response) {
       return error instanceof Error ? error : new Error(String(error));
     }
@@ -268,7 +274,6 @@ export class HttpCommunicationProtocol implements CommunicationProtocol {
     // axios's own message) rather than emitting a message that ends in a
     // bare colon. Bound the detail so a multi-megabyte error page (an HTML
     // stack trace, say) does not end up in messages and logs in full.
-    const MAX_DETAIL_CHARS = 2000;
     const rawDetail =
       typeof data === 'string'
         ? data.trim() || error.response.statusText || error.message
@@ -277,7 +282,10 @@ export class HttpCommunicationProtocol implements CommunicationProtocol {
           : (stringField(data.error, data.message, data.detail) ?? JSON.stringify(data));
     // Truncate by code point, not UTF-16 unit, so a multi-byte character on
     // the boundary is dropped whole rather than leaving a lone surrogate.
-    const detail = truncateByCodePoint(collapseControlChars(rawDetail), MAX_DETAIL_CHARS);
+    // A body made only of control characters collapses to nothing: fall back
+    // to the status text again rather than emitting a bare colon.
+    const collapsed = collapseControlChars(rawDetail) || collapseControlChars(error.response.statusText || error.message || '');
+    const detail = truncateByCodePoint(collapsed, maxDetailChars);
     const normalized = new Error(
       `HTTP ${status} ${context}: ${detail}`,
     ) as Error & { status: number; data: unknown };

--- a/packages/http/src/http_communication_protocol.ts
+++ b/packages/http/src/http_communication_protocol.ts
@@ -14,6 +14,7 @@ import { IUtcpClient } from '@utcp/sdk';
 import { HttpCallTemplateSchema, HttpCallTemplate } from './http_call_template';
 import { OpenApiConverter } from './openapi_converter';
 import { ensureSecureUrl, safeRequestWithRedirects, assertNoCrlf } from './_security';
+import { truncateByCodePoint } from './_text';
 
 /**
  * HTTP communication protocol implementation for UTCP client.
@@ -279,8 +280,7 @@ export class HttpCommunicationProtocol implements CommunicationProtocol {
           : (stringField(data.error, data.message, data.detail) ?? JSON.stringify(data));
     // Truncate by code point, not UTF-16 unit, so a multi-byte character on
     // the boundary is dropped whole rather than leaving a lone surrogate.
-    const codePoints = Array.from(rawDetail);
-    const detail = codePoints.length > MAX_DETAIL_CHARS ? `${codePoints.slice(0, MAX_DETAIL_CHARS).join('')}…` : rawDetail;
+    const detail = truncateByCodePoint(rawDetail, MAX_DETAIL_CHARS);
     const normalized = new Error(
       `HTTP ${status} calling tool '${toolName}': ${detail}`,
     ) as Error & { status: number; data: unknown };

--- a/packages/http/src/http_communication_protocol.ts
+++ b/packages/http/src/http_communication_protocol.ts
@@ -14,7 +14,7 @@ import { IUtcpClient } from '@utcp/sdk';
 import { HttpCallTemplateSchema, HttpCallTemplate } from './http_call_template';
 import { OpenApiConverter } from './openapi_converter';
 import { ensureSecureUrl, safeRequestWithRedirects, assertNoCrlf } from './_security';
-import { truncateByCodePoint } from './_text';
+import { truncateByCodePoint, collapseControlChars } from './_text';
 import { buildUrlWithPathParams } from './_url';
 
 /**
@@ -128,7 +128,7 @@ export class HttpCommunicationProtocol implements CommunicationProtocol {
         manualCallTemplate: httpCallTemplate,
         manual: UtcpManualSchema.parse({ tools: [] }),
         success: false,
-        errors: [axios.isAxiosError(error) ? error.message : String(error)]
+        errors: [this._normalizeToolError(httpCallTemplate.name ?? '', error, `discovering tools from '${httpCallTemplate.name}'`).message]
       };
     }
   }
@@ -243,7 +243,7 @@ export class HttpCommunicationProtocol implements CommunicationProtocol {
    * `status` / `data` fields, so the reason survives both `.message` readers and
    * structured serialization. Non-HTTP errors (network, timeout) pass through.
    */
-  private _normalizeToolError(toolName: string, error: any): Error {
+  private _normalizeToolError(toolName: string, error: any, context: string = `calling tool '${toolName}'`): Error {
     if (!axios.isAxiosError(error) || !error.response) {
       return error instanceof Error ? error : new Error(String(error));
     }
@@ -277,13 +277,20 @@ export class HttpCommunicationProtocol implements CommunicationProtocol {
           : (stringField(data.error, data.message, data.detail) ?? JSON.stringify(data));
     // Truncate by code point, not UTF-16 unit, so a multi-byte character on
     // the boundary is dropped whole rather than leaving a lone surrogate.
-    const detail = truncateByCodePoint(rawDetail, MAX_DETAIL_CHARS);
+    const detail = truncateByCodePoint(collapseControlChars(rawDetail), MAX_DETAIL_CHARS);
     const normalized = new Error(
-      `HTTP ${status} calling tool '${toolName}': ${detail}`,
+      `HTTP ${status} ${context}: ${detail}`,
     ) as Error & { status: number; data: unknown };
     // Enumerable so they survive JSON.stringify out of an isolated-vm runner.
     normalized.status = status;
     normalized.data = data;
+    // Keep the original axios error reachable for callers that inspect
+    // err.response.headers (Retry-After, say), err.code or err.cause, but
+    // non-enumerable so the large, circular response object stays out of
+    // structured serialization.
+    for (const [key, value] of Object.entries({ cause: error, response: error.response, code: error.code })) {
+      Object.defineProperty(normalized, key, { value, enumerable: false, writable: true, configurable: true });
+    }
     return normalized;
   }
 
@@ -401,19 +408,20 @@ export class HttpCommunicationProtocol implements CommunicationProtocol {
     // Cache per full OAuth configuration, never per client_id alone: two
     // templates may share a client_id but point at different issuers, scopes
     // or secrets, and must not receive each other's tokens.
+    // The token URL ultimately comes from a call template, and call
+    // templates can be sourced from attacker-controlled OpenAPI specs
+    // (the OpenApiConverter copies ``tokenUrl`` from the spec).
+    // Validate it before posting credentials, and before the cache is
+    // consulted, so a malicious spec cannot redirect ``client_id`` /
+    // ``client_secret`` exfiltration through this protocol nor receive a
+    // token fetched on behalf of another template -- see GHSA-8cp3-qxj6-px34.
+    ensureSecureUrl(authDetails.token_url, 'OAuth2 token URL');
+
     const cacheKey = JSON.stringify([authDetails.token_url, clientId, authDetails.client_secret, authDetails.scope || '']);
     const cachedToken = this._oauthTokens.get(cacheKey);
     if (cachedToken && cachedToken.expiresAt > Date.now()) {
       return cachedToken.accessToken;
     }
-
-    // The token URL ultimately comes from a call template, and call
-    // templates can be sourced from attacker-controlled OpenAPI specs
-    // (the OpenApiConverter copies ``tokenUrl`` from the spec).
-    // Validate it before posting credentials so a malicious spec
-    // cannot redirect ``client_id`` / ``client_secret`` exfiltration
-    // through this protocol -- see GHSA-8cp3-qxj6-px34.
-    ensureSecureUrl(authDetails.token_url, 'OAuth2 token URL');
 
     this._logInfo(`Fetching new OAuth2 token for client: '${clientId}'`);
     const tokenFetchPromises: Promise<string>[] = [];

--- a/packages/http/src/http_communication_protocol.ts
+++ b/packages/http/src/http_communication_protocol.ts
@@ -253,12 +253,18 @@ export class HttpCommunicationProtocol implements CommunicationProtocol {
     // full JSON so the real structure shows instead of "[object Object]".
     const stringField = (...candidates: unknown[]): string | undefined =>
       candidates.find((c): c is string => typeof c === 'string');
-    const detail =
+    // A blank body carries no reason: fall back to the status text (then
+    // axios's own message) rather than emitting a message that ends in a
+    // bare colon. Bound the detail so a multi-megabyte error page (an HTML
+    // stack trace, say) does not end up in messages and logs in full.
+    const MAX_DETAIL_CHARS = 2000;
+    const rawDetail =
       typeof data === 'string'
-        ? data
+        ? data.trim() || error.response.statusText || error.message
         : data == null
           ? error.message
           : (stringField(data.error, data.message, data.detail) ?? JSON.stringify(data));
+    const detail = rawDetail.length > MAX_DETAIL_CHARS ? `${rawDetail.slice(0, MAX_DETAIL_CHARS)}…` : rawDetail;
     const normalized = new Error(
       `HTTP ${status} calling tool '${toolName}': ${detail}`,
     ) as Error & { status: number; data: unknown };

--- a/packages/http/src/http_communication_protocol.ts
+++ b/packages/http/src/http_communication_protocol.ts
@@ -277,7 +277,10 @@ export class HttpCommunicationProtocol implements CommunicationProtocol {
         : data == null
           ? error.message
           : (stringField(data.error, data.message, data.detail) ?? JSON.stringify(data));
-    const detail = rawDetail.length > MAX_DETAIL_CHARS ? `${rawDetail.slice(0, MAX_DETAIL_CHARS)}…` : rawDetail;
+    // Truncate by code point, not UTF-16 unit, so a multi-byte character on
+    // the boundary is dropped whole rather than leaving a lone surrogate.
+    const codePoints = Array.from(rawDetail);
+    const detail = codePoints.length > MAX_DETAIL_CHARS ? `${codePoints.slice(0, MAX_DETAIL_CHARS).join('')}…` : rawDetail;
     const normalized = new Error(
       `HTTP ${status} calling tool '${toolName}': ${detail}`,
     ) as Error & { status: number; data: unknown };

--- a/packages/http/src/http_communication_protocol.ts
+++ b/packages/http/src/http_communication_protocol.ts
@@ -251,8 +251,21 @@ export class HttpCommunicationProtocol implements CommunicationProtocol {
     // APIs nest an OBJECT there (e.g. { error: { code, reason } }), so only use
     // the candidate when it's actually a string — otherwise fall through to the
     // full JSON so the real structure shows instead of "[object Object]".
-    const stringField = (...candidates: unknown[]): string | undefined =>
-      candidates.find((c): c is string => typeof c === 'string');
+    // The first of `error` / `message` / `detail` that is present decides: a
+    // non-blank string is the reason; anything else (an object, say) is a
+    // structured error, so return undefined to fall through to the full JSON
+    // rather than skipping ahead to a lower-priority generic string.
+    const stringField = (...candidates: unknown[]): string | undefined => {
+      for (const c of candidates) {
+        if (c === undefined || c === null) continue;
+        if (typeof c === 'string') {
+          if (c.trim()) return c;
+          continue;
+        }
+        return undefined;
+      }
+      return undefined;
+    };
     // A blank body carries no reason: fall back to the status text (then
     // axios's own message) rather than emitting a message that ends in a
     // bare colon. Bound the detail so a multi-megabyte error page (an HTML

--- a/packages/http/src/sse_communication_protocol.ts
+++ b/packages/http/src/sse_communication_protocol.ts
@@ -16,6 +16,7 @@ import { IUtcpClient } from '@utcp/sdk';
 import { SseCallTemplate, SseCallTemplateSchema } from './sse_call_template';
 import { ensureSecureUrl, assertNoCrlf } from './_security';
 import { truncateByCodePoint } from './_text';
+import { buildUrlWithPathParams } from './_url';
 
 /**
  * A single parsed Server-Sent Event.
@@ -689,32 +690,7 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
    * Consumed parameters are removed from args so they are not sent as query parameters.
    */
   private _buildUrlWithPathParams(urlTemplate: string, args: Record<string, any>): string {
-    let url = urlTemplate;
-    // Both the `{param}` form from the spec and the `${param}` form the
-    // package README documents.
-    const placeholders = urlTemplate.match(/\$?\{([^}]+)\}/g) || [];
-    const paramNames = Array.from(new Set(
-      placeholders.map(p => (p.startsWith('${') ? p.slice(2, -1) : p.slice(1, -1)))
-    ));
-
-    for (const paramName of paramNames) {
-      if (!(paramName in args)) {
-        throw new Error(`Missing required path parameter: ${paramName}`);
-      }
-      // URL-encode the value to prevent path injection, and replace every
-      // occurrence of either form (a template may repeat a parameter).
-      // `${x}` goes first so that replacing `{x}` never leaves a stray `$`.
-      const value = encodeURIComponent(String(args[paramName]));
-      url = url.split('${' + paramName + '}').join(value).split('{' + paramName + '}').join(value);
-      delete args[paramName];
-    }
-
-    const remainingParams = url.match(/\$?\{([^}]+)\}/g);
-    if (remainingParams && remainingParams.length > 0) {
-      throw new Error(`Missing required path parameters in URL template: ${remainingParams.join(', ')}`);
-    }
-
-    return url;
+    return buildUrlWithPathParams(urlTemplate, args);
   }
 
   /**

--- a/packages/http/src/sse_communication_protocol.ts
+++ b/packages/http/src/sse_communication_protocol.ts
@@ -219,7 +219,9 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
         // (e.g. { "error": "..." }); discarding it leaves callers with only a
         // status code. Fall back to statusText when the body is empty.
         const body = await response.text().catch(() => '');
-        const detail = body.trim() || response.statusText;
+        // Truncate like the streaming path does, so a huge error page does
+        // not land in errors[] and logs in full.
+        const detail = body.trim().slice(0, 200) || response.statusText;
         throw new Error(`HTTP ${response.status}: ${detail}`);
       }
 

--- a/packages/http/src/sse_communication_protocol.ts
+++ b/packages/http/src/sse_communication_protocol.ts
@@ -215,7 +215,12 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
       });
 
       if (!response.ok) {
-        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+        // Read the body before throwing — servers put the real reason there
+        // (e.g. { "error": "..." }); discarding it leaves callers with only a
+        // status code. Fall back to statusText when the body is empty.
+        const body = await response.text().catch(() => '');
+        const detail = body.trim() || response.statusText;
+        throw new Error(`HTTP ${response.status}: ${detail}`);
       }
 
       // Discovery returns the manual as a plain JSON document.

--- a/packages/http/src/sse_communication_protocol.ts
+++ b/packages/http/src/sse_communication_protocol.ts
@@ -28,6 +28,17 @@ interface SseEvent {
 }
 
 /**
+ * The server violated the SSE wire format. Not a connection loss, so it is
+ * never retried.
+ */
+export class SseProtocolError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SseProtocolError';
+  }
+}
+
+/**
  * REQUIRED
  * SSE communication protocol implementation for UTCP client.
  *
@@ -45,6 +56,23 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
    * Keeps a tool call bounded even if the server keeps dropping the connection.
    */
   public static readonly MAX_RECONNECT_ATTEMPTS = 5;
+  /**
+   * Cap on the delay before a reconnect, whatever `retry_timeout` or a
+   * server-sent `retry:` field asks for. Together with MAX_RECONNECT_ATTEMPTS
+   * this bounds the total time a call can spend waiting to reconnect.
+   */
+  public static readonly MAX_RECONNECT_DELAY_MS = 60_000;
+  /**
+   * Time allowed for the SSE handshake, i.e. until response headers arrive.
+   * Reading the body is unbounded: an SSE stream may legitimately stay quiet.
+   */
+  public static readonly HANDSHAKE_TIMEOUT_MS = 30_000;
+  /**
+   * Largest partial event the parser buffers (in UTF-16 code units) before
+   * declaring the stream malformed. Guards against a server that streams
+   * data without ever sending the blank-line event delimiter.
+   */
+  public static readonly MAX_EVENT_BUFFER_CHARS = 16 * 1024 * 1024;
 
   private oauthTokens: Map<string, { access_token: string; expires_at?: number }> = new Map();
 
@@ -132,7 +160,7 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
     }
 
     if (provider.auth && 'token_url' in provider.auth) {
-      const token = await this._handleOAuth2(provider.auth as OAuth2Auth);
+      const token = await this._handleOAuth2(provider.auth as OAuth2Auth, SseCommunicationProtocol.HANDSHAKE_TIMEOUT_MS);
       headers['Authorization'] = `Bearer ${token}`;
     }
   }
@@ -326,7 +354,13 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
         attemptHeaders['Last-Event-ID'] = lastEventId;
       }
 
+      const delayMs = () => Math.min(retryDelayMs, SseCommunicationProtocol.MAX_RECONNECT_DELAY_MS);
+
       let response: Response;
+      // Bound the handshake only: the signal is dropped once headers arrive,
+      // so a quiet stream is never cut off.
+      const handshake = new AbortController();
+      const handshakeTimer = setTimeout(() => handshake.abort(), SseCommunicationProtocol.HANDSHAKE_TIMEOUT_MS);
       try {
         // ``redirect: 'error'`` -- see registerManual for rationale (GHSA-9qhg-99ww-9mqc).
         // ``keepalive: false`` -- do not take a pooled socket for the stream. Bun's
@@ -340,6 +374,7 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
           body,
           redirect: 'error',
           keepalive: false,
+          signal: handshake.signal,
         });
 
         if (!response.ok) {
@@ -352,10 +387,27 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
           throw new Error(`HTTP ${response.status}: ${response.statusText}${detail ? ` - ${detail.slice(0, 200)}` : ''}`);
         }
       } catch (error: any) {
-        // Failing to establish the connection (or a non-2xx status) is a
-        // definitive answer, not a connection loss: fail fast, no retry.
-        this._logError(`Error establishing SSE connection to '${providerName}': ${error.message}`);
-        throw error;
+        if (reconnectAttempts === 0) {
+          // The initial handshake failing (refused, timed out, non-2xx) is a
+          // definitive answer about the endpoint: fail fast, no retry.
+          this._logError(`Error establishing SSE connection to '${providerName}': ${error.message}`);
+          throw error;
+        }
+        // A reconnect handshake failing is part of the outage we are riding
+        // out (the server may still be restarting): count it and try again.
+        reconnectAttempts += 1;
+        if (reconnectAttempts > SseCommunicationProtocol.MAX_RECONNECT_ATTEMPTS) {
+          this._logError(`SSE reconnect to '${providerName}' failed and attempts are exhausted: ${error.message}`);
+          throw error;
+        }
+        this._logInfo(
+          `SSE reconnect to '${providerName}' failed (${error.message}); retrying in ${delayMs()} ms ` +
+          `(attempt ${reconnectAttempts}/${SseCommunicationProtocol.MAX_RECONNECT_ATTEMPTS})`
+        );
+        await new Promise<void>(resolve => setTimeout(resolve, delayMs()));
+        continue;
+      } finally {
+        clearTimeout(handshakeTimer);
       }
 
       try {
@@ -377,18 +429,23 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
         // The server ended the stream cleanly: the tool call is complete.
         return;
       } catch (error: any) {
+        if (error instanceof SseProtocolError) {
+          // A malformed stream is the server's doing, not a connection loss.
+          this._logError(`Malformed SSE stream from '${providerName}': ${error.message}`);
+          throw error;
+        }
         reconnectAttempts += 1;
         if (!reconnect || reconnectAttempts > SseCommunicationProtocol.MAX_RECONNECT_ATTEMPTS) {
           this._logError(`SSE connection to '${providerName}' lost and not reconnecting: ${error.message}`);
           throw error;
         }
         this._logInfo(
-          `SSE connection to '${providerName}' lost (${error.message}); reconnecting in ${retryDelayMs} ms ` +
+          `SSE connection to '${providerName}' lost (${error.message}); reconnecting in ${delayMs()} ms ` +
           `(attempt ${reconnectAttempts}/${SseCommunicationProtocol.MAX_RECONNECT_ATTEMPTS})`
         );
       }
 
-      await new Promise<void>(resolve => setTimeout(resolve, retryDelayMs));
+      await new Promise<void>(resolve => setTimeout(resolve, delayMs()));
     }
   }
 
@@ -418,13 +475,29 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
     const reader = body.getReader();
     const decoder = new TextDecoder('utf-8');
     let buffer = '';
+    // A "\r" that ended the previous chunk is held back until the next chunk
+    // shows whether a "\n" follows; otherwise a CRLF split across two reads
+    // would become two LFs and dispatch an event early.
+    let pendingCr = false;
+    const normalise = (chunk: string): string => {
+      let text = chunk;
+      if (pendingCr) {
+        text = '\r' + text;
+        pendingCr = false;
+      }
+      if (text.endsWith('\r')) {
+        text = text.slice(0, -1);
+        pendingCr = true;
+      }
+      // Normalise CRLF / CR line endings to LF so the event delimiter is always "\n\n".
+      return text.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+    };
 
     try {
       while (true) {
         const { done, value } = await reader.read();
         if (done) break;
-        // Normalise CRLF / CR line endings to LF so the event delimiter is always "\n\n".
-        buffer += decoder.decode(value, { stream: true }).replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+        buffer += normalise(decoder.decode(value, { stream: true }));
 
         let delimiterIndex: number;
         while ((delimiterIndex = buffer.indexOf('\n\n')) >= 0) {
@@ -435,10 +508,19 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
             yield event;
           }
         }
+
+        if (buffer.length > SseCommunicationProtocol.MAX_EVENT_BUFFER_CHARS) {
+          throw new SseProtocolError(
+            `SSE event exceeded ${SseCommunicationProtocol.MAX_EVENT_BUFFER_CHARS} characters without a blank-line delimiter`
+          );
+        }
       }
 
       // Flush a trailing event that was not terminated by a blank line.
-      buffer += decoder.decode();
+      buffer += normalise(decoder.decode());
+      if (pendingCr) {
+        buffer += '\n';
+      }
       const trailing = this._parseSseEvent(buffer);
       if (trailing) {
         yield trailing;
@@ -506,47 +588,64 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
 
   /**
    * Handles the OAuth2 client-credentials flow, trying credentials in the body
-   * first and then as a Basic Auth header. Tokens are cached per client_id.
+   * first and then as a Basic Auth header. Tokens are cached per full OAuth
+   * configuration (token URL, client id, secret, scope), never per client_id
+   * alone: two templates may share a client_id but point at different issuers.
+   * Each token request is bounded by `timeoutMs` so a stalled token endpoint
+   * cannot hang the tool call before its own timeout even starts.
    */
-  private async _handleOAuth2(authDetails: OAuth2Auth): Promise<string> {
+  private async _handleOAuth2(authDetails: OAuth2Auth, timeoutMs: number): Promise<string> {
     const clientId = authDetails.client_id;
-    const cached = this.oauthTokens.get(clientId);
+
+    // The token URL may come from an untrusted call template; validate it
+    // before the cache is consulted, so a template with a rejected URL never
+    // receives a token fetched on behalf of another (GHSA-8cp3-qxj6-px34).
+    ensureSecureUrl(authDetails.token_url, 'OAuth2 token URL');
+
+    const cacheKey = JSON.stringify([authDetails.token_url, clientId, authDetails.client_secret, authDetails.scope || '']);
+    const cached = this.oauthTokens.get(cacheKey);
     if (cached && (cached.expires_at === undefined || cached.expires_at > Date.now())) {
       return cached.access_token;
     }
-
-    // The token URL may come from an untrusted call template; validate it
-    // before posting credentials (GHSA-8cp3-qxj6-px34).
-    ensureSecureUrl(authDetails.token_url, 'OAuth2 token URL');
 
     const storeToken = (tokenData: any): string => {
       if (!tokenData || !tokenData.access_token) {
         throw new Error('Access token not found in response.');
       }
       const expiresIn = typeof tokenData.expires_in === 'number' ? tokenData.expires_in : 3600;
-      this.oauthTokens.set(clientId, { access_token: tokenData.access_token, expires_at: Date.now() + expiresIn * 1000 });
+      this.oauthTokens.set(cacheKey, { access_token: tokenData.access_token, expires_at: Date.now() + expiresIn * 1000 });
       return tokenData.access_token;
+    };
+
+    const requestToken = async (headers: Record<string, string>, form: Record<string, string>): Promise<string> => {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), timeoutMs);
+      try {
+        const response = await fetch(authDetails.token_url, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded', ...headers },
+          body: new URLSearchParams(form).toString(),
+          redirect: 'error',
+          signal: controller.signal,
+        });
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+        }
+        return storeToken(await response.json());
+      } finally {
+        clearTimeout(timer);
+      }
     };
 
     // Method 1: credentials in the request body
     try {
       this._logInfo(`Attempting OAuth2 token fetch for '${clientId}' with credentials in body.`);
-      const bodyData = new URLSearchParams({
+      return await requestToken({}, {
         grant_type: 'client_credentials',
         client_id: clientId,
         client_secret: authDetails.client_secret,
         scope: authDetails.scope || '',
       });
-      const response = await fetch(authDetails.token_url, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        body: bodyData.toString(),
-        redirect: 'error',
-      });
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-      }
-      return storeToken(await response.json());
     } catch (error: any) {
       this._logError(`OAuth2 with credentials in body failed for '${clientId}': ${error.message}. Trying Basic Auth header.`);
     }
@@ -554,24 +653,11 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
     // Method 2: credentials as a Basic Auth header
     try {
       this._logInfo(`Attempting OAuth2 token fetch for '${clientId}' with Basic Auth header.`);
-      const bodyData = new URLSearchParams({
+      const credentials = Buffer.from(`${clientId}:${authDetails.client_secret}`).toString('base64');
+      return await requestToken({ 'Authorization': `Basic ${credentials}` }, {
         grant_type: 'client_credentials',
         scope: authDetails.scope || '',
       });
-      const credentials = Buffer.from(`${clientId}:${authDetails.client_secret}`).toString('base64');
-      const response = await fetch(authDetails.token_url, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
-          'Authorization': `Basic ${credentials}`,
-        },
-        body: bodyData.toString(),
-        redirect: 'error',
-      });
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-      }
-      return storeToken(await response.json());
     } catch (error: any) {
       this._logError(`OAuth2 with Basic Auth header also failed for '${clientId}': ${error.message}`);
       throw new Error(`Failed to fetch OAuth2 token for client '${clientId}' after trying all methods. Details: ${error.message}`);
@@ -584,20 +670,26 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
    */
   private _buildUrlWithPathParams(urlTemplate: string, args: Record<string, any>): string {
     let url = urlTemplate;
-    const pathParams = urlTemplate.match(/\{([^}]+)\}/g) || [];
+    // Both the `{param}` form from the spec and the `${param}` form the
+    // package README documents.
+    const placeholders = urlTemplate.match(/\$?\{([^}]+)\}/g) || [];
+    const paramNames = Array.from(new Set(
+      placeholders.map(p => (p.startsWith('${') ? p.slice(2, -1) : p.slice(1, -1)))
+    ));
 
-    for (const param of pathParams) {
-      const paramName = param.slice(1, -1);
-      if (paramName in args) {
-        // URL-encode the parameter value to prevent path injection
-        url = url.replace(param, encodeURIComponent(String(args[paramName])));
-        delete args[paramName];
-      } else {
+    for (const paramName of paramNames) {
+      if (!(paramName in args)) {
         throw new Error(`Missing required path parameter: ${paramName}`);
       }
+      // URL-encode the value to prevent path injection, and replace every
+      // occurrence of either form (a template may repeat a parameter).
+      // `${x}` goes first so that replacing `{x}` never leaves a stray `$`.
+      const value = encodeURIComponent(String(args[paramName]));
+      url = url.split('${' + paramName + '}').join(value).split('{' + paramName + '}').join(value);
+      delete args[paramName];
     }
 
-    const remainingParams = url.match(/\{([^}]+)\}/g);
+    const remainingParams = url.match(/\$?\{([^}]+)\}/g);
     if (remainingParams && remainingParams.length > 0) {
       throw new Error(`Missing required path parameters in URL template: ${remainingParams.join(', ')}`);
     }

--- a/packages/http/src/sse_communication_protocol.ts
+++ b/packages/http/src/sse_communication_protocol.ts
@@ -8,13 +8,11 @@ import { CommunicationProtocol } from '@utcp/sdk';
 import { RegisterManualResult } from '@utcp/sdk';
 import { CallTemplate } from '@utcp/sdk';
 import { UtcpManual, UtcpManualSerializer } from '@utcp/sdk';
-import { ApiKeyAuth } from '@utcp/sdk';
-import { BasicAuth } from '@utcp/sdk';
 import { OAuth2Auth } from '@utcp/sdk';
-import { OAuth2UserAuth } from '@utcp/sdk';
 import { IUtcpClient } from '@utcp/sdk';
 import { SseCallTemplate, SseCallTemplateSchema } from './sse_call_template';
 import { ensureSecureUrl, assertNoCrlf } from './_security';
+import { applyAuth, finalizeAuthHeaders, fetchOAuth2Token, AuthLogger } from './_auth';
 import { readErrorDetail } from './_text';
 import { buildUrlWithPathParams } from './_url';
 
@@ -86,61 +84,22 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
     console.error(`[SseCommunicationProtocol] ${message}`);
   }
 
+  private get _authLog(): AuthLogger {
+    return { info: (m) => this._logInfo(m), error: (m) => this._logError(m) };
+  }
+
   private _applyAuth(
     provider: SseCallTemplate,
     headers: Record<string, string>,
     queryParams: Record<string, any>
   ): { auth?: { username: string; password: string }; cookies: Record<string, string> } {
-    let auth: { username: string; password: string } | undefined;
-    const cookies: Record<string, string> = {};
-
-    if (provider.auth) {
-      if ('api_key' in provider.auth) {
-        const apiKeyAuth = provider.auth as ApiKeyAuth;
-        if (apiKeyAuth.api_key) {
-          assertNoCrlf(apiKeyAuth.var_name, 'ApiKeyAuth.var_name');
-          // Default to 'header' if location is not specified
-          const location = apiKeyAuth.location || 'header';
-          if (location === 'header') {
-            headers[apiKeyAuth.var_name] = apiKeyAuth.api_key;
-          } else if (location === 'query') {
-            queryParams[apiKeyAuth.var_name] = apiKeyAuth.api_key;
-          } else if (location === 'cookie') {
-            cookies[apiKeyAuth.var_name] = apiKeyAuth.api_key;
-          }
-        } else {
-          this._logError('API key not found for ApiKeyAuth.');
-          throw new Error('API key for ApiKeyAuth not found.');
-        }
-      } else if ('username' in provider.auth && 'password' in provider.auth) {
-        const basicAuth = provider.auth as BasicAuth;
-        auth = { username: basicAuth.username, password: basicAuth.password };
-      } else if ('token_url' in provider.auth) {
-        // OAuth2 will be handled separately
-      } else if (provider.auth.auth_type === 'oauth2_user') {
-        // Interactive (user-delegated) OAuth2: token provisioned out-of-band.
-        const userAuth = provider.auth as OAuth2UserAuth;
-        if (!userAuth.access_token) {
-          throw new Error(
-            "access_token for oauth2_user auth is empty. Run an interactive " +
-              "login to provision it.",
-          );
-        }
-        const headerName = userAuth.var_name || 'Authorization';
-        const prefix = userAuth.prefix ?? 'Bearer ';
-        assertNoCrlf(headerName, 'OAuth2UserAuth.var_name');
-        assertNoCrlf(prefix, 'OAuth2UserAuth.prefix');
-        assertNoCrlf(userAuth.access_token, 'OAuth2UserAuth.access_token');
-        headers[headerName] = `${prefix}${userAuth.access_token}`;
-      }
-    }
-
-    return { auth, cookies };
+    return applyAuth(provider.auth, headers, queryParams, this._authLog);
   }
 
   /**
    * Applies Basic auth, cookies and (if configured) an OAuth2 client-credentials
-   * bearer token to the request headers.
+   * bearer token to the request headers. Shared with the other fetch-based
+   * protocol via _auth.ts so security fixes land in one place.
    */
   private async _finalizeAuthHeaders(
     provider: SseCallTemplate,
@@ -149,23 +108,7 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
     cookies: Record<string, string>,
     signal: AbortSignal,
   ): Promise<void> {
-    if (auth) {
-      const credentials = Buffer.from(`${auth.username}:${auth.password}`).toString('base64');
-      headers['Authorization'] = `Basic ${credentials}`;
-    }
-
-    if (Object.keys(cookies).length > 0) {
-      const cookieHeader = Object.entries(cookies)
-        .map(([k, v]) => `${k}=${v}`)
-        .join('; ');
-      assertNoCrlf(cookieHeader, 'Cookie');
-      headers['Cookie'] = headers['Cookie'] ? `${headers['Cookie']}; ${cookieHeader}` : cookieHeader;
-    }
-
-    if (provider.auth && 'token_url' in provider.auth) {
-      const token = await this._handleOAuth2(provider.auth as OAuth2Auth, signal);
-      headers['Authorization'] = `Bearer ${token}`;
-    }
+    return finalizeAuthHeaders(provider.auth, headers, auth, cookies, signal, this.oauthTokens, this._authLog);
   }
 
   /**
@@ -560,15 +503,9 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
         }
       }
 
-      // Flush a trailing event that was not terminated by a blank line.
-      buffer += normalise(decoder.decode());
-      if (pendingCr) {
-        buffer += '\n';
-      }
-      const trailing = this._parseSseEvent(buffer);
-      if (trailing) {
-        yield trailing;
-      }
+      // Spec: if the stream ends in the middle of an event, before the final
+      // blank line, the incomplete event is not dispatched.
+      decoder.decode();
     } finally {
       // Release the connection if the consumer stopped early or an error occurred.
       try {
@@ -616,9 +553,9 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
       } else if (field === 'id') {
         event.id = value;
       } else if (field === 'retry') {
-        const retry = parseInt(value, 10);
-        if (!Number.isNaN(retry)) {
-          event.retry = retry;
+        // Spec: only a value made of ASCII digits sets the reconnection time.
+        if (/^[0-9]+$/.test(value)) {
+          event.retry = Number(value);
         }
       }
     }
@@ -631,78 +568,10 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
   }
 
   /**
-   * Handles the OAuth2 client-credentials flow, trying credentials in the body
-   * first and then as a Basic Auth header. Tokens are cached per full OAuth
-   * configuration (token URL, client id, secret, scope), never per client_id
-   * alone: two templates may share a client_id but point at different issuers.
-   * Both credential methods run under the caller's `signal`, which carries
-   * the call's own deadline, so the whole token flow can never exceed it.
+   * OAuth2 client-credentials flow, shared via _auth.ts.
    */
   private async _handleOAuth2(authDetails: OAuth2Auth, signal: AbortSignal): Promise<string> {
-    const clientId = authDetails.client_id;
-
-    // The token URL may come from an untrusted call template; validate it
-    // before the cache is consulted, so a template with a rejected URL never
-    // receives a token fetched on behalf of another (GHSA-8cp3-qxj6-px34).
-    ensureSecureUrl(authDetails.token_url, 'OAuth2 token URL');
-
-    const cacheKey = JSON.stringify([authDetails.token_url, clientId, authDetails.client_secret, authDetails.scope || '']);
-    const cached = this.oauthTokens.get(cacheKey);
-    if (cached && (cached.expires_at === undefined || cached.expires_at > Date.now())) {
-      return cached.access_token;
-    }
-
-    const storeToken = (tokenData: any): string => {
-      if (!tokenData || !tokenData.access_token) {
-        throw new Error('Access token not found in response.');
-      }
-      const expiresIn = typeof tokenData.expires_in === 'number' ? tokenData.expires_in : 3600;
-      this.oauthTokens.set(cacheKey, { access_token: tokenData.access_token, expires_at: Date.now() + expiresIn * 1000 });
-      return tokenData.access_token;
-    };
-
-    const requestToken = async (headers: Record<string, string>, form: Record<string, string>): Promise<string> => {
-      if (signal.aborted) {
-        throw new Error('Timed out before the token request could start.');
-      }
-      const response = await fetch(authDetails.token_url, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded', ...headers },
-        body: new URLSearchParams(form).toString(),
-        redirect: 'error',
-        signal,
-      });
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-      }
-      return storeToken(await response.json());
-    };
-
-    // Method 1: credentials in the request body
-    try {
-      this._logInfo(`Attempting OAuth2 token fetch for '${clientId}' with credentials in body.`);
-      return await requestToken({}, {
-        grant_type: 'client_credentials',
-        client_id: clientId,
-        client_secret: authDetails.client_secret,
-        scope: authDetails.scope || '',
-      });
-    } catch (error: any) {
-      this._logError(`OAuth2 with credentials in body failed for '${clientId}': ${error.message}. Trying Basic Auth header.`);
-    }
-
-    // Method 2: credentials as a Basic Auth header
-    try {
-      this._logInfo(`Attempting OAuth2 token fetch for '${clientId}' with Basic Auth header.`);
-      const credentials = Buffer.from(`${clientId}:${authDetails.client_secret}`).toString('base64');
-      return await requestToken({ 'Authorization': `Basic ${credentials}` }, {
-        grant_type: 'client_credentials',
-        scope: authDetails.scope || '',
-      });
-    } catch (error: any) {
-      this._logError(`OAuth2 with Basic Auth header also failed for '${clientId}': ${error.message}`);
-      throw new Error(`Failed to fetch OAuth2 token for client '${clientId}' after trying all methods. Details: ${error.message}`);
-    }
+    return fetchOAuth2Token(authDetails, signal, this.oauthTokens, this._authLog);
   }
 
   /**

--- a/packages/http/src/sse_communication_protocol.ts
+++ b/packages/http/src/sse_communication_protocol.ts
@@ -220,8 +220,9 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
         // status code. Fall back to statusText when the body is empty.
         const body = await response.text().catch(() => '');
         // Truncate like the streaming path does, so a huge error page does
-        // not land in errors[] and logs in full.
-        const detail = body.trim().slice(0, 200) || response.statusText;
+        // not land in errors[] and logs in full. By code point, so a
+        // multi-byte character on the boundary cannot leave a lone surrogate.
+        const detail = Array.from(body.trim()).slice(0, 200).join('') || response.statusText;
         throw new Error(`HTTP ${response.status}: ${detail}`);
       }
 

--- a/packages/http/src/sse_communication_protocol.ts
+++ b/packages/http/src/sse_communication_protocol.ts
@@ -357,7 +357,10 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
         // Anything but an event stream would be parsed into silence: a JSON
         // error document, say, yields zero events and a "successful" call.
         const contentType = response.headers.get('content-type') || '';
-        if (!contentType.toLowerCase().includes('text/event-stream')) {
+        // Compare the media type exactly (parameters such as charset allowed),
+        // so "text/event-stream-invalid" does not pass a substring check.
+        const mediaType = contentType.split(';', 1)[0].trim().toLowerCase();
+        if (mediaType !== 'text/event-stream') {
           try {
             await response.body?.cancel();
           } catch {

--- a/packages/http/src/sse_communication_protocol.ts
+++ b/packages/http/src/sse_communication_protocol.ts
@@ -145,6 +145,7 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
     headers: Record<string, string>,
     auth: { username: string; password: string } | undefined,
     cookies: Record<string, string>,
+    signal: AbortSignal,
   ): Promise<void> {
     if (auth) {
       const credentials = Buffer.from(`${auth.username}:${auth.password}`).toString('base64');
@@ -160,7 +161,7 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
     }
 
     if (provider.auth && 'token_url' in provider.auth) {
-      const token = await this._handleOAuth2(provider.auth as OAuth2Auth, SseCommunicationProtocol.HANDSHAKE_TIMEOUT_MS);
+      const token = await this._handleOAuth2(provider.auth as OAuth2Auth, signal);
       headers['Authorization'] = `Bearer ${token}`;
     }
   }
@@ -185,11 +186,14 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
 
     this._logInfo(`Discovering tools from '${provider.name}' (SSE) at ${url}`);
 
+    // One handshake-sized deadline for the whole discovery call, token fetch included.
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), SseCommunicationProtocol.HANDSHAKE_TIMEOUT_MS);
     try {
       const requestHeaders: Record<string, string> = provider.headers ? { ...provider.headers } : {};
       const queryParams: Record<string, any> = {};
       const { auth, cookies } = this._applyAuth(provider, requestHeaders, queryParams);
-      await this._finalizeAuthHeaders(provider, requestHeaders, auth, cookies);
+      await this._finalizeAuthHeaders(provider, requestHeaders, auth, cookies, controller.signal);
 
       // Build URL with query parameters
       const urlObj = new URL(url);
@@ -207,6 +211,7 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
         method: 'GET',
         headers: requestHeaders,
         redirect: 'error',
+        signal: controller.signal,
       });
 
       if (!response.ok) {
@@ -233,6 +238,8 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
         success: false,
         errors: [error.message || String(error)],
       };
+    } finally {
+      clearTimeout(timer);
     }
   }
 
@@ -310,9 +317,16 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
     // The rest of the arguments are query parameters
     const queryParams: Record<string, any> = { ...remainingArgs };
 
-    // Handle authentication
+    // Handle authentication. The token fetch (both credential methods) shares
+    // one handshake-sized deadline so a stalled token endpoint cannot hang the call.
     const { auth, cookies } = this._applyAuth(provider, requestHeaders, queryParams);
-    await this._finalizeAuthHeaders(provider, requestHeaders, auth, cookies);
+    const authController = new AbortController();
+    const authTimer = setTimeout(() => authController.abort(), SseCommunicationProtocol.HANDSHAKE_TIMEOUT_MS);
+    try {
+      await this._finalizeAuthHeaders(provider, requestHeaders, auth, cookies, authController.signal);
+    } finally {
+      clearTimeout(authTimer);
+    }
 
     const urlObj = new URL(url);
     Object.entries(queryParams).forEach(([key, value]) => {
@@ -591,10 +605,10 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
    * first and then as a Basic Auth header. Tokens are cached per full OAuth
    * configuration (token URL, client id, secret, scope), never per client_id
    * alone: two templates may share a client_id but point at different issuers.
-   * Each token request is bounded by `timeoutMs` so a stalled token endpoint
-   * cannot hang the tool call before its own timeout even starts.
+   * Both credential methods run under the caller's `signal`, which carries
+   * the call's own deadline, so the whole token flow can never exceed it.
    */
-  private async _handleOAuth2(authDetails: OAuth2Auth, timeoutMs: number): Promise<string> {
+  private async _handleOAuth2(authDetails: OAuth2Auth, signal: AbortSignal): Promise<string> {
     const clientId = authDetails.client_id;
 
     // The token URL may come from an untrusted call template; validate it
@@ -618,23 +632,20 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
     };
 
     const requestToken = async (headers: Record<string, string>, form: Record<string, string>): Promise<string> => {
-      const controller = new AbortController();
-      const timer = setTimeout(() => controller.abort(), timeoutMs);
-      try {
-        const response = await fetch(authDetails.token_url, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/x-www-form-urlencoded', ...headers },
-          body: new URLSearchParams(form).toString(),
-          redirect: 'error',
-          signal: controller.signal,
-        });
-        if (!response.ok) {
-          throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-        }
-        return storeToken(await response.json());
-      } finally {
-        clearTimeout(timer);
+      if (signal.aborted) {
+        throw new Error('Timed out before the token request could start.');
       }
+      const response = await fetch(authDetails.token_url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded', ...headers },
+        body: new URLSearchParams(form).toString(),
+        redirect: 'error',
+        signal,
+      });
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+      return storeToken(await response.json());
     };
 
     // Method 1: credentials in the request body

--- a/packages/http/src/sse_communication_protocol.ts
+++ b/packages/http/src/sse_communication_protocol.ts
@@ -311,9 +311,7 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
     // Never re-send a request body: a reconnect re-issues the request, and for
     // a POST that would re-execute a possibly non-idempotent tool.
     const reconnect = provider.reconnect !== false && bodyContent === undefined;
-    if (provider.reconnect !== false && bodyContent !== undefined) {
-      this._logInfo(`Reconnection is disabled for '${providerName}' because the call sends a request body.`);
-    }
+    const reconnectSuppressedByBody = provider.reconnect !== false && bodyContent !== undefined;
     let retryDelayMs = provider.retry_timeout;
     let lastEventId: string | undefined;
     let reconnectAttempts = 0;
@@ -426,7 +424,10 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
         }
         reconnectAttempts += 1;
         if (!reconnect || reconnectAttempts > SseCommunicationProtocol.MAX_RECONNECT_ATTEMPTS) {
-          this._logError(`SSE connection to '${providerName}' lost and not reconnecting: ${error.message}`);
+          const why = reconnectSuppressedByBody
+            ? ' (reconnection is disabled for calls that send a request body, since a re-issued POST could re-execute the tool)'
+            : '';
+          this._logError(`SSE connection to '${providerName}' lost and not reconnecting${why}: ${error.message}`);
           throw error;
         }
         this._logInfo(
@@ -506,9 +507,24 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
         }
       }
 
-      // Spec: if the stream ends in the middle of an event, before the final
-      // blank line, the incomplete event is not dispatched.
-      decoder.decode();
+      // At end of stream, a held-back CR is a real line terminator and may
+      // complete the closing blank line of the last event. Dispatch whatever
+      // is fully delimited; per spec, an event still incomplete after that
+      // (no final blank line) is discarded.
+      buffer += normalise(decoder.decode());
+      if (pendingCr) {
+        buffer += '\n';
+        pendingCr = false;
+      }
+      let delimiterIndex: number;
+      while ((delimiterIndex = buffer.indexOf('\n\n')) >= 0) {
+        const rawEvent = buffer.slice(0, delimiterIndex);
+        buffer = buffer.slice(delimiterIndex + 2);
+        const event = this._parseSseEvent(rawEvent);
+        if (event) {
+          yield event;
+        }
+      }
     } finally {
       // Release the connection if the consumer stopped early or an error occurred.
       try {
@@ -557,7 +573,8 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
         event.id = value;
       } else if (field === 'retry') {
         // Spec: only a value made of ASCII digits sets the reconnection time.
-        if (/^[0-9]+$/.test(value)) {
+        // An absurdly long digit string parses to Infinity and is ignored.
+        if (/^[0-9]+$/.test(value) && Number.isFinite(Number(value))) {
           event.retry = Number(value);
         }
       }

--- a/packages/http/src/sse_communication_protocol.ts
+++ b/packages/http/src/sse_communication_protocol.ts
@@ -15,6 +15,7 @@ import { OAuth2UserAuth } from '@utcp/sdk';
 import { IUtcpClient } from '@utcp/sdk';
 import { SseCallTemplate, SseCallTemplateSchema } from './sse_call_template';
 import { ensureSecureUrl, assertNoCrlf } from './_security';
+import { truncateByCodePoint } from './_text';
 
 /**
  * A single parsed Server-Sent Event.
@@ -222,7 +223,7 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
         // Truncate like the streaming path does, so a huge error page does
         // not land in errors[] and logs in full. By code point, so a
         // multi-byte character on the boundary cannot leave a lone surrogate.
-        const detail = Array.from(body.trim()).slice(0, 200).join('') || response.statusText;
+        const detail = truncateByCodePoint(body.trim(), 200) || response.statusText;
         throw new Error(`HTTP ${response.status}: ${detail}`);
       }
 

--- a/packages/http/src/sse_communication_protocol.ts
+++ b/packages/http/src/sse_communication_protocol.ts
@@ -1,6 +1,6 @@
 /**
  * Server-Sent Events (SSE) Communication Protocol for UTCP.
- * 
+ *
  * Handles Server-Sent Events based tool providers with streaming capabilities.
  */
 // packages/http/src/sse_communication_protocol.ts
@@ -13,16 +13,39 @@ import { BasicAuth } from '@utcp/sdk';
 import { OAuth2Auth } from '@utcp/sdk';
 import { OAuth2UserAuth } from '@utcp/sdk';
 import { IUtcpClient } from '@utcp/sdk';
-import { SseCallTemplate } from './sse_call_template';
+import { SseCallTemplate, SseCallTemplateSchema } from './sse_call_template';
 import { ensureSecureUrl, assertNoCrlf } from './_security';
+
+/**
+ * A single parsed Server-Sent Event.
+ */
+interface SseEvent {
+  event?: string;
+  id?: string;
+  retry?: number;
+  /** Joined data lines. Absent for blocks that only carry id/retry/event fields. */
+  data?: string;
+}
 
 /**
  * REQUIRED
  * SSE communication protocol implementation for UTCP client.
- * 
+ *
  * Handles Server-Sent Events based tool providers with streaming capabilities.
+ *
+ * Each SSE event's ``data`` payload is yielded as one chunk. Payloads that
+ * parse as JSON are yielded as the parsed value; otherwise the raw string is
+ * yielded. When ``event_type`` is set on the call template, only events whose
+ * ``event`` field matches are yielded.
  */
 export class SseCommunicationProtocol implements CommunicationProtocol {
+  /**
+   * Upper bound on reconnection attempts for a single tool call when the
+   * established stream drops and the call template has `reconnect` enabled.
+   * Keeps a tool call bounded even if the server keeps dropping the connection.
+   */
+  public static readonly MAX_RECONNECT_ATTEMPTS = 5;
+
   private oauthTokens: Map<string, { access_token: string; expires_at?: number }> = new Map();
 
   private _logInfo(message: string): void {
@@ -86,6 +109,35 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
   }
 
   /**
+   * Applies Basic auth, cookies and (if configured) an OAuth2 client-credentials
+   * bearer token to the request headers.
+   */
+  private async _finalizeAuthHeaders(
+    provider: SseCallTemplate,
+    headers: Record<string, string>,
+    auth: { username: string; password: string } | undefined,
+    cookies: Record<string, string>,
+  ): Promise<void> {
+    if (auth) {
+      const credentials = Buffer.from(`${auth.username}:${auth.password}`).toString('base64');
+      headers['Authorization'] = `Basic ${credentials}`;
+    }
+
+    if (Object.keys(cookies).length > 0) {
+      const cookieHeader = Object.entries(cookies)
+        .map(([k, v]) => `${k}=${v}`)
+        .join('; ');
+      assertNoCrlf(cookieHeader, 'Cookie');
+      headers['Cookie'] = headers['Cookie'] ? `${headers['Cookie']}; ${cookieHeader}` : cookieHeader;
+    }
+
+    if (provider.auth && 'token_url' in provider.auth) {
+      const token = await this._handleOAuth2(provider.auth as OAuth2Auth);
+      headers['Authorization'] = `Bearer ${token}`;
+    }
+  }
+
+  /**
    * REQUIRED
    * Register a manual and its tools from an SSE provider.
    */
@@ -97,7 +149,7 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
       throw new Error('SseCommunicationProtocol can only be used with SseCallTemplate');
     }
 
-    const provider = manualCallTemplate as SseCallTemplate;
+    const provider = SseCallTemplateSchema.parse(manualCallTemplate);
     const url = provider.url;
 
     // Security check: only HTTPS or loopback HTTP allowed for manual discovery.
@@ -109,6 +161,7 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
       const requestHeaders: Record<string, string> = provider.headers ? { ...provider.headers } : {};
       const queryParams: Record<string, any> = {};
       const { auth, cookies } = this._applyAuth(provider, requestHeaders, queryParams);
+      await this._finalizeAuthHeaders(provider, requestHeaders, auth, cookies);
 
       // Build URL with query parameters
       const urlObj = new URL(url);
@@ -116,40 +169,23 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
         urlObj.searchParams.append(key, String(value));
       });
 
-      // SSE requires Accept: text/event-stream
-      requestHeaders['Accept'] = 'text/event-stream';
-
-      // Build fetch options. ``redirect: 'error'`` refuses to follow
-      // 3xx responses on the SSE handshake -- the streaming response
-      // has to stay open for the lifetime of the tool call, which is
-      // incompatible with a per-hop revalidator, and SSE redirects
-      // are pathological in practice. Without this, an
-      // attacker-controlled endpoint could 302 the handshake into an
-      // internal service (GHSA-9qhg-99ww-9mqc).
-      const fetchOptions: RequestInit = {
+      // ``redirect: 'error'`` refuses to follow 3xx responses on the SSE
+      // handshake -- the streaming response has to stay open for the
+      // lifetime of the tool call, which is incompatible with a per-hop
+      // revalidator, and SSE redirects are pathological in practice.
+      // Without this, an attacker-controlled endpoint could 302 the
+      // handshake into an internal service (GHSA-9qhg-99ww-9mqc).
+      const response = await fetch(urlObj.toString(), {
         method: 'GET',
         headers: requestHeaders,
         redirect: 'error',
-      };
-
-      // Add basic auth if present
-      if (auth) {
-        const credentials = Buffer.from(`${auth.username}:${auth.password}`).toString('base64');
-        fetchOptions.headers = {
-          ...fetchOptions.headers as Record<string, string>,
-          'Authorization': `Basic ${credentials}`,
-        };
-      }
-
-      // Make discovery request
-      const response = await fetch(urlObj.toString(), fetchOptions);
+      });
 
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}: ${response.statusText}`);
       }
 
-      // For SSE discovery, we expect the first event to contain the manual
-      // This is a simplified implementation
+      // Discovery returns the manual as a plain JSON document.
       const responseText = await response.text();
       const utcpManual = new UtcpManualSerializer().validateDict(JSON.parse(responseText));
 
@@ -183,6 +219,8 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
   /**
    * REQUIRED
    * Call a tool using SSE (non-streaming).
+   *
+   * Consumes the whole event stream and returns every event payload as an array.
    */
   async callTool(
     caller: IUtcpClient,
@@ -190,8 +228,7 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
     toolArgs: Record<string, any>,
     toolCallTemplate: CallTemplate
   ): Promise<any> {
-    // For SSE, we collect all events and return them
-    const events: string[] = [];
+    const events: any[] = [];
     for await (const event of this.callToolStreaming(caller, toolName, toolArgs, toolCallTemplate)) {
       events.push(event);
     }
@@ -201,7 +238,7 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
   /**
    * REQUIRED
    * Call a tool using SSE streaming.
-   * Returns an async generator that yields SSE events.
+   * Returns an async generator that yields the payload of each SSE event.
    */
   async *callToolStreaming(
     caller: IUtcpClient,
@@ -209,14 +246,363 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
     toolArgs: Record<string, any>,
     toolCallTemplate: CallTemplate
   ): AsyncGenerator<any, void, unknown> {
-    const provider = toolCallTemplate as SseCallTemplate;
+    if ((toolCallTemplate as any).call_template_type !== 'sse') {
+      throw new Error('SseCommunicationProtocol can only be used with SseCallTemplate');
+    }
+    const provider = SseCallTemplateSchema.parse(toolCallTemplate);
 
-    // TODO: Implement actual SSE call logic
-    // This would involve connecting to the SSE endpoint and streaming events
-    this._logInfo(`Calling SSE tool '${toolName}' with args: ${JSON.stringify(toolArgs)}`);
-    
-    // Placeholder implementation
-    yield `SSE event for tool: ${toolName}`;
+    const requestHeaders: Record<string, string> = provider.headers ? { ...provider.headers } : {};
+    let bodyContent: any = undefined;
+    const remainingArgs: Record<string, any> = { ...toolArgs };
+    requestHeaders['Accept'] = 'text/event-stream';
+
+    if (provider.header_fields) {
+      for (const fieldName of provider.header_fields) {
+        if (fieldName in remainingArgs) {
+          assertNoCrlf(fieldName, 'header field name');
+          const value = String(remainingArgs[fieldName]);
+          assertNoCrlf(value, `header field '${fieldName}'`);
+          requestHeaders[fieldName] = value;
+          delete remainingArgs[fieldName];
+        }
+      }
+    }
+
+    if (provider.body_field && provider.body_field in remainingArgs) {
+      bodyContent = remainingArgs[provider.body_field];
+      delete remainingArgs[provider.body_field];
+    }
+
+    // Build the URL with path parameters substituted
+    const url = this._buildUrlWithPathParams(provider.url, remainingArgs);
+
+    // Security check: re-validate the resolved URL before each invocation.
+    ensureSecureUrl(url, 'tool invocation');
+
+    // The rest of the arguments are query parameters
+    const queryParams: Record<string, any> = { ...remainingArgs };
+
+    // Handle authentication
+    const { auth, cookies } = this._applyAuth(provider, requestHeaders, queryParams);
+    await this._finalizeAuthHeaders(provider, requestHeaders, auth, cookies);
+
+    const urlObj = new URL(url);
+    Object.entries(queryParams).forEach(([key, value]) => {
+      if (value === undefined || value === null) return;
+      urlObj.searchParams.append(key, typeof value === 'object' ? JSON.stringify(value) : String(value));
+    });
+
+    // Mirror the Python implementation: POST when a body is present, GET otherwise.
+    const method = bodyContent !== undefined ? 'POST' : 'GET';
+    let body: BodyInit | undefined = undefined;
+    if (bodyContent !== undefined) {
+      const contentTypeEntry = Object.entries(requestHeaders).find(([h]) => h.toLowerCase() === 'content-type');
+      if (!contentTypeEntry) {
+        requestHeaders['Content-Type'] = 'application/json';
+      }
+      const contentType = contentTypeEntry?.[1] || 'application/json';
+      if (contentType.includes('application/json')) {
+        body = JSON.stringify(bodyContent);
+      } else if (typeof bodyContent === 'string' || bodyContent instanceof Uint8Array || bodyContent instanceof ArrayBuffer) {
+        body = bodyContent as BodyInit;
+      } else {
+        body = JSON.stringify(bodyContent);
+      }
+    }
+
+    this._logInfo(`Executing SSE tool '${toolName}' with URL: ${urlObj.toString()} and method: ${method}`);
+
+    const providerName = provider.name || toolName;
+    const eventType = provider.event_type ?? undefined;
+    const reconnect = provider.reconnect !== false;
+    let retryDelayMs = provider.retry_timeout;
+    let lastEventId: string | undefined;
+    let reconnectAttempts = 0;
+
+    while (true) {
+      const attemptHeaders: Record<string, string> = { ...requestHeaders };
+      if (lastEventId !== undefined) {
+        // Let the server resume from where we left off (SSE spec).
+        attemptHeaders['Last-Event-ID'] = lastEventId;
+      }
+
+      let response: Response;
+      try {
+        // ``redirect: 'error'`` -- see registerManual for rationale (GHSA-9qhg-99ww-9mqc).
+        // ``keepalive: false`` -- do not take a pooled socket for the stream. Bun's
+        // fetch transparently re-issues a request when a reused keep-alive socket
+        // dies mid-response, which would bypass this reconnect logic (no
+        // Last-Event-ID, ``reconnect: false`` ignored, duplicated events). Node
+        // ignores the option. A fresh connection per streaming call is cheap.
+        response = await fetch(urlObj.toString(), {
+          method,
+          headers: attemptHeaders,
+          body,
+          redirect: 'error',
+          keepalive: false,
+        });
+
+        if (!response.ok) {
+          let detail = '';
+          try {
+            detail = await response.text();
+          } catch {
+            // ignore body read failures on error responses
+          }
+          throw new Error(`HTTP ${response.status}: ${response.statusText}${detail ? ` - ${detail.slice(0, 200)}` : ''}`);
+        }
+      } catch (error: any) {
+        // Failing to establish the connection (or a non-2xx status) is a
+        // definitive answer, not a connection loss: fail fast, no retry.
+        this._logError(`Error establishing SSE connection to '${providerName}': ${error.message}`);
+        throw error;
+      }
+
+      try {
+        for await (const event of this._iterSseEvents(response)) {
+          if (event.id !== undefined) {
+            lastEventId = event.id;
+          }
+          if (event.retry !== undefined) {
+            retryDelayMs = event.retry;
+          }
+          if (event.data === undefined) {
+            continue;
+          }
+          if (eventType && event.event !== eventType) {
+            continue;
+          }
+          yield this._parseEventData(event.data);
+        }
+        // The server ended the stream cleanly: the tool call is complete.
+        return;
+      } catch (error: any) {
+        reconnectAttempts += 1;
+        if (!reconnect || reconnectAttempts > SseCommunicationProtocol.MAX_RECONNECT_ATTEMPTS) {
+          this._logError(`SSE connection to '${providerName}' lost and not reconnecting: ${error.message}`);
+          throw error;
+        }
+        this._logInfo(
+          `SSE connection to '${providerName}' lost (${error.message}); reconnecting in ${retryDelayMs} ms ` +
+          `(attempt ${reconnectAttempts}/${SseCommunicationProtocol.MAX_RECONNECT_ATTEMPTS})`
+        );
+      }
+
+      await new Promise<void>(resolve => setTimeout(resolve, retryDelayMs));
+    }
+  }
+
+  /**
+   * Returns the JSON-decoded payload when possible, otherwise the raw string.
+   */
+  private _parseEventData(data: string): any {
+    try {
+      return JSON.parse(data);
+    } catch {
+      return data;
+    }
+  }
+
+  /**
+   * Parses the SSE wire format from the response body and yields one
+   * {@link SseEvent} per event block. Blocks that only carry id/retry fields
+   * are yielded too (without data) so the caller can track reconnection state.
+   * A read error (connection loss) propagates to the caller.
+   */
+  private async *_iterSseEvents(response: Response): AsyncGenerator<SseEvent, void, unknown> {
+    const body = response.body;
+    if (!body) {
+      return;
+    }
+
+    const reader = body.getReader();
+    const decoder = new TextDecoder('utf-8');
+    let buffer = '';
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        // Normalise CRLF / CR line endings to LF so the event delimiter is always "\n\n".
+        buffer += decoder.decode(value, { stream: true }).replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+
+        let delimiterIndex: number;
+        while ((delimiterIndex = buffer.indexOf('\n\n')) >= 0) {
+          const rawEvent = buffer.slice(0, delimiterIndex);
+          buffer = buffer.slice(delimiterIndex + 2);
+          const event = this._parseSseEvent(rawEvent);
+          if (event) {
+            yield event;
+          }
+        }
+      }
+
+      // Flush a trailing event that was not terminated by a blank line.
+      buffer += decoder.decode();
+      const trailing = this._parseSseEvent(buffer);
+      if (trailing) {
+        yield trailing;
+      }
+    } finally {
+      // Release the connection if the consumer stopped early or an error occurred.
+      try {
+        await reader.cancel();
+      } catch {
+        // ignore
+      }
+    }
+  }
+
+  /**
+   * Parses one SSE event block (lines separated by "\n"). Returns undefined
+   * for blocks with no fields at all (blank / comment-only keep-alives).
+   */
+  private _parseSseEvent(rawEvent: string): SseEvent | undefined {
+    if (!rawEvent.trim()) {
+      return undefined;
+    }
+
+    const event: SseEvent = {};
+    const dataLines: string[] = [];
+
+    for (const line of rawEvent.split('\n')) {
+      if (line.startsWith(':')) {
+        continue; // comment
+      }
+      const colonIndex = line.indexOf(':');
+      let field: string;
+      let value: string;
+      if (colonIndex === -1) {
+        field = line;
+        value = '';
+      } else {
+        field = line.slice(0, colonIndex);
+        value = line.slice(colonIndex + 1);
+        if (value.startsWith(' ')) {
+          value = value.slice(1);
+        }
+      }
+
+      if (field === 'event') {
+        event.event = value;
+      } else if (field === 'data') {
+        dataLines.push(value);
+      } else if (field === 'id') {
+        event.id = value;
+      } else if (field === 'retry') {
+        const retry = parseInt(value, 10);
+        if (!Number.isNaN(retry)) {
+          event.retry = retry;
+        }
+      }
+    }
+
+    if (dataLines.length > 0) {
+      event.data = dataLines.join('\n');
+    }
+
+    return Object.keys(event).length > 0 ? event : undefined;
+  }
+
+  /**
+   * Handles the OAuth2 client-credentials flow, trying credentials in the body
+   * first and then as a Basic Auth header. Tokens are cached per client_id.
+   */
+  private async _handleOAuth2(authDetails: OAuth2Auth): Promise<string> {
+    const clientId = authDetails.client_id;
+    const cached = this.oauthTokens.get(clientId);
+    if (cached && (cached.expires_at === undefined || cached.expires_at > Date.now())) {
+      return cached.access_token;
+    }
+
+    // The token URL may come from an untrusted call template; validate it
+    // before posting credentials (GHSA-8cp3-qxj6-px34).
+    ensureSecureUrl(authDetails.token_url, 'OAuth2 token URL');
+
+    const storeToken = (tokenData: any): string => {
+      if (!tokenData || !tokenData.access_token) {
+        throw new Error('Access token not found in response.');
+      }
+      const expiresIn = typeof tokenData.expires_in === 'number' ? tokenData.expires_in : 3600;
+      this.oauthTokens.set(clientId, { access_token: tokenData.access_token, expires_at: Date.now() + expiresIn * 1000 });
+      return tokenData.access_token;
+    };
+
+    // Method 1: credentials in the request body
+    try {
+      this._logInfo(`Attempting OAuth2 token fetch for '${clientId}' with credentials in body.`);
+      const bodyData = new URLSearchParams({
+        grant_type: 'client_credentials',
+        client_id: clientId,
+        client_secret: authDetails.client_secret,
+        scope: authDetails.scope || '',
+      });
+      const response = await fetch(authDetails.token_url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: bodyData.toString(),
+        redirect: 'error',
+      });
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+      return storeToken(await response.json());
+    } catch (error: any) {
+      this._logError(`OAuth2 with credentials in body failed for '${clientId}': ${error.message}. Trying Basic Auth header.`);
+    }
+
+    // Method 2: credentials as a Basic Auth header
+    try {
+      this._logInfo(`Attempting OAuth2 token fetch for '${clientId}' with Basic Auth header.`);
+      const bodyData = new URLSearchParams({
+        grant_type: 'client_credentials',
+        scope: authDetails.scope || '',
+      });
+      const credentials = Buffer.from(`${clientId}:${authDetails.client_secret}`).toString('base64');
+      const response = await fetch(authDetails.token_url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'Authorization': `Basic ${credentials}`,
+        },
+        body: bodyData.toString(),
+        redirect: 'error',
+      });
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+      return storeToken(await response.json());
+    } catch (error: any) {
+      this._logError(`OAuth2 with Basic Auth header also failed for '${clientId}': ${error.message}`);
+      throw new Error(`Failed to fetch OAuth2 token for client '${clientId}' after trying all methods. Details: ${error.message}`);
+    }
+  }
+
+  /**
+   * Builds the URL by substituting {param} path parameters from args.
+   * Consumed parameters are removed from args so they are not sent as query parameters.
+   */
+  private _buildUrlWithPathParams(urlTemplate: string, args: Record<string, any>): string {
+    let url = urlTemplate;
+    const pathParams = urlTemplate.match(/\{([^}]+)\}/g) || [];
+
+    for (const param of pathParams) {
+      const paramName = param.slice(1, -1);
+      if (paramName in args) {
+        // URL-encode the parameter value to prevent path injection
+        url = url.replace(param, encodeURIComponent(String(args[paramName])));
+        delete args[paramName];
+      } else {
+        throw new Error(`Missing required path parameter: ${paramName}`);
+      }
+    }
+
+    const remainingParams = url.match(/\{([^}]+)\}/g);
+    if (remainingParams && remainingParams.length > 0) {
+      throw new Error(`Missing required path parameters in URL template: ${remainingParams.join(', ')}`);
+    }
+
+    return url;
   }
 
   /**

--- a/packages/http/src/sse_communication_protocol.ts
+++ b/packages/http/src/sse_communication_protocol.ts
@@ -580,8 +580,10 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
         event.id = value;
       } else if (field === 'retry') {
         // Spec: only a value made of ASCII digits sets the reconnection time.
-        // An absurdly long digit string parses to Infinity and is ignored.
-        if (/^[0-9]+$/.test(value) && Number.isFinite(Number(value))) {
+        // An overflowing digit string becomes Infinity, which the reconnect
+        // delay cap turns into MAX_RECONNECT_DELAY_MS: the server asked for a
+        // long wait and gets the longest one allowed.
+        if (/^[0-9]+$/.test(value)) {
           event.retry = Number(value);
         }
       }

--- a/packages/http/src/sse_communication_protocol.ts
+++ b/packages/http/src/sse_communication_protocol.ts
@@ -15,7 +15,7 @@ import { OAuth2UserAuth } from '@utcp/sdk';
 import { IUtcpClient } from '@utcp/sdk';
 import { SseCallTemplate, SseCallTemplateSchema } from './sse_call_template';
 import { ensureSecureUrl, assertNoCrlf } from './_security';
-import { truncateByCodePoint } from './_text';
+import { readErrorDetail } from './_text';
 import { buildUrlWithPathParams } from './_url';
 
 /**
@@ -220,11 +220,8 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
         // Read the body before throwing — servers put the real reason there
         // (e.g. { "error": "..." }); discarding it leaves callers with only a
         // status code. Fall back to statusText when the body is empty.
-        const body = await response.text().catch(() => '');
-        // Truncate like the streaming path does, so a huge error page does
-        // not land in errors[] and logs in full. By code point, so a
-        // multi-byte character on the boundary cannot leave a lone surrogate.
-        const detail = truncateByCodePoint(body.trim(), 200) || response.statusText;
+        // Bounded read, control characters collapsed, truncated by code point.
+        const detail = (await readErrorDetail(response, 200)) || response.statusText;
         throw new Error(`HTTP ${response.status}: ${detail}`);
       }
 
@@ -362,19 +359,27 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
       }
     }
 
-    this._logInfo(`Executing SSE tool '${toolName}' with URL: ${urlObj.toString()} and method: ${method}`);
+    // Log without the query string: an API key with location 'query', or any
+    // sensitive tool argument, would otherwise land in the logs.
+    this._logInfo(`Executing SSE tool '${toolName}' with URL: ${urlObj.origin}${urlObj.pathname} and method: ${method}`);
 
     const providerName = provider.name || toolName;
     const eventType = provider.event_type ?? undefined;
-    const reconnect = provider.reconnect !== false;
+    // Never re-send a request body: a reconnect re-issues the request, and for
+    // a POST that would re-execute a possibly non-idempotent tool.
+    const reconnect = provider.reconnect !== false && bodyContent === undefined;
+    if (provider.reconnect !== false && bodyContent !== undefined) {
+      this._logInfo(`Reconnection is disabled for '${providerName}' because the call sends a request body.`);
+    }
     let retryDelayMs = provider.retry_timeout;
     let lastEventId: string | undefined;
     let reconnectAttempts = 0;
 
     while (true) {
       const attemptHeaders: Record<string, string> = { ...requestHeaders };
-      if (lastEventId !== undefined) {
-        // Let the server resume from where we left off (SSE spec).
+      if (lastEventId) {
+        // Let the server resume from where we left off (SSE spec). An empty
+        // last event ID means "none": the header is not sent.
         attemptHeaders['Last-Event-ID'] = lastEventId;
       }
 
@@ -402,15 +407,27 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
         });
 
         if (!response.ok) {
-          let detail = '';
+          const detail = await readErrorDetail(response, 200);
+          throw new Error(`HTTP ${response.status}: ${response.statusText}${detail ? ` - ${detail}` : ''}`);
+        }
+
+        // Anything but an event stream would be parsed into silence: a JSON
+        // error document, say, yields zero events and a "successful" call.
+        const contentType = response.headers.get('content-type') || '';
+        if (!contentType.toLowerCase().includes('text/event-stream')) {
           try {
-            detail = await response.text();
+            await response.body?.cancel();
           } catch {
-            // ignore body read failures on error responses
+            // ignore
           }
-          throw new Error(`HTTP ${response.status}: ${response.statusText}${detail ? ` - ${detail.slice(0, 200)}` : ''}`);
+          throw new SseProtocolError(
+            `Expected a text/event-stream response but got '${contentType || 'no Content-Type'}'`
+          );
         }
       } catch (error: any) {
+        if (error instanceof SseProtocolError) {
+          throw error;
+        }
         if (reconnectAttempts === 0) {
           // The initial handshake failing (refused, timed out, non-2xx) is a
           // definitive answer about the endpoint: fail fast, no retry.
@@ -436,7 +453,9 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
 
       try {
         for await (const event of this._iterSseEvents(response)) {
-          if (event.id !== undefined) {
+          // Per the SSE spec an id containing NUL is ignored, and an empty id
+          // resets the last event ID.
+          if (event.id !== undefined && !event.id.includes('\0')) {
             lastEventId = event.id;
           }
           if (event.retry !== undefined) {
@@ -445,7 +464,8 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
           if (event.data === undefined) {
             continue;
           }
-          if (eventType && event.event !== eventType) {
+          // An event block without an `event:` field has the type "message".
+          if (eventType && (event.event || 'message') !== eventType) {
             continue;
           }
           yield this._parseEventData(event.data);
@@ -695,7 +715,8 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
 
   /**
    * REQUIRED
-   * Close all active connections and clear internal state.
+   * Clear cached OAuth2 tokens. Streams in flight are owned by their
+   * consumers and end when the consumer stops iterating or the server closes.
    */
   async close(): Promise<void> {
     this._logInfo('Closing SseCommunicationProtocol.');

--- a/packages/http/src/sse_communication_protocol.ts
+++ b/packages/http/src/sse_communication_protocol.ts
@@ -525,6 +525,13 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
           yield event;
         }
       }
+      // The residual (discarded) buffer is still subject to the cap, so an
+      // over-limit malformed stream fails the same way at end of stream.
+      if (buffer.length > SseCommunicationProtocol.MAX_EVENT_BUFFER_CHARS) {
+        throw new SseProtocolError(
+          `SSE event exceeded ${SseCommunicationProtocol.MAX_EVENT_BUFFER_CHARS} characters without a blank-line delimiter`
+        );
+      }
     } finally {
       // Release the connection if the consumer stopped early or an error occurred.
       try {

--- a/packages/http/src/streamable_http_communication_protocol.ts
+++ b/packages/http/src/streamable_http_communication_protocol.ts
@@ -8,13 +8,11 @@ import { CommunicationProtocol } from '@utcp/sdk';
 import { RegisterManualResult } from '@utcp/sdk';
 import { CallTemplate } from '@utcp/sdk';
 import { UtcpManual, UtcpManualSerializer } from '@utcp/sdk';
-import { ApiKeyAuth } from '@utcp/sdk';
-import { BasicAuth } from '@utcp/sdk';
 import { OAuth2Auth } from '@utcp/sdk';
-import { OAuth2UserAuth } from '@utcp/sdk';
 import { IUtcpClient } from '@utcp/sdk';
 import { StreamableHttpCallTemplate, StreamableHttpCallTemplateSchema } from './streamable_http_call_template';
 import { ensureSecureUrl, assertNoCrlf } from './_security';
+import { applyAuth, finalizeAuthHeaders, fetchOAuth2Token, AuthLogger } from './_auth';
 import { readErrorDetail } from './_text';
 import { buildUrlWithPathParams } from './_url';
 
@@ -47,61 +45,22 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
     console.error(`[StreamableHttpCommunicationProtocol] ${message}`);
   }
 
+  private get _authLog(): AuthLogger {
+    return { info: (m) => this._logInfo(m), error: (m) => this._logError(m) };
+  }
+
   private _applyAuth(
     provider: StreamableHttpCallTemplate,
     headers: Record<string, string>,
     queryParams: Record<string, any>
   ): { auth?: { username: string; password: string }; cookies: Record<string, string> } {
-    let auth: { username: string; password: string } | undefined;
-    const cookies: Record<string, string> = {};
-
-    if (provider.auth) {
-      if ('api_key' in provider.auth) {
-        const apiKeyAuth = provider.auth as ApiKeyAuth;
-        if (apiKeyAuth.api_key) {
-          assertNoCrlf(apiKeyAuth.var_name, 'ApiKeyAuth.var_name');
-          // Default to 'header' if location is not specified
-          const location = apiKeyAuth.location || 'header';
-          if (location === 'header') {
-            headers[apiKeyAuth.var_name] = apiKeyAuth.api_key;
-          } else if (location === 'query') {
-            queryParams[apiKeyAuth.var_name] = apiKeyAuth.api_key;
-          } else if (location === 'cookie') {
-            cookies[apiKeyAuth.var_name] = apiKeyAuth.api_key;
-          }
-        } else {
-          this._logError('API key not found for ApiKeyAuth.');
-          throw new Error('API key for ApiKeyAuth not found.');
-        }
-      } else if ('username' in provider.auth && 'password' in provider.auth) {
-        const basicAuth = provider.auth as BasicAuth;
-        auth = { username: basicAuth.username, password: basicAuth.password };
-      } else if ('token_url' in provider.auth) {
-        // OAuth2 will be handled separately
-      } else if (provider.auth.auth_type === 'oauth2_user') {
-        // Interactive (user-delegated) OAuth2: token provisioned out-of-band.
-        const userAuth = provider.auth as OAuth2UserAuth;
-        if (!userAuth.access_token) {
-          throw new Error(
-            "access_token for oauth2_user auth is empty. Run an interactive " +
-              "login to provision it.",
-          );
-        }
-        const headerName = userAuth.var_name || 'Authorization';
-        const prefix = userAuth.prefix ?? 'Bearer ';
-        assertNoCrlf(headerName, 'OAuth2UserAuth.var_name');
-        assertNoCrlf(prefix, 'OAuth2UserAuth.prefix');
-        assertNoCrlf(userAuth.access_token, 'OAuth2UserAuth.access_token');
-        headers[headerName] = `${prefix}${userAuth.access_token}`;
-      }
-    }
-
-    return { auth, cookies };
+    return applyAuth(provider.auth, headers, queryParams, this._authLog);
   }
 
   /**
    * Applies Basic auth, cookies and (if configured) an OAuth2 client-credentials
-   * bearer token to the request headers.
+   * bearer token to the request headers. Shared with the other fetch-based
+   * protocol via _auth.ts so security fixes land in one place.
    */
   private async _finalizeAuthHeaders(
     provider: StreamableHttpCallTemplate,
@@ -110,23 +69,7 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
     cookies: Record<string, string>,
     signal: AbortSignal,
   ): Promise<void> {
-    if (auth) {
-      const credentials = Buffer.from(`${auth.username}:${auth.password}`).toString('base64');
-      headers['Authorization'] = `Basic ${credentials}`;
-    }
-
-    if (Object.keys(cookies).length > 0) {
-      const cookieHeader = Object.entries(cookies)
-        .map(([k, v]) => `${k}=${v}`)
-        .join('; ');
-      assertNoCrlf(cookieHeader, 'Cookie');
-      headers['Cookie'] = headers['Cookie'] ? `${headers['Cookie']}; ${cookieHeader}` : cookieHeader;
-    }
-
-    if (provider.auth && 'token_url' in provider.auth) {
-      const token = await this._handleOAuth2(provider.auth as OAuth2Auth, signal);
-      headers['Authorization'] = `Bearer ${token}`;
-    }
+    return finalizeAuthHeaders(provider.auth, headers, auth, cookies, signal, this.oauthTokens, this._authLog);
   }
 
   /**
@@ -382,7 +325,7 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
     chunkSize: number | undefined,
     providerName: string,
   ): AsyncGenerator<any, void, unknown> {
-    const contentType = response.headers.get('content-type') || '';
+    const contentType = (response.headers.get('content-type') || '').toLowerCase();
     const body = response.body;
 
     if (!body) {
@@ -474,78 +417,10 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
   }
 
   /**
-   * Handles the OAuth2 client-credentials flow, trying credentials in the body
-   * first and then as a Basic Auth header. Tokens are cached per full OAuth
-   * configuration (token URL, client id, secret, scope), never per client_id
-   * alone: two templates may share a client_id but point at different issuers.
-   * Both credential methods run under the caller's `signal`, which carries
-   * the call's own deadline, so the whole token flow can never exceed it.
+   * OAuth2 client-credentials flow, shared via _auth.ts.
    */
   private async _handleOAuth2(authDetails: OAuth2Auth, signal: AbortSignal): Promise<string> {
-    const clientId = authDetails.client_id;
-
-    // The token URL may come from an untrusted call template; validate it
-    // before the cache is consulted, so a template with a rejected URL never
-    // receives a token fetched on behalf of another (GHSA-8cp3-qxj6-px34).
-    ensureSecureUrl(authDetails.token_url, 'OAuth2 token URL');
-
-    const cacheKey = JSON.stringify([authDetails.token_url, clientId, authDetails.client_secret, authDetails.scope || '']);
-    const cached = this.oauthTokens.get(cacheKey);
-    if (cached && (cached.expires_at === undefined || cached.expires_at > Date.now())) {
-      return cached.access_token;
-    }
-
-    const storeToken = (tokenData: any): string => {
-      if (!tokenData || !tokenData.access_token) {
-        throw new Error('Access token not found in response.');
-      }
-      const expiresIn = typeof tokenData.expires_in === 'number' ? tokenData.expires_in : 3600;
-      this.oauthTokens.set(cacheKey, { access_token: tokenData.access_token, expires_at: Date.now() + expiresIn * 1000 });
-      return tokenData.access_token;
-    };
-
-    const requestToken = async (headers: Record<string, string>, form: Record<string, string>): Promise<string> => {
-      if (signal.aborted) {
-        throw new Error('Timed out before the token request could start.');
-      }
-      const response = await fetch(authDetails.token_url, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded', ...headers },
-        body: new URLSearchParams(form).toString(),
-        redirect: 'error',
-        signal,
-      });
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-      }
-      return storeToken(await response.json());
-    };
-
-    // Method 1: credentials in the request body
-    try {
-      this._logInfo(`Attempting OAuth2 token fetch for '${clientId}' with credentials in body.`);
-      return await requestToken({}, {
-        grant_type: 'client_credentials',
-        client_id: clientId,
-        client_secret: authDetails.client_secret,
-        scope: authDetails.scope || '',
-      });
-    } catch (error: any) {
-      this._logError(`OAuth2 with credentials in body failed for '${clientId}': ${error.message}. Trying Basic Auth header.`);
-    }
-
-    // Method 2: credentials as a Basic Auth header
-    try {
-      this._logInfo(`Attempting OAuth2 token fetch for '${clientId}' with Basic Auth header.`);
-      const credentials = Buffer.from(`${clientId}:${authDetails.client_secret}`).toString('base64');
-      return await requestToken({ 'Authorization': `Basic ${credentials}` }, {
-        grant_type: 'client_credentials',
-        scope: authDetails.scope || '',
-      });
-    } catch (error: any) {
-      this._logError(`OAuth2 with Basic Auth header also failed for '${clientId}': ${error.message}`);
-      throw new Error(`Failed to fetch OAuth2 token for client '${clientId}' after trying all methods. Details: ${error.message}`);
-    }
+    return fetchOAuth2Token(authDetails, signal, this.oauthTokens, this._authLog);
   }
 
   /**

--- a/packages/http/src/streamable_http_communication_protocol.ts
+++ b/packages/http/src/streamable_http_communication_protocol.ts
@@ -1,6 +1,6 @@
 /**
  * Streamable HTTP Communication Protocol for UTCP.
- * 
+ *
  * Handles HTTP streaming with chunked transfer encoding for real-time data.
  */
 // packages/http/src/streamable_http_communication_protocol.ts
@@ -13,14 +13,19 @@ import { BasicAuth } from '@utcp/sdk';
 import { OAuth2Auth } from '@utcp/sdk';
 import { OAuth2UserAuth } from '@utcp/sdk';
 import { IUtcpClient } from '@utcp/sdk';
-import { StreamableHttpCallTemplate } from './streamable_http_call_template';
+import { StreamableHttpCallTemplate, StreamableHttpCallTemplateSchema } from './streamable_http_call_template';
 import { ensureSecureUrl, assertNoCrlf } from './_security';
 
 /**
  * REQUIRED
  * Streamable HTTP communication protocol implementation for UTCP client.
- * 
+ *
  * Handles HTTP streaming with chunked transfer encoding for real-time data.
+ *
+ * Chunks are yielded according to the response Content-Type:
+ *   - application/x-ndjson: one parsed JSON value per line (raw line on parse error)
+ *   - application/json: the whole body buffered and parsed as a single JSON value
+ *   - application/octet-stream and anything else: Buffer chunks of at most chunk_size bytes
  */
 export class StreamableHttpCommunicationProtocol implements CommunicationProtocol {
   private oauthTokens: Map<string, { access_token: string; expires_at?: number }> = new Map();
@@ -86,6 +91,35 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
   }
 
   /**
+   * Applies Basic auth, cookies and (if configured) an OAuth2 client-credentials
+   * bearer token to the request headers.
+   */
+  private async _finalizeAuthHeaders(
+    provider: StreamableHttpCallTemplate,
+    headers: Record<string, string>,
+    auth: { username: string; password: string } | undefined,
+    cookies: Record<string, string>,
+  ): Promise<void> {
+    if (auth) {
+      const credentials = Buffer.from(`${auth.username}:${auth.password}`).toString('base64');
+      headers['Authorization'] = `Basic ${credentials}`;
+    }
+
+    if (Object.keys(cookies).length > 0) {
+      const cookieHeader = Object.entries(cookies)
+        .map(([k, v]) => `${k}=${v}`)
+        .join('; ');
+      assertNoCrlf(cookieHeader, 'Cookie');
+      headers['Cookie'] = headers['Cookie'] ? `${headers['Cookie']}; ${cookieHeader}` : cookieHeader;
+    }
+
+    if (provider.auth && 'token_url' in provider.auth) {
+      const token = await this._handleOAuth2(provider.auth as OAuth2Auth);
+      headers['Authorization'] = `Bearer ${token}`;
+    }
+  }
+
+  /**
    * REQUIRED
    * Register a manual and its tools from a StreamableHttp provider.
    */
@@ -97,7 +131,7 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
       throw new Error('StreamableHttpCommunicationProtocol can only be used with StreamableHttpCallTemplate');
     }
 
-    const provider = manualCallTemplate as StreamableHttpCallTemplate;
+    const provider = StreamableHttpCallTemplateSchema.parse(manualCallTemplate);
     const url = provider.url;
 
     // Security check: only HTTPS or loopback HTTP allowed for manual discovery.
@@ -109,6 +143,7 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
       const requestHeaders: Record<string, string> = provider.headers ? { ...provider.headers } : {};
       const queryParams: Record<string, any> = {};
       const { auth, cookies } = this._applyAuth(provider, requestHeaders, queryParams);
+      await this._finalizeAuthHeaders(provider, requestHeaders, auth, cookies);
 
       // Build URL with query parameters
       const urlObj = new URL(url);
@@ -116,45 +151,38 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
         urlObj.searchParams.append(key, String(value));
       });
 
-      // Build fetch options. ``redirect: 'error'`` refuses to follow
-      // 3xx responses -- streaming handshakes shouldn't redirect, and
-      // doing so silently would let an attacker-controlled endpoint
-      // steer the stream into an internal service
-      // (GHSA-9qhg-99ww-9mqc).
-      const fetchOptions: RequestInit = {
-        method: provider.http_method || 'GET',
-        headers: requestHeaders,
-        redirect: 'error',
-      };
+      // ``redirect: 'error'`` refuses to follow 3xx responses -- streaming
+      // handshakes shouldn't redirect, and doing so silently would let an
+      // attacker-controlled endpoint steer the stream into an internal
+      // service (GHSA-9qhg-99ww-9mqc).
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), provider.timeout || 60000);
+      try {
+        const response = await fetch(urlObj.toString(), {
+          method: provider.http_method || 'GET',
+          headers: requestHeaders,
+          redirect: 'error',
+          signal: controller.signal,
+        });
 
-      // Add basic auth if present
-      if (auth) {
-        const credentials = Buffer.from(`${auth.username}:${auth.password}`).toString('base64');
-        fetchOptions.headers = {
-          ...fetchOptions.headers as Record<string, string>,
-          'Authorization': `Basic ${credentials}`,
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+        }
+
+        const responseText = await response.text();
+        const utcpManual = new UtcpManualSerializer().validateDict(JSON.parse(responseText));
+
+        this._logInfo(`Discovered ${utcpManual.tools.length} tools from '${provider.name}'`);
+
+        return {
+          manualCallTemplate: provider,
+          manual: utcpManual,
+          success: true,
+          errors: [],
         };
+      } finally {
+        clearTimeout(timer);
       }
-
-      // Make discovery request
-      const response = await fetch(urlObj.toString(), fetchOptions);
-
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-      }
-
-      // Read response body
-      const responseText = await response.text();
-      const utcpManual = new UtcpManualSerializer().validateDict(JSON.parse(responseText));
-
-      this._logInfo(`Discovered ${utcpManual.tools.length} tools from '${provider.name}'`);
-
-      return {
-        manualCallTemplate: provider,
-        manual: utcpManual,
-        success: true,
-        errors: [],
-      };
     } catch (error: any) {
       this._logError(`Error discovering tools from '${provider.name}': ${error.message}`);
       return {
@@ -177,6 +205,10 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
   /**
    * REQUIRED
    * Call a tool using HTTP (non-streaming).
+   *
+   * Collects every chunk produced by callToolStreaming. Binary chunks are
+   * concatenated into a single Buffer; parsed (JSON / NDJSON) chunks are
+   * returned as an array, mirroring the Python implementation.
    */
   async callTool(
     caller: IUtcpClient,
@@ -184,12 +216,19 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
     toolArgs: Record<string, any>,
     toolCallTemplate: CallTemplate
   ): Promise<any> {
-    // For streamable HTTP, we collect all chunks and return the complete result
-    const chunks: string[] = [];
+    const binaryChunks: Buffer[] = [];
+    const parsedChunks: any[] = [];
     for await (const chunk of this.callToolStreaming(caller, toolName, toolArgs, toolCallTemplate)) {
-      chunks.push(chunk);
+      if (Buffer.isBuffer(chunk) || chunk instanceof Uint8Array) {
+        binaryChunks.push(Buffer.from(chunk));
+      } else {
+        parsedChunks.push(chunk);
+      }
     }
-    return chunks.join('');
+    if (binaryChunks.length > 0) {
+      return Buffer.concat(binaryChunks);
+    }
+    return parsedChunks;
   }
 
   /**
@@ -203,14 +242,298 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
     toolArgs: Record<string, any>,
     toolCallTemplate: CallTemplate
   ): AsyncGenerator<any, void, unknown> {
-    const provider = toolCallTemplate as StreamableHttpCallTemplate;
+    if ((toolCallTemplate as any).call_template_type !== 'streamable_http') {
+      throw new Error('StreamableHttpCommunicationProtocol can only be used with StreamableHttpCallTemplate');
+    }
+    const provider = StreamableHttpCallTemplateSchema.parse(toolCallTemplate);
 
-    // TODO: Implement actual streaming call logic
-    // This would involve making an HTTP request and streaming the response in chunks
-    this._logInfo(`Calling streaming tool '${toolName}' with args: ${JSON.stringify(toolArgs)}`);
-    
-    // Placeholder implementation
-    yield `Streaming response for tool: ${toolName}`;
+    const requestHeaders: Record<string, string> = provider.headers ? { ...provider.headers } : {};
+    let bodyContent: any = undefined;
+    const remainingArgs: Record<string, any> = { ...toolArgs };
+
+    if (provider.header_fields) {
+      for (const fieldName of provider.header_fields) {
+        if (fieldName in remainingArgs) {
+          assertNoCrlf(fieldName, 'header field name');
+          const value = String(remainingArgs[fieldName]);
+          assertNoCrlf(value, `header field '${fieldName}'`);
+          requestHeaders[fieldName] = value;
+          delete remainingArgs[fieldName];
+        }
+      }
+    }
+
+    if (provider.body_field && provider.body_field in remainingArgs) {
+      bodyContent = remainingArgs[provider.body_field];
+      delete remainingArgs[provider.body_field];
+    }
+
+    // Build the URL with path parameters substituted
+    const url = this._buildUrlWithPathParams(provider.url, remainingArgs);
+
+    // Security check: re-validate the resolved URL before each invocation.
+    ensureSecureUrl(url, 'tool invocation');
+
+    // The rest of the arguments are query parameters
+    const queryParams: Record<string, any> = { ...remainingArgs };
+
+    // Handle authentication
+    const { auth, cookies } = this._applyAuth(provider, requestHeaders, queryParams);
+    await this._finalizeAuthHeaders(provider, requestHeaders, auth, cookies);
+
+    const urlObj = new URL(url);
+    Object.entries(queryParams).forEach(([key, value]) => {
+      if (value === undefined || value === null) return;
+      urlObj.searchParams.append(key, typeof value === 'object' ? JSON.stringify(value) : String(value));
+    });
+
+    let body: BodyInit | undefined = undefined;
+    if (bodyContent !== undefined) {
+      const hasContentType = Object.keys(requestHeaders).some(h => h.toLowerCase() === 'content-type');
+      if (!hasContentType) {
+        requestHeaders['Content-Type'] = provider.content_type;
+      }
+      const contentType = Object.entries(requestHeaders).find(([h]) => h.toLowerCase() === 'content-type')?.[1] || '';
+      if (contentType.includes('application/json')) {
+        body = JSON.stringify(bodyContent);
+      } else if (typeof bodyContent === 'string' || bodyContent instanceof Uint8Array || bodyContent instanceof ArrayBuffer) {
+        body = bodyContent as BodyInit;
+      } else {
+        body = JSON.stringify(bodyContent);
+      }
+    }
+
+    this._logInfo(`Executing streaming HTTP tool '${toolName}' with URL: ${urlObj.toString()} and method: ${provider.http_method}`);
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), provider.timeout || 60000);
+    try {
+      // ``redirect: 'error'`` -- see registerManual for rationale (GHSA-9qhg-99ww-9mqc).
+      // ``keepalive: false`` -- do not take a pooled socket for the stream. Bun's
+      // fetch transparently re-issues a request when a reused keep-alive socket
+      // dies mid-response, which would hand the consumer the partial chunks
+      // followed by a full replay. Node ignores the option.
+      const response = await fetch(urlObj.toString(), {
+        method: provider.http_method || 'GET',
+        headers: requestHeaders,
+        body,
+        redirect: 'error',
+        signal: controller.signal,
+        keepalive: false,
+      });
+
+      if (!response.ok) {
+        let detail = '';
+        try {
+          detail = await response.text();
+        } catch {
+          // ignore body read failures on error responses
+        }
+        throw new Error(`HTTP ${response.status}: ${response.statusText}${detail ? ` - ${detail.slice(0, 200)}` : ''}`);
+      }
+
+      for await (const chunk of this._processHttpStream(response, provider.chunk_size, provider.name || toolName)) {
+        yield chunk;
+      }
+    } catch (error: any) {
+      this._logError(`Error during HTTP stream for '${provider.name || toolName}': ${error.message}`);
+      throw error;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  /**
+   * Processes the HTTP response body and yields chunks based on content type.
+   */
+  private async *_processHttpStream(
+    response: Response,
+    chunkSize: number | undefined,
+    providerName: string,
+  ): AsyncGenerator<any, void, unknown> {
+    const contentType = response.headers.get('content-type') || '';
+    const body = response.body;
+
+    if (!body) {
+      // No body (e.g. 204). Nothing to yield.
+      return;
+    }
+
+    const reader = body.getReader();
+    try {
+      if (contentType.includes('application/x-ndjson')) {
+        const decoder = new TextDecoder('utf-8');
+        let buffer = '';
+        const parseLine = (line: string): any => {
+          try {
+            return JSON.parse(line);
+          } catch {
+            this._logError(`Error parsing NDJSON line for '${providerName}': ${line.slice(0, 100)}`);
+            return line; // Yield raw line on error
+          }
+        };
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          buffer += decoder.decode(value, { stream: true });
+          let newlineIndex: number;
+          while ((newlineIndex = buffer.indexOf('\n')) >= 0) {
+            const line = buffer.slice(0, newlineIndex).replace(/\r$/, '');
+            buffer = buffer.slice(newlineIndex + 1);
+            if (line.trim()) {
+              yield parseLine(line);
+            }
+          }
+        }
+        buffer += decoder.decode();
+        if (buffer.trim()) {
+          yield parseLine(buffer.replace(/\r$/, ''));
+        }
+      } else if (contentType.includes('application/json')) {
+        // Buffer the entire response for a single JSON object
+        const parts: Buffer[] = [];
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          parts.push(Buffer.from(value));
+        }
+        const buffer = Buffer.concat(parts);
+        if (buffer.length > 0) {
+          const text = buffer.toString('utf-8');
+          try {
+            yield JSON.parse(text);
+          } catch {
+            this._logError(`Error parsing JSON response for '${providerName}': ${text.slice(0, 100)}`);
+            yield buffer; // Yield raw buffer on error
+          }
+        }
+      } else {
+        // Binary chunk streaming for application/octet-stream and unknown content types.
+        // Re-chunk the network reads so each yielded Buffer is at most chunkSize bytes.
+        const size = chunkSize && chunkSize > 0 ? chunkSize : 8192;
+        let pending = Buffer.alloc(0);
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          pending = pending.length === 0 ? Buffer.from(value) : Buffer.concat([pending, Buffer.from(value)]);
+          while (pending.length >= size) {
+            yield pending.subarray(0, size);
+            pending = pending.subarray(size);
+          }
+        }
+        if (pending.length > 0) {
+          yield pending;
+        }
+      }
+    } finally {
+      // Release the connection if the consumer stopped early or an error occurred.
+      try {
+        await reader.cancel();
+      } catch {
+        // ignore
+      }
+    }
+  }
+
+  /**
+   * Handles the OAuth2 client-credentials flow, trying credentials in the body
+   * first and then as a Basic Auth header. Tokens are cached per client_id.
+   */
+  private async _handleOAuth2(authDetails: OAuth2Auth): Promise<string> {
+    const clientId = authDetails.client_id;
+    const cached = this.oauthTokens.get(clientId);
+    if (cached && (cached.expires_at === undefined || cached.expires_at > Date.now())) {
+      return cached.access_token;
+    }
+
+    // The token URL may come from an untrusted call template; validate it
+    // before posting credentials (GHSA-8cp3-qxj6-px34).
+    ensureSecureUrl(authDetails.token_url, 'OAuth2 token URL');
+
+    const storeToken = (tokenData: any): string => {
+      if (!tokenData || !tokenData.access_token) {
+        throw new Error('Access token not found in response.');
+      }
+      const expiresIn = typeof tokenData.expires_in === 'number' ? tokenData.expires_in : 3600;
+      this.oauthTokens.set(clientId, { access_token: tokenData.access_token, expires_at: Date.now() + expiresIn * 1000 });
+      return tokenData.access_token;
+    };
+
+    // Method 1: credentials in the request body
+    try {
+      this._logInfo(`Attempting OAuth2 token fetch for '${clientId}' with credentials in body.`);
+      const bodyData = new URLSearchParams({
+        grant_type: 'client_credentials',
+        client_id: clientId,
+        client_secret: authDetails.client_secret,
+        scope: authDetails.scope || '',
+      });
+      const response = await fetch(authDetails.token_url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: bodyData.toString(),
+        redirect: 'error',
+      });
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+      return storeToken(await response.json());
+    } catch (error: any) {
+      this._logError(`OAuth2 with credentials in body failed for '${clientId}': ${error.message}. Trying Basic Auth header.`);
+    }
+
+    // Method 2: credentials as a Basic Auth header
+    try {
+      this._logInfo(`Attempting OAuth2 token fetch for '${clientId}' with Basic Auth header.`);
+      const bodyData = new URLSearchParams({
+        grant_type: 'client_credentials',
+        scope: authDetails.scope || '',
+      });
+      const credentials = Buffer.from(`${clientId}:${authDetails.client_secret}`).toString('base64');
+      const response = await fetch(authDetails.token_url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'Authorization': `Basic ${credentials}`,
+        },
+        body: bodyData.toString(),
+        redirect: 'error',
+      });
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+      return storeToken(await response.json());
+    } catch (error: any) {
+      this._logError(`OAuth2 with Basic Auth header also failed for '${clientId}': ${error.message}`);
+      throw new Error(`Failed to fetch OAuth2 token for client '${clientId}' after trying all methods. Details: ${error.message}`);
+    }
+  }
+
+  /**
+   * Builds the URL by substituting {param} path parameters from args.
+   * Consumed parameters are removed from args so they are not sent as query parameters.
+   */
+  private _buildUrlWithPathParams(urlTemplate: string, args: Record<string, any>): string {
+    let url = urlTemplate;
+    const pathParams = urlTemplate.match(/\{([^}]+)\}/g) || [];
+
+    for (const param of pathParams) {
+      const paramName = param.slice(1, -1);
+      if (paramName in args) {
+        // URL-encode the parameter value to prevent path injection
+        url = url.replace(param, encodeURIComponent(String(args[paramName])));
+        delete args[paramName];
+      } else {
+        throw new Error(`Missing required path parameter: ${paramName}`);
+      }
+    }
+
+    const remainingParams = url.match(/\{([^}]+)\}/g);
+    if (remainingParams && remainingParams.length > 0) {
+      throw new Error(`Missing required path parameters in URL template: ${remainingParams.join(', ')}`);
+    }
+
+    return url;
   }
 
   /**

--- a/packages/http/src/streamable_http_communication_protocol.ts
+++ b/packages/http/src/streamable_http_communication_protocol.ts
@@ -298,38 +298,36 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
     // One deadline for the whole call: token fetch, request and stream.
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), provider.timeout || 60000);
+    // Everything from here on runs under the deadline, and the single
+    // finally below clears the timer on every exit path, including a throw
+    // while building the URL or serializing the body.
     try {
       await this._finalizeAuthHeaders(provider, requestHeaders, auth, cookies, controller.signal);
-    } catch (error) {
-      clearTimeout(timer);
-      throw error;
-    }
 
-    const urlObj = new URL(url);
-    Object.entries(queryParams).forEach(([key, value]) => {
-      if (value === undefined || value === null) return;
-      urlObj.searchParams.append(key, typeof value === 'object' ? JSON.stringify(value) : String(value));
-    });
+      const urlObj = new URL(url);
+      Object.entries(queryParams).forEach(([key, value]) => {
+        if (value === undefined || value === null) return;
+        urlObj.searchParams.append(key, typeof value === 'object' ? JSON.stringify(value) : String(value));
+      });
 
-    let body: BodyInit | undefined = undefined;
-    if (bodyContent !== undefined) {
-      const hasContentType = Object.keys(requestHeaders).some(h => h.toLowerCase() === 'content-type');
-      if (!hasContentType) {
-        requestHeaders['Content-Type'] = provider.content_type;
+      let body: BodyInit | undefined = undefined;
+      if (bodyContent !== undefined) {
+        const hasContentType = Object.keys(requestHeaders).some(h => h.toLowerCase() === 'content-type');
+        if (!hasContentType) {
+          requestHeaders['Content-Type'] = provider.content_type;
+        }
+        const contentType = Object.entries(requestHeaders).find(([h]) => h.toLowerCase() === 'content-type')?.[1] || '';
+        if (contentType.includes('application/json')) {
+          body = JSON.stringify(bodyContent);
+        } else if (typeof bodyContent === 'string' || bodyContent instanceof Uint8Array || bodyContent instanceof ArrayBuffer) {
+          body = bodyContent as BodyInit;
+        } else {
+          body = JSON.stringify(bodyContent);
+        }
       }
-      const contentType = Object.entries(requestHeaders).find(([h]) => h.toLowerCase() === 'content-type')?.[1] || '';
-      if (contentType.includes('application/json')) {
-        body = JSON.stringify(bodyContent);
-      } else if (typeof bodyContent === 'string' || bodyContent instanceof Uint8Array || bodyContent instanceof ArrayBuffer) {
-        body = bodyContent as BodyInit;
-      } else {
-        body = JSON.stringify(bodyContent);
-      }
-    }
 
-    this._logInfo(`Executing streaming HTTP tool '${toolName}' with URL: ${urlObj.toString()} and method: ${provider.http_method}`);
+      this._logInfo(`Executing streaming HTTP tool '${toolName}' with URL: ${urlObj.toString()} and method: ${provider.http_method}`);
 
-    try {
       // ``redirect: 'error'`` -- see registerManual for rationale (GHSA-9qhg-99ww-9mqc).
       // ``keepalive: false`` -- do not take a pooled socket for the stream. Bun's
       // fetch transparently re-issues a request when a reused keep-alive socket

--- a/packages/http/src/streamable_http_communication_protocol.ts
+++ b/packages/http/src/streamable_http_communication_protocol.ts
@@ -15,6 +15,7 @@ import { OAuth2UserAuth } from '@utcp/sdk';
 import { IUtcpClient } from '@utcp/sdk';
 import { StreamableHttpCallTemplate, StreamableHttpCallTemplateSchema } from './streamable_http_call_template';
 import { ensureSecureUrl, assertNoCrlf } from './_security';
+import { truncateByCodePoint } from './_text';
 
 /**
  * REQUIRED
@@ -175,7 +176,7 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
           // Truncate like the streaming path does, so a huge error page does
           // not land in errors[] and logs in full. By code point, so a
           // multi-byte character on the boundary cannot leave a lone surrogate.
-          const detail = Array.from(body.trim()).slice(0, 200).join('') || response.statusText;
+          const detail = truncateByCodePoint(body.trim(), 200) || response.statusText;
           throw new Error(`HTTP ${response.status}: ${detail}`);
         }
 

--- a/packages/http/src/streamable_http_communication_protocol.ts
+++ b/packages/http/src/streamable_http_communication_protocol.ts
@@ -168,7 +168,12 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
         });
 
         if (!response.ok) {
-          throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+          // Read the body before throwing: servers put the real reason there
+          // (e.g. { "error": "..." }); discarding it leaves callers with only a
+          // status code. Fall back to statusText when the body is empty.
+          const body = await response.text().catch(() => '');
+          const detail = body.trim() || response.statusText;
+          throw new Error(`HTTP ${response.status}: ${detail}`);
         }
 
         const responseText = await response.text();

--- a/packages/http/src/streamable_http_communication_protocol.ts
+++ b/packages/http/src/streamable_http_communication_protocol.ts
@@ -114,7 +114,7 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
     }
 
     if (provider.auth && 'token_url' in provider.auth) {
-      const token = await this._handleOAuth2(provider.auth as OAuth2Auth);
+      const token = await this._handleOAuth2(provider.auth as OAuth2Auth, provider.timeout || 60000);
       headers['Authorization'] = `Bearer ${token}`;
     }
   }
@@ -266,6 +266,15 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
     if (provider.body_field && provider.body_field in remainingArgs) {
       bodyContent = remainingArgs[provider.body_field];
       delete remainingArgs[provider.body_field];
+    }
+
+    if (bodyContent !== undefined && (provider.http_method || 'GET').toUpperCase() === 'GET') {
+      // fetch() rejects a GET with a body before anything reaches the server;
+      // surface the misconfiguration as a clear error instead.
+      throw new Error(
+        `Tool '${toolName}': body_field '${provider.body_field}' was supplied but http_method is GET, ` +
+        `which cannot carry a request body. Set http_method to POST.`
+      );
     }
 
     // Build the URL with path parameters substituted
@@ -437,47 +446,64 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
 
   /**
    * Handles the OAuth2 client-credentials flow, trying credentials in the body
-   * first and then as a Basic Auth header. Tokens are cached per client_id.
+   * first and then as a Basic Auth header. Tokens are cached per full OAuth
+   * configuration (token URL, client id, secret, scope), never per client_id
+   * alone: two templates may share a client_id but point at different issuers.
+   * Each token request is bounded by `timeoutMs` so a stalled token endpoint
+   * cannot hang the tool call before its own timeout even starts.
    */
-  private async _handleOAuth2(authDetails: OAuth2Auth): Promise<string> {
+  private async _handleOAuth2(authDetails: OAuth2Auth, timeoutMs: number): Promise<string> {
     const clientId = authDetails.client_id;
-    const cached = this.oauthTokens.get(clientId);
+
+    // The token URL may come from an untrusted call template; validate it
+    // before the cache is consulted, so a template with a rejected URL never
+    // receives a token fetched on behalf of another (GHSA-8cp3-qxj6-px34).
+    ensureSecureUrl(authDetails.token_url, 'OAuth2 token URL');
+
+    const cacheKey = JSON.stringify([authDetails.token_url, clientId, authDetails.client_secret, authDetails.scope || '']);
+    const cached = this.oauthTokens.get(cacheKey);
     if (cached && (cached.expires_at === undefined || cached.expires_at > Date.now())) {
       return cached.access_token;
     }
-
-    // The token URL may come from an untrusted call template; validate it
-    // before posting credentials (GHSA-8cp3-qxj6-px34).
-    ensureSecureUrl(authDetails.token_url, 'OAuth2 token URL');
 
     const storeToken = (tokenData: any): string => {
       if (!tokenData || !tokenData.access_token) {
         throw new Error('Access token not found in response.');
       }
       const expiresIn = typeof tokenData.expires_in === 'number' ? tokenData.expires_in : 3600;
-      this.oauthTokens.set(clientId, { access_token: tokenData.access_token, expires_at: Date.now() + expiresIn * 1000 });
+      this.oauthTokens.set(cacheKey, { access_token: tokenData.access_token, expires_at: Date.now() + expiresIn * 1000 });
       return tokenData.access_token;
+    };
+
+    const requestToken = async (headers: Record<string, string>, form: Record<string, string>): Promise<string> => {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), timeoutMs);
+      try {
+        const response = await fetch(authDetails.token_url, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded', ...headers },
+          body: new URLSearchParams(form).toString(),
+          redirect: 'error',
+          signal: controller.signal,
+        });
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+        }
+        return storeToken(await response.json());
+      } finally {
+        clearTimeout(timer);
+      }
     };
 
     // Method 1: credentials in the request body
     try {
       this._logInfo(`Attempting OAuth2 token fetch for '${clientId}' with credentials in body.`);
-      const bodyData = new URLSearchParams({
+      return await requestToken({}, {
         grant_type: 'client_credentials',
         client_id: clientId,
         client_secret: authDetails.client_secret,
         scope: authDetails.scope || '',
       });
-      const response = await fetch(authDetails.token_url, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        body: bodyData.toString(),
-        redirect: 'error',
-      });
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-      }
-      return storeToken(await response.json());
     } catch (error: any) {
       this._logError(`OAuth2 with credentials in body failed for '${clientId}': ${error.message}. Trying Basic Auth header.`);
     }
@@ -485,24 +511,11 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
     // Method 2: credentials as a Basic Auth header
     try {
       this._logInfo(`Attempting OAuth2 token fetch for '${clientId}' with Basic Auth header.`);
-      const bodyData = new URLSearchParams({
+      const credentials = Buffer.from(`${clientId}:${authDetails.client_secret}`).toString('base64');
+      return await requestToken({ 'Authorization': `Basic ${credentials}` }, {
         grant_type: 'client_credentials',
         scope: authDetails.scope || '',
       });
-      const credentials = Buffer.from(`${clientId}:${authDetails.client_secret}`).toString('base64');
-      const response = await fetch(authDetails.token_url, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/x-www-form-urlencoded',
-          'Authorization': `Basic ${credentials}`,
-        },
-        body: bodyData.toString(),
-        redirect: 'error',
-      });
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-      }
-      return storeToken(await response.json());
     } catch (error: any) {
       this._logError(`OAuth2 with Basic Auth header also failed for '${clientId}': ${error.message}`);
       throw new Error(`Failed to fetch OAuth2 token for client '${clientId}' after trying all methods. Details: ${error.message}`);
@@ -515,20 +528,26 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
    */
   private _buildUrlWithPathParams(urlTemplate: string, args: Record<string, any>): string {
     let url = urlTemplate;
-    const pathParams = urlTemplate.match(/\{([^}]+)\}/g) || [];
+    // Both the `{param}` form from the spec and the `${param}` form the
+    // package README documents.
+    const placeholders = urlTemplate.match(/\$?\{([^}]+)\}/g) || [];
+    const paramNames = Array.from(new Set(
+      placeholders.map(p => (p.startsWith('${') ? p.slice(2, -1) : p.slice(1, -1)))
+    ));
 
-    for (const param of pathParams) {
-      const paramName = param.slice(1, -1);
-      if (paramName in args) {
-        // URL-encode the parameter value to prevent path injection
-        url = url.replace(param, encodeURIComponent(String(args[paramName])));
-        delete args[paramName];
-      } else {
+    for (const paramName of paramNames) {
+      if (!(paramName in args)) {
         throw new Error(`Missing required path parameter: ${paramName}`);
       }
+      // URL-encode the value to prevent path injection, and replace every
+      // occurrence of either form (a template may repeat a parameter).
+      // `${x}` goes first so that replacing `{x}` never leaves a stray `$`.
+      const value = encodeURIComponent(String(args[paramName]));
+      url = url.split('${' + paramName + '}').join(value).split('{' + paramName + '}').join(value);
+      delete args[paramName];
     }
 
-    const remainingParams = url.match(/\{([^}]+)\}/g);
+    const remainingParams = url.match(/\$?\{([^}]+)\}/g);
     if (remainingParams && remainingParams.length > 0) {
       throw new Error(`Missing required path parameters in URL template: ${remainingParams.join(', ')}`);
     }

--- a/packages/http/src/streamable_http_communication_protocol.ts
+++ b/packages/http/src/streamable_http_communication_protocol.ts
@@ -99,6 +99,7 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
     headers: Record<string, string>,
     auth: { username: string; password: string } | undefined,
     cookies: Record<string, string>,
+    signal: AbortSignal,
   ): Promise<void> {
     if (auth) {
       const credentials = Buffer.from(`${auth.username}:${auth.password}`).toString('base64');
@@ -114,7 +115,7 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
     }
 
     if (provider.auth && 'token_url' in provider.auth) {
-      const token = await this._handleOAuth2(provider.auth as OAuth2Auth, provider.timeout || 60000);
+      const token = await this._handleOAuth2(provider.auth as OAuth2Auth, signal);
       headers['Authorization'] = `Bearer ${token}`;
     }
   }
@@ -139,11 +140,14 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
 
     this._logInfo(`Discovering tools from '${provider.name}' (HTTP Stream) at ${url}`);
 
+    // One deadline for the whole discovery call, token fetch included.
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), provider.timeout || 60000);
     try {
       const requestHeaders: Record<string, string> = provider.headers ? { ...provider.headers } : {};
       const queryParams: Record<string, any> = {};
       const { auth, cookies } = this._applyAuth(provider, requestHeaders, queryParams);
-      await this._finalizeAuthHeaders(provider, requestHeaders, auth, cookies);
+      await this._finalizeAuthHeaders(provider, requestHeaders, auth, cookies, controller.signal);
 
       // Build URL with query parameters
       const urlObj = new URL(url);
@@ -155,8 +159,6 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
       // handshakes shouldn't redirect, and doing so silently would let an
       // attacker-controlled endpoint steer the stream into an internal
       // service (GHSA-9qhg-99ww-9mqc).
-      const controller = new AbortController();
-      const timer = setTimeout(() => controller.abort(), provider.timeout || 60000);
       try {
         const response = await fetch(urlObj.toString(), {
           method: provider.http_method || 'GET',
@@ -184,6 +186,7 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
         clearTimeout(timer);
       }
     } catch (error: any) {
+      clearTimeout(timer);
       this._logError(`Error discovering tools from '${provider.name}': ${error.message}`);
       return {
         manualCallTemplate: provider,
@@ -263,12 +266,15 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
       }
     }
 
-    if (provider.body_field && provider.body_field in remainingArgs) {
+    // "Supplied" means the caller passed the field, whatever its value; a
+    // field already mapped to a header above is no longer in remainingArgs.
+    const bodyFieldSupplied = !!provider.body_field && provider.body_field in remainingArgs;
+    if (provider.body_field && bodyFieldSupplied) {
       bodyContent = remainingArgs[provider.body_field];
       delete remainingArgs[provider.body_field];
     }
 
-    if (bodyContent !== undefined && (provider.http_method || 'GET').toUpperCase() === 'GET') {
+    if (bodyFieldSupplied && (provider.http_method || 'GET').toUpperCase() === 'GET') {
       // fetch() rejects a GET with a body before anything reaches the server;
       // surface the misconfiguration as a clear error instead.
       throw new Error(
@@ -288,7 +294,16 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
 
     // Handle authentication
     const { auth, cookies } = this._applyAuth(provider, requestHeaders, queryParams);
-    await this._finalizeAuthHeaders(provider, requestHeaders, auth, cookies);
+
+    // One deadline for the whole call: token fetch, request and stream.
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), provider.timeout || 60000);
+    try {
+      await this._finalizeAuthHeaders(provider, requestHeaders, auth, cookies, controller.signal);
+    } catch (error) {
+      clearTimeout(timer);
+      throw error;
+    }
 
     const urlObj = new URL(url);
     Object.entries(queryParams).forEach(([key, value]) => {
@@ -314,8 +329,6 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
 
     this._logInfo(`Executing streaming HTTP tool '${toolName}' with URL: ${urlObj.toString()} and method: ${provider.http_method}`);
 
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), provider.timeout || 60000);
     try {
       // ``redirect: 'error'`` -- see registerManual for rationale (GHSA-9qhg-99ww-9mqc).
       // ``keepalive: false`` -- do not take a pooled socket for the stream. Bun's
@@ -449,10 +462,10 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
    * first and then as a Basic Auth header. Tokens are cached per full OAuth
    * configuration (token URL, client id, secret, scope), never per client_id
    * alone: two templates may share a client_id but point at different issuers.
-   * Each token request is bounded by `timeoutMs` so a stalled token endpoint
-   * cannot hang the tool call before its own timeout even starts.
+   * Both credential methods run under the caller's `signal`, which carries
+   * the call's own deadline, so the whole token flow can never exceed it.
    */
-  private async _handleOAuth2(authDetails: OAuth2Auth, timeoutMs: number): Promise<string> {
+  private async _handleOAuth2(authDetails: OAuth2Auth, signal: AbortSignal): Promise<string> {
     const clientId = authDetails.client_id;
 
     // The token URL may come from an untrusted call template; validate it
@@ -476,23 +489,20 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
     };
 
     const requestToken = async (headers: Record<string, string>, form: Record<string, string>): Promise<string> => {
-      const controller = new AbortController();
-      const timer = setTimeout(() => controller.abort(), timeoutMs);
-      try {
-        const response = await fetch(authDetails.token_url, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/x-www-form-urlencoded', ...headers },
-          body: new URLSearchParams(form).toString(),
-          redirect: 'error',
-          signal: controller.signal,
-        });
-        if (!response.ok) {
-          throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-        }
-        return storeToken(await response.json());
-      } finally {
-        clearTimeout(timer);
+      if (signal.aborted) {
+        throw new Error('Timed out before the token request could start.');
       }
+      const response = await fetch(authDetails.token_url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded', ...headers },
+        body: new URLSearchParams(form).toString(),
+        redirect: 'error',
+        signal,
+      });
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+      return storeToken(await response.json());
     };
 
     // Method 1: credentials in the request body

--- a/packages/http/src/streamable_http_communication_protocol.ts
+++ b/packages/http/src/streamable_http_communication_protocol.ts
@@ -16,6 +16,7 @@ import { IUtcpClient } from '@utcp/sdk';
 import { StreamableHttpCallTemplate, StreamableHttpCallTemplateSchema } from './streamable_http_call_template';
 import { ensureSecureUrl, assertNoCrlf } from './_security';
 import { truncateByCodePoint } from './_text';
+import { buildUrlWithPathParams } from './_url';
 
 /**
  * REQUIRED
@@ -544,32 +545,7 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
    * Consumed parameters are removed from args so they are not sent as query parameters.
    */
   private _buildUrlWithPathParams(urlTemplate: string, args: Record<string, any>): string {
-    let url = urlTemplate;
-    // Both the `{param}` form from the spec and the `${param}` form the
-    // package README documents.
-    const placeholders = urlTemplate.match(/\$?\{([^}]+)\}/g) || [];
-    const paramNames = Array.from(new Set(
-      placeholders.map(p => (p.startsWith('${') ? p.slice(2, -1) : p.slice(1, -1)))
-    ));
-
-    for (const paramName of paramNames) {
-      if (!(paramName in args)) {
-        throw new Error(`Missing required path parameter: ${paramName}`);
-      }
-      // URL-encode the value to prevent path injection, and replace every
-      // occurrence of either form (a template may repeat a parameter).
-      // `${x}` goes first so that replacing `{x}` never leaves a stray `$`.
-      const value = encodeURIComponent(String(args[paramName]));
-      url = url.split('${' + paramName + '}').join(value).split('{' + paramName + '}').join(value);
-      delete args[paramName];
-    }
-
-    const remainingParams = url.match(/\$?\{([^}]+)\}/g);
-    if (remainingParams && remainingParams.length > 0) {
-      throw new Error(`Missing required path parameters in URL template: ${remainingParams.join(', ')}`);
-    }
-
-    return url;
+    return buildUrlWithPathParams(urlTemplate, args);
   }
 
   /**

--- a/packages/http/src/streamable_http_communication_protocol.ts
+++ b/packages/http/src/streamable_http_communication_protocol.ts
@@ -172,7 +172,9 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
           // (e.g. { "error": "..." }); discarding it leaves callers with only a
           // status code. Fall back to statusText when the body is empty.
           const body = await response.text().catch(() => '');
-          const detail = body.trim() || response.statusText;
+          // Truncate like the streaming path does, so a huge error page does
+          // not land in errors[] and logs in full.
+          const detail = body.trim().slice(0, 200) || response.statusText;
           throw new Error(`HTTP ${response.status}: ${detail}`);
         }
 

--- a/packages/http/src/streamable_http_communication_protocol.ts
+++ b/packages/http/src/streamable_http_communication_protocol.ts
@@ -173,8 +173,9 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
           // status code. Fall back to statusText when the body is empty.
           const body = await response.text().catch(() => '');
           // Truncate like the streaming path does, so a huge error page does
-          // not land in errors[] and logs in full.
-          const detail = body.trim().slice(0, 200) || response.statusText;
+          // not land in errors[] and logs in full. By code point, so a
+          // multi-byte character on the boundary cannot leave a lone surrogate.
+          const detail = Array.from(body.trim()).slice(0, 200).join('') || response.statusText;
           throw new Error(`HTTP ${response.status}: ${detail}`);
         }
 

--- a/packages/http/src/streamable_http_communication_protocol.ts
+++ b/packages/http/src/streamable_http_communication_protocol.ts
@@ -15,7 +15,7 @@ import { OAuth2UserAuth } from '@utcp/sdk';
 import { IUtcpClient } from '@utcp/sdk';
 import { StreamableHttpCallTemplate, StreamableHttpCallTemplateSchema } from './streamable_http_call_template';
 import { ensureSecureUrl, assertNoCrlf } from './_security';
-import { truncateByCodePoint } from './_text';
+import { readErrorDetail } from './_text';
 import { buildUrlWithPathParams } from './_url';
 
 /**
@@ -30,6 +30,13 @@ import { buildUrlWithPathParams } from './_url';
  *   - application/octet-stream and anything else: Buffer chunks of at most chunk_size bytes
  */
 export class StreamableHttpCommunicationProtocol implements CommunicationProtocol {
+  /**
+   * Largest NDJSON line the parser buffers (in UTF-16 code units) before
+   * declaring the stream malformed. Guards against a server that streams
+   * bytes without ever sending a newline.
+   */
+  public static readonly MAX_LINE_CHARS = 16 * 1024 * 1024;
+
   private oauthTokens: Map<string, { access_token: string; expires_at?: number }> = new Map();
 
   private _logInfo(message: string): void {
@@ -173,11 +180,8 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
           // Read the body before throwing: servers put the real reason there
           // (e.g. { "error": "..." }); discarding it leaves callers with only a
           // status code. Fall back to statusText when the body is empty.
-          const body = await response.text().catch(() => '');
-          // Truncate like the streaming path does, so a huge error page does
-          // not land in errors[] and logs in full. By code point, so a
-          // multi-byte character on the boundary cannot leave a lone surrogate.
-          const detail = truncateByCodePoint(body.trim(), 200) || response.statusText;
+          // Bounded read, control characters collapsed, truncated by code point.
+          const detail = (await readErrorDetail(response, 200)) || response.statusText;
           throw new Error(`HTTP ${response.status}: ${detail}`);
         }
 
@@ -336,7 +340,9 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
         }
       }
 
-      this._logInfo(`Executing streaming HTTP tool '${toolName}' with URL: ${urlObj.toString()} and method: ${provider.http_method}`);
+      // Log without the query string: an API key with location 'query', or any
+      // sensitive tool argument, would otherwise land in the logs.
+      this._logInfo(`Executing streaming HTTP tool '${toolName}' with URL: ${urlObj.origin}${urlObj.pathname} and method: ${provider.http_method}`);
 
       // ``redirect: 'error'`` -- see registerManual for rationale (GHSA-9qhg-99ww-9mqc).
       // ``keepalive: false`` -- do not take a pooled socket for the stream. Bun's
@@ -353,13 +359,8 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
       });
 
       if (!response.ok) {
-        let detail = '';
-        try {
-          detail = await response.text();
-        } catch {
-          // ignore body read failures on error responses
-        }
-        throw new Error(`HTTP ${response.status}: ${response.statusText}${detail ? ` - ${detail.slice(0, 200)}` : ''}`);
+        const detail = await readErrorDetail(response, 200);
+        throw new Error(`HTTP ${response.status}: ${response.statusText}${detail ? ` - ${detail}` : ''}`);
       }
 
       for await (const chunk of this._processHttpStream(response, provider.chunk_size, provider.name || toolName)) {
@@ -413,6 +414,13 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
             if (line.trim()) {
               yield parseLine(line);
             }
+          }
+          if (buffer.length > StreamableHttpCommunicationProtocol.MAX_LINE_CHARS) {
+            // A server that never sends a newline must not grow memory until
+            // the call deadline; mirrors the SSE event buffer cap.
+            throw new Error(
+              `NDJSON line exceeded ${StreamableHttpCommunicationProtocol.MAX_LINE_CHARS} characters without a newline`
+            );
           }
         }
         buffer += decoder.decode();
@@ -550,7 +558,9 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
 
   /**
    * REQUIRED
-   * Close all active connections and clear internal state.
+   * Clear cached OAuth2 tokens. Streams in flight are owned by their
+   * consumers and end when the consumer stops iterating, the call deadline
+   * fires, or the server closes.
    */
   async close(): Promise<void> {
     this._logInfo('Closing StreamableHttpCommunicationProtocol.');

--- a/packages/http/src/streamable_http_communication_protocol.ts
+++ b/packages/http/src/streamable_http_communication_protocol.ts
@@ -354,6 +354,13 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
           while ((newlineIndex = buffer.indexOf('\n')) >= 0) {
             const line = buffer.slice(0, newlineIndex).replace(/\r$/, '');
             buffer = buffer.slice(newlineIndex + 1);
+            if (line.length > StreamableHttpCommunicationProtocol.MAX_LINE_CHARS) {
+              // A complete but oversized line arriving in one read must hit
+              // the same cap as an unterminated one.
+              throw new Error(
+                `NDJSON line exceeded ${StreamableHttpCommunicationProtocol.MAX_LINE_CHARS} characters`
+              );
+            }
             if (line.trim()) {
               yield parseLine(line);
             }

--- a/packages/http/tests/http_communication_protocol.test.ts
+++ b/packages/http/tests/http_communication_protocol.test.ts
@@ -3,7 +3,12 @@ import { test, expect, describe, beforeAll, afterAll } from "bun:test";
 import express, { Express } from 'express';
 import { Server } from 'http';
 // Import from package index to trigger auto-registration
-import { HttpCommunicationProtocol, HttpCallTemplate } from "@utcp/http";
+import {
+  HttpCommunicationProtocol,
+  HttpCallTemplate,
+  StreamableHttpCommunicationProtocol,
+  SseCommunicationProtocol,
+} from "@utcp/http";
 import { ApiKeyAuth, BasicAuth, OAuth2Auth } from "@utcp/sdk";
 import { IUtcpClient } from "@utcp/sdk";
 
@@ -66,6 +71,11 @@ beforeAll(async () => {
   // refuses a call. Used to prove callTool surfaces that body, not just the status.
   app.post("/forbidden", (req, res) => {
     res.status(403).json({ error: "You are not allowed to do that, and here is exactly why." });
+  });
+
+  // GET variant for the streamable/sse discovery (registerManual) error-body test.
+  app.get("/forbidden-discovery", (req, res) => {
+    res.status(403).send("discovery refused: tenant is not provisioned for streaming");
   });
 
   await new Promise<void>((resolve) => {
@@ -221,5 +231,39 @@ describe("HttpCommunicationProtocol", () => {
       expect(roundTripped.status).toBe(403);
       expect(roundTripped.data).toEqual({ error: "You are not allowed to do that, and here is exactly why." });
     });
+  });
+});
+
+// The streamable/sse protocols' callTool paths are stubs; the only real fetch
+// that can fail with a body is in registerManual (discovery). These prove that
+// failure surfaces the server's body, not just "HTTP 403: Forbidden".
+describe("discovery error body (streamable_http + sse)", () => {
+  test("StreamableHttpCommunicationProtocol.registerManual surfaces the server body", async () => {
+    const protocol = new StreamableHttpCommunicationProtocol();
+    const result = await protocol.registerManual(mockClient, {
+      name: "forbidden_stream",
+      call_template_type: "streamable_http",
+      url: `http://localhost:${serverPort}/forbidden-discovery`,
+      http_method: "GET",
+    } as any);
+
+    expect(result.success).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+    expect(result.errors[0]).toContain("discovery refused: tenant is not provisioned for streaming");
+    expect(result.errors[0]).toContain("403");
+  });
+
+  test("SseCommunicationProtocol.registerManual surfaces the server body", async () => {
+    const protocol = new SseCommunicationProtocol();
+    const result = await protocol.registerManual(mockClient, {
+      name: "forbidden_sse",
+      call_template_type: "sse",
+      url: `http://localhost:${serverPort}/forbidden-discovery`,
+    } as any);
+
+    expect(result.success).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+    expect(result.errors[0]).toContain("discovery refused: tenant is not provisioned for streaming");
+    expect(result.errors[0]).toContain("403");
   });
 });

--- a/packages/http/tests/http_communication_protocol.test.ts
+++ b/packages/http/tests/http_communication_protocol.test.ts
@@ -62,6 +62,12 @@ beforeAll(async () => {
     res.status(500).json({ error: "Internal Server Error" });
   });
 
+  // Returns a non-2xx with a descriptive JSON body, like a real API does when it
+  // refuses a call. Used to prove callTool surfaces that body, not just the status.
+  app.post("/forbidden", (req, res) => {
+    res.status(403).json({ error: "You are not allowed to do that, and here is exactly why." });
+  });
+
   await new Promise<void>((resolve) => {
     server = app.listen(0, () => {
       serverPort = (server.address() as any).port;
@@ -187,6 +193,33 @@ describe("HttpCommunicationProtocol", () => {
       };
       const result = await protocol.callTool(mockClient, "test.tool", {}, callTemplate);
       expect(result.result).toBe("success");
+    });
+
+    test("should surface the server's error body, not just the status code", async () => {
+      const callTemplate: HttpCallTemplate = {
+        name: "forbidden_server",
+        call_template_type: "http",
+        url: `http://localhost:${serverPort}/forbidden`,
+        http_method: "POST",
+      };
+
+      let thrown: any;
+      try {
+        await protocol.callTool(mockClient, "test.forbidden", {}, callTemplate);
+      } catch (e) {
+        thrown = e;
+      }
+
+      expect(thrown).toBeInstanceOf(Error);
+      // The reason the server sent (not just "status code 403") must be present.
+      expect(thrown.message).toContain("You are not allowed to do that, and here is exactly why.");
+      expect(thrown.message).toContain("403");
+      // Enumerable status/data survive structured serialization out of a sandbox.
+      expect(thrown.status).toBe(403);
+      expect(thrown.data).toEqual({ error: "You are not allowed to do that, and here is exactly why." });
+      const roundTripped = JSON.parse(JSON.stringify(thrown));
+      expect(roundTripped.status).toBe(403);
+      expect(roundTripped.data).toEqual({ error: "You are not allowed to do that, and here is exactly why." });
     });
   });
 });

--- a/packages/http/tests/http_communication_protocol.test.ts
+++ b/packages/http/tests/http_communication_protocol.test.ts
@@ -78,6 +78,12 @@ beforeAll(async () => {
     res.status(403).send("discovery refused: tenant is not provisioned for streaming");
   });
 
+  // Some APIs nest an OBJECT under `error` — the message must show its JSON,
+  // not "[object Object]".
+  app.post("/forbidden-object", (req, res) => {
+    res.status(422).json({ error: { code: "INVALID_FIELD", reason: "value out of range" } });
+  });
+
   await new Promise<void>((resolve) => {
     server = app.listen(0, () => {
       serverPort = (server.address() as any).port;
@@ -230,6 +236,31 @@ describe("HttpCommunicationProtocol", () => {
       const roundTripped = JSON.parse(JSON.stringify(thrown));
       expect(roundTripped.status).toBe(403);
       expect(roundTripped.data).toEqual({ error: "You are not allowed to do that, and here is exactly why." });
+    });
+
+    test("should JSON-stringify an object-valued error field, not '[object Object]'", async () => {
+      const callTemplate: HttpCallTemplate = {
+        name: "forbidden_object_server",
+        call_template_type: "http",
+        url: `http://localhost:${serverPort}/forbidden-object`,
+        http_method: "POST",
+      };
+
+      let thrown: any;
+      try {
+        await protocol.callTool(mockClient, "test.forbidden_object", {}, callTemplate);
+      } catch (e) {
+        thrown = e;
+      }
+
+      expect(thrown).toBeInstanceOf(Error);
+      expect(thrown.message).not.toContain("[object Object]");
+      // The structured detail survives in the message...
+      expect(thrown.message).toContain("INVALID_FIELD");
+      expect(thrown.message).toContain("value out of range");
+      // ...and the raw object is preserved on `data`.
+      expect(thrown.status).toBe(422);
+      expect(thrown.data).toEqual({ error: { code: "INVALID_FIELD", reason: "value out of range" } });
     });
   });
 });

--- a/packages/http/tests/http_communication_protocol.test.ts
+++ b/packages/http/tests/http_communication_protocol.test.ts
@@ -97,6 +97,11 @@ beforeAll(async () => {
     res.status(403).type("text/plain").send("x".repeat(5000));
   });
 
+  // A structured `error` next to a generic `message`: the structure must win.
+  app.post("/forbidden-object-then-message", (req, res) => {
+    res.status(422).json({ error: { code: "INVALID_FIELD", reason: "value out of range" }, message: "Request failed" });
+  });
+
   await new Promise<void>((resolve) => {
     server = app.listen(0, () => {
       serverPort = (server.address() as any).port;
@@ -335,6 +340,14 @@ describe("error body edge cases", () => {
     expect(thrown.message).toContain("403");
     expect(thrown.message).toContain("Forbidden");
     expect(thrown.message.trimEnd().endsWith(":")).toBe(false);
+  });
+
+  test("a structured error field wins over a lower-priority generic message", async () => {
+    const thrown = await callForbidden("/forbidden-object-then-message");
+    expect(thrown.status).toBe(422);
+    expect(thrown.message).toContain("INVALID_FIELD");
+    expect(thrown.message).toContain("value out of range");
+    expect(thrown.message).not.toContain("[object Object]");
   });
 
   test("a huge error body is truncated in the message but kept in full on data", async () => {

--- a/packages/http/tests/http_communication_protocol.test.ts
+++ b/packages/http/tests/http_communication_protocol.test.ts
@@ -97,6 +97,11 @@ beforeAll(async () => {
     res.status(403).type("text/plain").send("x".repeat(5000));
   });
 
+  // An emoji sitting exactly on the truncation boundary of the message.
+  app.post("/forbidden-emoji-boundary", (req, res) => {
+    res.status(403).type("text/plain").send("x".repeat(1999) + "😀" + "y".repeat(50));
+  });
+
   // A structured `error` next to a generic `message`: the structure must win.
   app.post("/forbidden-object-then-message", (req, res) => {
     res.status(422).json({ error: { code: "INVALID_FIELD", reason: "value out of range" }, message: "Request failed" });
@@ -348,6 +353,15 @@ describe("error body edge cases", () => {
     expect(thrown.message).toContain("INVALID_FIELD");
     expect(thrown.message).toContain("value out of range");
     expect(thrown.message).not.toContain("[object Object]");
+  });
+
+  test("truncation never splits a surrogate pair", async () => {
+    const thrown = await callForbidden("/forbidden-emoji-boundary");
+    expect(thrown.status).toBe(403);
+    const loneSurrogate = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/;
+    expect(loneSurrogate.test(thrown.message)).toBe(false);
+    expect(thrown.message).toContain("😀");
+    expect(thrown.message).toContain("…");
   });
 
   test("a huge error body is truncated in the message but kept in full on data", async () => {

--- a/packages/http/tests/http_communication_protocol.test.ts
+++ b/packages/http/tests/http_communication_protocol.test.ts
@@ -84,6 +84,19 @@ beforeAll(async () => {
     res.status(422).json({ error: { code: "INVALID_FIELD", reason: "value out of range" } });
   });
 
+  // A refusal with no body at all: the message must still carry a reason.
+  app.post("/forbidden-empty", (req, res) => {
+    res.status(403).end();
+  });
+
+  // A refusal with a huge body (think an HTML stack trace): messages stay bounded.
+  app.post("/forbidden-huge", (req, res) => {
+    res.status(403).type("text/plain").send("x".repeat(5000));
+  });
+  app.get("/forbidden-huge", (req, res) => {
+    res.status(403).type("text/plain").send("x".repeat(5000));
+  });
+
   await new Promise<void>((resolve) => {
     server = app.listen(0, () => {
       serverPort = (server.address() as any).port;
@@ -296,5 +309,51 @@ describe("discovery error body (streamable_http + sse)", () => {
     expect(result.errors.length).toBeGreaterThan(0);
     expect(result.errors[0]).toContain("discovery refused: tenant is not provisioned for streaming");
     expect(result.errors[0]).toContain("403");
+  });
+});
+
+describe("error body edge cases", () => {
+  const callForbidden = async (path: string) => {
+    const protocol = new HttpCommunicationProtocol();
+    try {
+      await protocol.callTool(mockClient, "test.forbidden", {}, {
+        name: "forbidden_server",
+        call_template_type: "http",
+        url: `http://localhost:${serverPort}${path}`,
+        http_method: "POST",
+      } as any);
+    } catch (e) {
+      return e as any;
+    }
+    throw new Error("expected the call to fail");
+  };
+
+  test("a blank error body falls back to the status text instead of a bare colon", async () => {
+    const thrown = await callForbidden("/forbidden-empty");
+    expect(thrown).toBeInstanceOf(Error);
+    expect(thrown.status).toBe(403);
+    expect(thrown.message).toContain("403");
+    expect(thrown.message).toContain("Forbidden");
+    expect(thrown.message.trimEnd().endsWith(":")).toBe(false);
+  });
+
+  test("a huge error body is truncated in the message but kept in full on data", async () => {
+    const thrown = await callForbidden("/forbidden-huge");
+    expect(thrown.status).toBe(403);
+    expect(thrown.message.length).toBeLessThan(2500);
+    expect(thrown.data).toHaveLength(5000);
+  });
+
+  test("a huge discovery error body is truncated in errors[]", async () => {
+    const protocol = new StreamableHttpCommunicationProtocol();
+    const result = await protocol.registerManual(mockClient, {
+      name: "huge_stream",
+      call_template_type: "streamable_http",
+      url: `http://localhost:${serverPort}/forbidden-huge`,
+      http_method: "GET",
+    } as any);
+    expect(result.success).toBe(false);
+    expect(result.errors[0]).toContain("403");
+    expect(result.errors[0].length).toBeLessThan(400);
   });
 });

--- a/packages/http/tests/http_communication_protocol.test.ts
+++ b/packages/http/tests/http_communication_protocol.test.ts
@@ -288,9 +288,8 @@ describe("HttpCommunicationProtocol", () => {
   });
 });
 
-// The streamable/sse protocols' callTool paths are stubs; the only real fetch
-// that can fail with a body is in registerManual (discovery). These prove that
-// failure surfaces the server's body, not just "HTTP 403: Forbidden".
+// Discovery (registerManual) for the streamable/sse protocols must surface the
+// server's body on failure, not just "HTTP 403: Forbidden".
 describe("discovery error body (streamable_http + sse)", () => {
   test("StreamableHttpCommunicationProtocol.registerManual surfaces the server body", async () => {
     const protocol = new StreamableHttpCommunicationProtocol();
@@ -352,6 +351,29 @@ describe("error body edge cases", () => {
     }
     throw new Error("expected the call to fail");
   };
+
+  test("the original axios error stays reachable but out of JSON serialization", async () => {
+    const thrown = await callForbidden("/forbidden");
+    expect(thrown.response.status).toBe(403);
+    expect(thrown.cause).toBeDefined();
+    const roundTripped = JSON.parse(JSON.stringify(thrown));
+    expect(roundTripped.status).toBe(403);
+    expect("response" in roundTripped).toBe(false);
+    expect("cause" in roundTripped).toBe(false);
+  });
+
+  test("registerManual surfaces the server's error body too", async () => {
+    const protocol = new HttpCommunicationProtocol();
+    const result = await protocol.registerManual(mockClient, {
+      name: "forbidden_http",
+      call_template_type: "http",
+      url: `http://localhost:${serverPort}/forbidden-discovery`,
+      http_method: "GET",
+    } as any);
+    expect(result.success).toBe(false);
+    expect(result.errors[0]).toContain("403");
+    expect(result.errors[0]).toContain("discovery refused: tenant is not provisioned for streaming");
+  });
 
   test("a blank error body falls back to the status text instead of a bare colon", async () => {
     const thrown = await callForbidden("/forbidden-empty");

--- a/packages/http/tests/http_communication_protocol.test.ts
+++ b/packages/http/tests/http_communication_protocol.test.ts
@@ -322,6 +322,21 @@ describe("discovery error body (streamable_http + sse)", () => {
   });
 });
 
+describe("path parameters", () => {
+  test("repeated and ${param}-style path parameters are all substituted", async () => {
+    const protocol = new HttpCommunicationProtocol();
+    const result = await protocol.callTool(mockClient, "test.path", { p: "x", extra: "1" }, {
+      name: "path_server",
+      call_template_type: "http",
+      url: `http://localhost:${serverPort}/tool/{p}/\${p}`,
+      http_method: "GET",
+    } as any);
+    expect(result.result).toBe("path_success");
+    expect(result.params).toEqual({ param1: "x", param2: "x" });
+    expect(result.query).toEqual({ extra: "1" });
+  });
+});
+
 describe("error body edge cases", () => {
   const callForbidden = async (path: string) => {
     const protocol = new HttpCommunicationProtocol();

--- a/packages/http/tests/loopback_manual_security.test.ts
+++ b/packages/http/tests/loopback_manual_security.test.ts
@@ -1,0 +1,56 @@
+// Security: a remotely-discovered UTCP manual must not point tool calls at the
+// agent's own loopback interface. ensureSecureUrl permits loopback HTTP for
+// local dev, so _rejectRemoteLoopbackToolUrls is the only guard on the
+// hand-written-manual path (the OpenAPI converter enforces the same rule for
+// specs it converts).
+import { test, expect, describe } from "bun:test";
+import { HttpCommunicationProtocol } from "@utcp/http";
+
+describe("HttpCommunicationProtocol remote-loopback SSRF guard", () => {
+  const protocol: any = new HttpCommunicationProtocol();
+
+  const manualWith = (url: string) => ({
+    tools: [
+      {
+        name: "steal_secret",
+        tool_call_template: { call_template_type: "http", name: "t", url, http_method: "GET" },
+      },
+    ],
+  });
+
+  test("rejects a loopback tool URL from a remote (non-loopback) manual", () => {
+    expect(() =>
+      protocol._rejectRemoteLoopbackToolUrls(
+        "https://attacker.example/manual",
+        manualWith("http://127.0.0.1:9200/secret"),
+      ),
+    ).toThrow("loopback tool URL");
+  });
+
+  test("rejects wildcard loopback forms (127.0.0.2) too", () => {
+    expect(() =>
+      protocol._rejectRemoteLoopbackToolUrls(
+        "https://attacker.example/manual",
+        manualWith("http://127.0.0.2:9200/secret"),
+      ),
+    ).toThrow("loopback tool URL");
+  });
+
+  test("allows a loopback tool URL when discovery itself is loopback (local dev)", () => {
+    expect(() =>
+      protocol._rejectRemoteLoopbackToolUrls(
+        "http://127.0.0.1:8765/manual",
+        manualWith("http://127.0.0.1:9200/secret"),
+      ),
+    ).not.toThrow();
+  });
+
+  test("allows non-loopback tool URLs from a remote manual", () => {
+    expect(() =>
+      protocol._rejectRemoteLoopbackToolUrls(
+        "https://attacker.example/manual",
+        manualWith("https://api.example.com/x"),
+      ),
+    ).not.toThrow();
+  });
+});

--- a/packages/http/tests/sse_communication_protocol.test.ts
+++ b/packages/http/tests/sse_communication_protocol.test.ts
@@ -480,16 +480,23 @@ describe("SseCommunicationProtocol", () => {
 
     test("a query-string API key is not written to the logs", async () => {
       const logSpy = spyOn(console, "log");
+      const errSpy = spyOn(console, "error");
       try {
         await protocol.callTool(mockClient, "sse_server.t", {}, template({
           url: `http://localhost:${serverPort}/events`,
           auth: { auth_type: "api_key", api_key: "qs-secret-value", var_name: "api_key", location: "query" } as any,
         }));
-        const logged = logSpy.mock.calls.map(args => args.map(String).join(" ")).join("\n");
+        // Also a failing call, which goes through the error log sink.
+        await protocol.callTool(mockClient, "sse_server.t", {}, template({
+          url: `http://localhost:${serverPort}/error`,
+          auth: { auth_type: "api_key", api_key: "qs-secret-value", var_name: "api_key", location: "query" } as any,
+        })).catch(() => undefined);
+        const logged = [...logSpy.mock.calls, ...errSpy.mock.calls].map(args => args.map(String).join(" ")).join("\n");
         expect(logged).not.toContain("qs-secret-value");
         expect(logged).toContain("/events");
       } finally {
         logSpy.mockRestore();
+        errSpy.mockRestore();
       }
     });
   });

--- a/packages/http/tests/sse_communication_protocol.test.ts
+++ b/packages/http/tests/sse_communication_protocol.test.ts
@@ -3,7 +3,7 @@ import { test, expect, describe, beforeAll, afterAll } from "bun:test";
 import express, { Express } from 'express';
 import { Server } from 'http';
 // Import from package index to trigger auto-registration
-import { SseCommunicationProtocol, SseCallTemplate } from "@utcp/http";
+import { SseCommunicationProtocol, SseCallTemplate, SseProtocolError } from "@utcp/http";
 import { IUtcpClient } from "@utcp/sdk";
 
 // --- Test Server Setup ---
@@ -19,6 +19,10 @@ function resetFlaky(alwaysDrop = false) {
   flaky.lastEventIds = [];
   flaky.alwaysDrop = alwaysDrop;
 }
+const flaky503 = { connections: 0 };
+const hugeRetry = { connections: 0 };
+// Responses deliberately left without headers; ended by the test that opened them.
+const hanging: express.Response[] = [];
 
 function sseHeaders(res: express.Response) {
   res.setHeader('Content-Type', 'text/event-stream');
@@ -112,6 +116,67 @@ beforeAll(async () => {
     }
     res.write("id: 2\ndata: {\"seq\":2}\n\n");
     res.write("id: 3\ndata: {\"seq\":3}\n\n");
+    res.end();
+  });
+
+  // One multi-line CRLF event whose CRLF is split across two writes.
+  app.get("/events-crlf-split", (req, res) => {
+    sseHeaders(res);
+    res.write("data: line1\r");
+    setTimeout(() => {
+      res.write("\ndata: line2\r\n\r\n");
+      res.end();
+    }, 50);
+  });
+
+  // Streams data lines without ever sending the blank-line delimiter.
+  app.get("/events-no-delimiter", (req, res) => {
+    sseHeaders(res);
+    for (let i = 0; i < 20; i++) {
+      res.write("data: " + "x".repeat(500) + "\n");
+    }
+    res.end();
+  });
+
+  // Drops after the first event, answers the first reconnect with a 503,
+  // then serves the rest on the second reconnect.
+  app.get("/flaky-503", (req, res) => {
+    flaky503.connections += 1;
+    if (flaky503.connections === 2) {
+      res.status(503).send("restarting");
+      return;
+    }
+    sseHeaders(res);
+    if (flaky503.connections === 1) {
+      res.write("id: 1\ndata: {\"seq\":1}\n\n");
+      setTimeout(() => req.socket.destroy(), 10);
+      return;
+    }
+    res.write("id: 2\ndata: {\"seq\":2}\n\nid: 3\ndata: {\"seq\":3}\n\n");
+    res.end();
+  });
+
+  // Accepts the connection but never sends response headers.
+  app.get("/never-responds", (req, res) => {
+    hanging.push(res);
+  });
+
+  // First connection asks for a 100 s retry delay, then drops.
+  app.get("/huge-retry", (req, res) => {
+    hugeRetry.connections += 1;
+    sseHeaders(res);
+    if (hugeRetry.connections === 1) {
+      res.write("id: 1\nretry: 100000\ndata: {\"seq\":1}\n\n");
+      setTimeout(() => req.socket.destroy(), 10);
+      return;
+    }
+    res.write("id: 2\ndata: {\"seq\":2}\n\n");
+    res.end();
+  });
+
+  app.get("/pair/:a/:b", (req, res) => {
+    sseHeaders(res);
+    res.write(`data: ${JSON.stringify(req.params)}\n\n`);
     res.end();
   });
 
@@ -255,6 +320,79 @@ describe("SseCommunicationProtocol", () => {
       }));
       await expect(gen).rejects.toBeDefined();
       expect(flaky.connections).toBe(1 + SseCommunicationProtocol.MAX_RECONNECT_ATTEMPTS);
+    });
+  });
+
+  describe("framing robustness and bounded reconnects", () => {
+    test("a CRLF split across chunks does not end the event early", async () => {
+      const result = await protocol.callTool(mockClient, "sse_server.t", {}, template({ url: `http://localhost:${serverPort}/events-crlf-split` }));
+      expect(result).toEqual(["line1\nline2"]);
+    });
+
+    test("a stream that never sends the event delimiter is rejected, not buffered forever", async () => {
+      const original = SseCommunicationProtocol.MAX_EVENT_BUFFER_CHARS;
+      (SseCommunicationProtocol as any).MAX_EVENT_BUFFER_CHARS = 1000;
+      try {
+        const call = protocol.callTool(mockClient, "sse_server.t", {}, template({
+          url: `http://localhost:${serverPort}/events-no-delimiter`,
+          reconnect: true,
+          retry_timeout: 1,
+        }));
+        await expect(call).rejects.toBeInstanceOf(SseProtocolError);
+      } finally {
+        (SseCommunicationProtocol as any).MAX_EVENT_BUFFER_CHARS = original;
+      }
+    });
+
+    test("a failed reconnect handshake is retried, unlike the initial handshake", async () => {
+      flaky503.connections = 0;
+      const result = await protocol.callTool(mockClient, "sse_server.t", {}, template({
+        url: `http://localhost:${serverPort}/flaky-503`,
+        reconnect: true,
+        retry_timeout: 10,
+      }));
+      expect(result).toEqual([{ seq: 1 }, { seq: 2 }, { seq: 3 }]);
+      expect(flaky503.connections).toBe(3);
+    });
+
+    test("a server that accepts the connection but never sends headers cannot hang the call", async () => {
+      const original = SseCommunicationProtocol.HANDSHAKE_TIMEOUT_MS;
+      (SseCommunicationProtocol as any).HANDSHAKE_TIMEOUT_MS = 300;
+      try {
+        const started = Date.now();
+        const call = protocol.callTool(mockClient, "sse_server.t", {}, template({ url: `http://localhost:${serverPort}/never-responds` }));
+        await expect(call).rejects.toBeDefined();
+        expect(Date.now() - started).toBeLessThan(3000);
+      } finally {
+        (SseCommunicationProtocol as any).HANDSHAKE_TIMEOUT_MS = original;
+        for (const r of hanging.splice(0)) r.end();
+      }
+    });
+
+    test("a server-sent retry of 100 s cannot stall the reconnect past MAX_RECONNECT_DELAY_MS", async () => {
+      const original = SseCommunicationProtocol.MAX_RECONNECT_DELAY_MS;
+      (SseCommunicationProtocol as any).MAX_RECONNECT_DELAY_MS = 50;
+      hugeRetry.connections = 0;
+      try {
+        const started = Date.now();
+        const result = await protocol.callTool(mockClient, "sse_server.t", {}, template({
+          url: `http://localhost:${serverPort}/huge-retry`,
+          reconnect: true,
+          retry_timeout: 10,
+        }));
+        expect(result).toEqual([{ seq: 1 }, { seq: 2 }]);
+        expect(hugeRetry.connections).toBe(2);
+        expect(Date.now() - started).toBeLessThan(3000);
+      } finally {
+        (SseCommunicationProtocol as any).MAX_RECONNECT_DELAY_MS = original;
+      }
+    });
+
+    test("repeated and ${param}-style path parameters are all substituted", async () => {
+      const result = await protocol.callTool(mockClient, "sse_server.t", { id: "x" }, template({
+        url: `http://localhost:${serverPort}/pair/{id}/\${id}`,
+      }));
+      expect(result).toEqual([{ a: "x", b: "x" }]);
     });
   });
 });

--- a/packages/http/tests/sse_communication_protocol.test.ts
+++ b/packages/http/tests/sse_communication_protocol.test.ts
@@ -1,0 +1,260 @@
+// packages/http/tests/sse_communication_protocol.test.ts
+import { test, expect, describe, beforeAll, afterAll } from "bun:test";
+import express, { Express } from 'express';
+import { Server } from 'http';
+// Import from package index to trigger auto-registration
+import { SseCommunicationProtocol, SseCallTemplate } from "@utcp/http";
+import { IUtcpClient } from "@utcp/sdk";
+
+// --- Test Server Setup ---
+let app: Express;
+let server: Server;
+let serverPort: number;
+
+const mockClient = {} as IUtcpClient;
+
+const flaky = { connections: 0, lastEventIds: [] as (string | undefined)[], alwaysDrop: false };
+function resetFlaky(alwaysDrop = false) {
+  flaky.connections = 0;
+  flaky.lastEventIds = [];
+  flaky.alwaysDrop = alwaysDrop;
+}
+
+function sseHeaders(res: express.Response) {
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+  // Keep-alive on purpose: earlier tests leave pooled sockets behind, and the
+  // reconnection tests must still see exact hit counts. The protocol opts out
+  // of socket reuse for streams (keepalive: false) so Bun's transparent
+  // request replay on a dead pooled socket cannot bypass its reconnect logic.
+  res.setHeader('Connection', 'keep-alive');
+}
+
+beforeAll(async () => {
+  app = express();
+  app.use(express.json());
+
+  app.get("/utcp", (req, res) => {
+    res.json({
+      utcp_version: "1.0.1",
+      manual_version: "1.0.0",
+      tools: [{
+        name: "sse_tool",
+        description: "An SSE test tool",
+        tool_call_template: {
+          name: "sse_server",
+          call_template_type: 'sse',
+          url: `http://localhost:${serverPort}/events`,
+        }
+      }]
+    });
+  });
+
+  // Emits: a comment, a JSON "message" event, a multi-line "update" event,
+  // a plain-text event with an id and a retry, then closes.
+  app.get("/events", (req, res) => {
+    sseHeaders(res);
+    res.write(": keep-alive comment\n\n");
+    res.write(`event: message\ndata: ${JSON.stringify({ seq: 1, query: req.query })}\n\n`);
+    setTimeout(() => {
+      res.write("event: update\ndata: {\"seq\":\ndata: 2}\n\n");
+      setTimeout(() => {
+        res.write("id: 3\nretry: 1000\ndata: plain text payload\n\n");
+        res.end();
+      }, 10);
+    }, 10);
+  });
+
+  // CRLF line endings and a final event without trailing blank line.
+  app.get("/events-crlf", (req, res) => {
+    sseHeaders(res);
+    res.write("data: {\"a\":1}\r\n\r\n");
+    res.write("data: {\"a\":2}");
+    res.end();
+  });
+
+  app.post("/events-echo", (req, res) => {
+    sseHeaders(res);
+    res.write(`data: ${JSON.stringify({ body: req.body, header: req.headers['x-custom'] ?? null, accept: req.headers['accept'] })}\n\n`);
+    res.end();
+  });
+
+  app.get("/topics/:topic/events", (req, res) => {
+    sseHeaders(res);
+    res.write(`data: ${JSON.stringify({ topic: req.params.topic, query: req.query })}\n\n`);
+    res.end();
+  });
+
+  app.get("/auth", (req, res) => {
+    if (req.headers.authorization !== `Basic ${Buffer.from("user:pass").toString("base64")}`) {
+      return res.status(401).json({ error: "unauthorized" });
+    }
+    sseHeaders(res);
+    res.write("data: {\"ok\":true}\n\n");
+    res.end();
+  });
+
+  app.get("/error", (req, res) => {
+    res.status(500).json({ error: "Internal Server Error" });
+  });
+
+  // Serves the first event then drops the TCP connection on the first connection
+  // (or on every connection when alwaysDrop is set). A reconnecting client is
+  // served the remaining events and a clean end of stream.
+  app.get("/flaky", (req, res) => {
+    flaky.connections += 1;
+    flaky.lastEventIds.push(req.headers['last-event-id'] as string | undefined);
+    sseHeaders(res);
+    if (flaky.alwaysDrop || flaky.connections === 1) {
+      res.write("id: 1\nretry: 20\ndata: {\"seq\":1}\n\n");
+      setTimeout(() => req.socket.destroy(), 10);
+      return;
+    }
+    res.write("id: 2\ndata: {\"seq\":2}\n\n");
+    res.write("id: 3\ndata: {\"seq\":3}\n\n");
+    res.end();
+  });
+
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, () => {
+      serverPort = (server.address() as any).port;
+      resolve();
+    });
+  });
+});
+
+afterAll(() => {
+  return new Promise<void>((resolve) => {
+    server.close(() => resolve());
+  });
+});
+
+const template = (overrides: Partial<SseCallTemplate> & { url: string }): SseCallTemplate => ({
+  name: "sse_server",
+  call_template_type: "sse",
+  reconnect: true,
+  retry_timeout: 30000,
+  ...overrides,
+});
+
+describe("SseCommunicationProtocol", () => {
+  const protocol = new SseCommunicationProtocol();
+
+  test("registerManual discovers tools from a manual endpoint", async () => {
+    const result = await protocol.registerManual(mockClient, template({ url: `http://localhost:${serverPort}/utcp` }));
+    expect(result.success).toBe(true);
+    expect(result.manual.tools).toHaveLength(1);
+    expect(result.manual.tools[0]?.name).toBe("sse_tool");
+  });
+
+  test("callToolStreaming yields each event payload, parsing JSON where possible", async () => {
+    const chunks: any[] = [];
+    for await (const chunk of protocol.callToolStreaming(mockClient, "sse_server.sse_tool", { q: "x" }, template({ url: `http://localhost:${serverPort}/events` }))) {
+      chunks.push(chunk);
+    }
+    expect(chunks).toEqual([
+      { seq: 1, query: { q: "x" } },
+      { seq: 2 },
+      "plain text payload",
+    ]);
+  });
+
+  test("callTool collects all event payloads into an array", async () => {
+    const result = await protocol.callTool(mockClient, "sse_server.sse_tool", {}, template({ url: `http://localhost:${serverPort}/events` }));
+    expect(Array.isArray(result)).toBe(true);
+    expect(result).toHaveLength(3);
+    expect(result[0].seq).toBe(1);
+  });
+
+  test("event_type filters events", async () => {
+    const result = await protocol.callTool(mockClient, "sse_server.sse_tool", {}, template({
+      url: `http://localhost:${serverPort}/events`,
+      event_type: "update",
+    }));
+    expect(result).toEqual([{ seq: 2 }]);
+  });
+
+  test("handles CRLF delimiters and a trailing unterminated event", async () => {
+    const result = await protocol.callTool(mockClient, "sse_server.sse_tool", {}, template({ url: `http://localhost:${serverPort}/events-crlf` }));
+    expect(result).toEqual([{ a: 1 }, { a: 2 }]);
+  });
+
+  test("body_field switches to POST with a JSON body, header_fields become headers, Accept is set", async () => {
+    const result = await protocol.callTool(mockClient, "sse_server.echo", { payload: { n: 42 }, "x-custom": "hdr" }, template({
+      url: `http://localhost:${serverPort}/events-echo`,
+      body_field: "payload",
+      header_fields: ["x-custom"],
+    }));
+    expect(result).toEqual([{ body: { n: 42 }, header: "hdr", accept: "text/event-stream" }]);
+  });
+
+  test("path parameters are substituted and the rest become query params", async () => {
+    const result = await protocol.callTool(mockClient, "sse_server.topic", { topic: "news", limit: 5 }, template({
+      url: `http://localhost:${serverPort}/topics/{topic}/events`,
+    }));
+    expect(result).toEqual([{ topic: "news", query: { limit: "5" } }]);
+  });
+
+  test("Basic auth is applied", async () => {
+    const result = await protocol.callTool(mockClient, "sse_server.auth", {}, template({
+      url: `http://localhost:${serverPort}/auth`,
+      auth: { auth_type: "basic", username: "user", password: "pass" } as any,
+    }));
+    expect(result).toEqual([{ ok: true }]);
+  });
+
+  test("non-2xx responses reject", async () => {
+    const gen = protocol.callToolStreaming(mockClient, "sse_server.err", {}, template({ url: `http://localhost:${serverPort}/error` }));
+    await expect(gen.next()).rejects.toThrow(/HTTP 500/);
+  });
+
+  test("wrong call template type is rejected", async () => {
+    const gen = protocol.callToolStreaming(mockClient, "x", {}, { name: "x", call_template_type: "http" } as any);
+    await expect(gen.next()).rejects.toThrow(/SseCallTemplate/);
+  });
+
+  describe("reconnection", () => {
+    test("resumes a dropped stream with Last-Event-ID and yields every event once", async () => {
+      resetFlaky();
+      const result = await protocol.callTool(mockClient, "sse_server.flaky", {}, template({
+        url: `http://localhost:${serverPort}/flaky`,
+        reconnect: true,
+        retry_timeout: 1000, // overridden by the server's "retry: 20"
+      }));
+      expect(result).toEqual([{ seq: 1 }, { seq: 2 }, { seq: 3 }]);
+      expect(flaky.connections).toBe(2);
+      expect(flaky.lastEventIds).toEqual([undefined, "1"]);
+    });
+
+    test("with reconnect disabled a dropped stream surfaces as an error after the events received so far", async () => {
+      resetFlaky();
+      const received: any[] = [];
+      let error: any;
+      try {
+        for await (const chunk of protocol.callToolStreaming(mockClient, "sse_server.flaky", {}, template({
+          url: `http://localhost:${serverPort}/flaky`,
+          reconnect: false,
+          retry_timeout: 10,
+        }))) {
+          received.push(chunk);
+        }
+      } catch (e) {
+        error = e;
+      }
+      expect(error).toBeDefined();
+      expect(received).toEqual([{ seq: 1 }]);
+      expect(flaky.connections).toBe(1);
+    });
+
+    test("gives up after MAX_RECONNECT_ATTEMPTS so a tool call cannot hang forever", async () => {
+      resetFlaky(true);
+      const gen = protocol.callTool(mockClient, "sse_server.flaky", {}, template({
+        url: `http://localhost:${serverPort}/flaky`,
+        reconnect: true,
+        retry_timeout: 10,
+      }));
+      await expect(gen).rejects.toBeDefined();
+      expect(flaky.connections).toBe(1 + SseCommunicationProtocol.MAX_RECONNECT_ATTEMPTS);
+    });
+  });
+});

--- a/packages/http/tests/sse_communication_protocol.test.ts
+++ b/packages/http/tests/sse_communication_protocol.test.ts
@@ -1,5 +1,5 @@
 // packages/http/tests/sse_communication_protocol.test.ts
-import { test, expect, describe, beforeAll, afterAll } from "bun:test";
+import { test, expect, describe, beforeAll, afterAll, spyOn } from "bun:test";
 import express, { Express } from 'express';
 import { Server } from 'http';
 // Import from package index to trigger auto-registration
@@ -21,6 +21,7 @@ function resetFlaky(alwaysDrop = false) {
 }
 const flaky503 = { connections: 0 };
 const hugeRetry = { connections: 0 };
+const emptyId = { connections: 0, lastEventIds: [] as (string | undefined)[] };
 // Responses deliberately left without headers; ended by the test that opened them.
 const hanging: express.Response[] = [];
 
@@ -105,7 +106,7 @@ beforeAll(async () => {
   // Serves the first event then drops the TCP connection on the first connection
   // (or on every connection when alwaysDrop is set). A reconnecting client is
   // served the remaining events and a clean end of stream.
-  app.get("/flaky", (req, res) => {
+  const flakyHandler = (req: express.Request, res: express.Response) => {
     flaky.connections += 1;
     flaky.lastEventIds.push(req.headers['last-event-id'] as string | undefined);
     sseHeaders(res);
@@ -117,6 +118,27 @@ beforeAll(async () => {
     res.write("id: 2\ndata: {\"seq\":2}\n\n");
     res.write("id: 3\ndata: {\"seq\":3}\n\n");
     res.end();
+  };
+  app.get("/flaky", flakyHandler);
+  app.post("/flaky", flakyHandler);
+
+  // Sets an id, resets it with an empty id, then drops the connection.
+  app.get("/empty-id", (req, res) => {
+    emptyId.connections += 1;
+    emptyId.lastEventIds.push(req.headers['last-event-id'] as string | undefined);
+    sseHeaders(res);
+    if (emptyId.connections === 1) {
+      res.write("id: 1\ndata: {\"seq\":1}\n\nid\ndata: {\"seq\":2}\n\n");
+      setTimeout(() => req.socket.destroy(), 10);
+      return;
+    }
+    res.write("data: {\"seq\":3}\n\n");
+    res.end();
+  });
+
+  // A 200 that is not an event stream at all.
+  app.get("/json-not-sse", (req, res) => {
+    res.json({ error: "not a stream" });
   });
 
   // One multi-line CRLF event whose CRLF is split across two writes.
@@ -393,6 +415,70 @@ describe("SseCommunicationProtocol", () => {
         url: `http://localhost:${serverPort}/pair/{id}/\${id}`,
       }));
       expect(result).toEqual([{ a: "x", b: "x" }]);
+    });
+  });
+
+  describe("spec conformance follow-ups", () => {
+    test("event_type 'message' matches events without an event field", async () => {
+      // /events sends: event "message" (explicit), event "update", and one with no event field.
+      const result = await protocol.callTool(mockClient, "sse_server.t", {}, template({
+        url: `http://localhost:${serverPort}/events`,
+        event_type: "message",
+      }));
+      expect(result).toEqual([{ seq: 1, query: {} }, "plain text payload"]);
+    });
+
+    test("an empty id resets the last event ID, so no Last-Event-ID header is sent on reconnect", async () => {
+      emptyId.connections = 0;
+      emptyId.lastEventIds = [];
+      const result = await protocol.callTool(mockClient, "sse_server.t", {}, template({
+        url: `http://localhost:${serverPort}/empty-id`,
+        reconnect: true,
+        retry_timeout: 10,
+      }));
+      expect(result).toEqual([{ seq: 1 }, { seq: 2 }, { seq: 3 }]);
+      expect(emptyId.lastEventIds).toEqual([undefined, undefined]);
+    });
+
+    test("a 200 that is not text/event-stream fails instead of yielding zero events", async () => {
+      const call = protocol.callTool(mockClient, "sse_server.t", {}, template({ url: `http://localhost:${serverPort}/json-not-sse` }));
+      await expect(call).rejects.toBeInstanceOf(SseProtocolError);
+    });
+
+    test("a dropped POST stream is not re-issued", async () => {
+      resetFlaky();
+      const received: any[] = [];
+      let error: any;
+      try {
+        for await (const chunk of protocol.callToolStreaming(mockClient, "sse_server.t", { payload: { n: 1 } }, template({
+          url: `http://localhost:${serverPort}/flaky`,
+          reconnect: true,
+          retry_timeout: 10,
+          body_field: "payload",
+        }))) {
+          received.push(chunk);
+        }
+      } catch (e) {
+        error = e;
+      }
+      expect(error).toBeDefined();
+      expect(received).toEqual([{ seq: 1 }]);
+      expect(flaky.connections).toBe(1);
+    });
+
+    test("a query-string API key is not written to the logs", async () => {
+      const logSpy = spyOn(console, "log");
+      try {
+        await protocol.callTool(mockClient, "sse_server.t", {}, template({
+          url: `http://localhost:${serverPort}/events`,
+          auth: { auth_type: "api_key", api_key: "qs-secret-value", var_name: "api_key", location: "query" } as any,
+        }));
+        const logged = logSpy.mock.calls.map(args => args.map(String).join(" ")).join("\n");
+        expect(logged).not.toContain("qs-secret-value");
+        expect(logged).toContain("/events");
+      } finally {
+        logSpy.mockRestore();
+      }
     });
   });
 });

--- a/packages/http/tests/sse_communication_protocol.test.ts
+++ b/packages/http/tests/sse_communication_protocol.test.ts
@@ -136,6 +136,13 @@ beforeAll(async () => {
     res.end();
   });
 
+  // A retry field that is not made of digits must be ignored.
+  app.get("/events-bad-retry", (req, res) => {
+    sseHeaders(res);
+    res.write("retry: -1\ndata: {\"seq\":1}\n\nretry: 20ms\n\n");
+    res.end();
+  });
+
   // A 200 that is not an event stream at all.
   app.get("/json-not-sse", (req, res) => {
     res.json({ error: "not a stream" });
@@ -261,9 +268,14 @@ describe("SseCommunicationProtocol", () => {
     expect(result).toEqual([{ seq: 2 }]);
   });
 
-  test("handles CRLF delimiters and a trailing unterminated event", async () => {
+  test("handles CRLF delimiters and discards an unterminated trailing event (spec)", async () => {
     const result = await protocol.callTool(mockClient, "sse_server.sse_tool", {}, template({ url: `http://localhost:${serverPort}/events-crlf` }));
-    expect(result).toEqual([{ a: 1 }, { a: 2 }]);
+    expect(result).toEqual([{ a: 1 }]);
+  });
+
+  test("a malformed retry value is ignored", async () => {
+    const result = await protocol.callTool(mockClient, "sse_server.sse_tool", {}, template({ url: `http://localhost:${serverPort}/events-bad-retry` }));
+    expect(result).toEqual([{ seq: 1 }]);
   });
 
   test("body_field switches to POST with a JSON body, header_fields become headers, Accept is set", async () => {

--- a/packages/http/tests/sse_communication_protocol.test.ts
+++ b/packages/http/tests/sse_communication_protocol.test.ts
@@ -143,6 +143,13 @@ beforeAll(async () => {
     res.end();
   });
 
+  // A complete event whose closing blank line ends in a lone CR at end of stream.
+  app.get("/events-cr-eof", (req, res) => {
+    sseHeaders(res);
+    res.write("data: {\"seq\":1}\n\r");
+    res.end();
+  });
+
   // A 200 that is not an event stream at all.
   app.get("/json-not-sse", (req, res) => {
     res.json({ error: "not a stream" });
@@ -273,8 +280,13 @@ describe("SseCommunicationProtocol", () => {
     expect(result).toEqual([{ a: 1 }]);
   });
 
-  test("a malformed retry value is ignored", async () => {
+  test("a malformed retry value does not abort the stream", async () => {
     const result = await protocol.callTool(mockClient, "sse_server.sse_tool", {}, template({ url: `http://localhost:${serverPort}/events-bad-retry` }));
+    expect(result).toEqual([{ seq: 1 }]);
+  });
+
+  test("a final blank line ending in a lone CR still completes the last event", async () => {
+    const result = await protocol.callTool(mockClient, "sse_server.sse_tool", {}, template({ url: `http://localhost:${serverPort}/events-cr-eof` }));
     expect(result).toEqual([{ seq: 1 }]);
   });
 
@@ -491,6 +503,7 @@ describe("SseCommunicationProtocol", () => {
           url: `http://localhost:${serverPort}/error`,
           auth: { auth_type: "api_key", api_key: "qs-secret-value", var_name: "api_key", location: "query" } as any,
         })).catch(() => undefined);
+        expect(errSpy).toHaveBeenCalled();
         const logged = [...logSpy.mock.calls, ...errSpy.mock.calls].map(args => args.map(String).join(" ")).join("\n");
         expect(logged).not.toContain("qs-secret-value");
         expect(logged).toContain("/events");

--- a/packages/http/tests/streamable_http_communication_protocol.test.ts
+++ b/packages/http/tests/streamable_http_communication_protocol.test.ts
@@ -112,6 +112,15 @@ beforeAll(async () => {
     res.end();
   });
 
+  // NDJSON that never sends a newline.
+  app.get("/ndjson-no-newline", (req, res) => {
+    res.setHeader('Content-Type', 'application/x-ndjson');
+    for (let i = 0; i < 20; i++) {
+      res.write("x".repeat(500));
+    }
+    res.end();
+  });
+
   await new Promise<void>((resolve) => {
     server = app.listen(0, () => {
       serverPort = (server.address() as any).port;
@@ -288,6 +297,17 @@ describe("StreamableHttpCommunicationProtocol", () => {
         url: `http://localhost:${serverPort}/pair/{id}/\${id}`,
       }));
       expect(result).toEqual([{ a: "x", b: "x" }]);
+    });
+
+    test("an NDJSON line that never ends is rejected instead of buffered until the deadline", async () => {
+      const original = StreamableHttpCommunicationProtocol.MAX_LINE_CHARS;
+      (StreamableHttpCommunicationProtocol as any).MAX_LINE_CHARS = 1000;
+      try {
+        const call = protocol.callTool(mockClient, "stream_server.t", {}, template({ url: `http://localhost:${serverPort}/ndjson-no-newline` }));
+        await expect(call).rejects.toThrow(/NDJSON line exceeded/);
+      } finally {
+        (StreamableHttpCommunicationProtocol as any).MAX_LINE_CHARS = original;
+      }
     });
   });
 });

--- a/packages/http/tests/streamable_http_communication_protocol.test.ts
+++ b/packages/http/tests/streamable_http_communication_protocol.test.ts
@@ -14,6 +14,9 @@ let serverPort: number;
 const mockClient = {} as IUtcpClient;
 
 const BINARY_PAYLOAD = Buffer.alloc(10_000, 7); // 10,000 bytes of 0x07
+const tokenHits = { a: 0, b: 0 };
+// Token responses deliberately left unanswered; ended by the test that opened them.
+const hangingToken: express.Response[] = [];
 
 beforeAll(async () => {
   app = express();
@@ -85,6 +88,28 @@ beforeAll(async () => {
 
   app.get("/error", (req, res) => {
     res.status(500).json({ error: "Internal Server Error" });
+  });
+
+  app.post("/token-a", (req, res) => {
+    tokenHits.a += 1;
+    res.json({ access_token: "token-a", expires_in: 3600 });
+  });
+  app.post("/token-b", (req, res) => {
+    tokenHits.b += 1;
+    res.json({ access_token: "token-b", expires_in: 3600 });
+  });
+  app.post("/token-hang", (req, res) => {
+    hangingToken.push(res);
+  });
+  app.get("/whoami", (req, res) => {
+    res.setHeader('Content-Type', 'application/x-ndjson');
+    res.write(JSON.stringify({ auth: req.headers.authorization ?? null }) + "\n");
+    res.end();
+  });
+  app.get("/pair/:a/:b", (req, res) => {
+    res.setHeader('Content-Type', 'application/x-ndjson');
+    res.write(JSON.stringify(req.params) + "\n");
+    res.end();
   });
 
   await new Promise<void>((resolve) => {
@@ -202,5 +227,56 @@ describe("StreamableHttpCommunicationProtocol", () => {
   test("wrong call template type is rejected", async () => {
     const gen = protocol.callToolStreaming(mockClient, "x", {}, { name: "x", call_template_type: "http" } as any);
     await expect(gen.next()).rejects.toThrow(/StreamableHttpCallTemplate/);
+  });
+
+  describe("review follow-ups", () => {
+    test("GET with a body_field fails with a clear error instead of a fetch TypeError", async () => {
+      const gen = protocol.callToolStreaming(mockClient, "stream_server.t", { payload: { n: 1 } }, template({
+        url: `http://localhost:${serverPort}/ndjson`,
+        http_method: "GET",
+        body_field: "payload",
+      }));
+      await expect(gen.next()).rejects.toThrow(/http_method is GET/);
+    });
+
+    test("OAuth2 tokens are cached per token endpoint, not per client_id", async () => {
+      tokenHits.a = 0;
+      tokenHits.b = 0;
+      const oauth = (tokenUrl: string) => ({
+        auth_type: "oauth2",
+        token_url: tokenUrl,
+        client_id: "shared-id",
+        client_secret: "s",
+      } as any);
+      const whoami = (tokenUrl: string) =>
+        protocol.callTool(mockClient, "stream_server.t", {}, template({ url: `http://localhost:${serverPort}/whoami`, auth: oauth(tokenUrl) }));
+
+      expect(await whoami(`http://localhost:${serverPort}/token-a`)).toEqual([{ auth: "Bearer token-a" }]);
+      expect(await whoami(`http://localhost:${serverPort}/token-b`)).toEqual([{ auth: "Bearer token-b" }]);
+      expect(await whoami(`http://localhost:${serverPort}/token-a`)).toEqual([{ auth: "Bearer token-a" }]);
+      expect(tokenHits).toEqual({ a: 1, b: 1 });
+    });
+
+    test("a stalled OAuth2 token endpoint is bounded by the call timeout", async () => {
+      const started = Date.now();
+      const call = protocol.callTool(mockClient, "stream_server.t", {}, template({
+        url: `http://localhost:${serverPort}/whoami`,
+        timeout: 300,
+        auth: { auth_type: "oauth2", token_url: `http://localhost:${serverPort}/token-hang`, client_id: "c", client_secret: "s" } as any,
+      }));
+      try {
+        await expect(call).rejects.toThrow(/Failed to fetch OAuth2 token/);
+        expect(Date.now() - started).toBeLessThan(3000);
+      } finally {
+        for (const r of hangingToken.splice(0)) r.end();
+      }
+    });
+
+    test("repeated and ${param}-style path parameters are all substituted", async () => {
+      const result = await protocol.callTool(mockClient, "stream_server.t", { id: "x" }, template({
+        url: `http://localhost:${serverPort}/pair/{id}/\${id}`,
+      }));
+      expect(result).toEqual([{ a: "x", b: "x" }]);
+    });
   });
 });

--- a/packages/http/tests/streamable_http_communication_protocol.test.ts
+++ b/packages/http/tests/streamable_http_communication_protocol.test.ts
@@ -276,7 +276,6 @@ describe("StreamableHttpCommunicationProtocol", () => {
     });
 
     test("a stalled OAuth2 token endpoint is bounded by the call timeout, once, not per credential method", async () => {
-      const started = Date.now();
       const call = protocol.callTool(mockClient, "stream_server.t", {}, template({
         url: `http://localhost:${serverPort}/whoami`,
         timeout: 800,
@@ -284,9 +283,9 @@ describe("StreamableHttpCommunicationProtocol", () => {
       }));
       try {
         await expect(call).rejects.toThrow(/Failed to fetch OAuth2 token/);
-        // Two credential methods with a fresh 800 ms budget each would take
-        // about 1600 ms; a single shared deadline finishes just after 800 ms.
-        expect(Date.now() - started).toBeLessThan(1300);
+        // With one shared deadline the second credential method never starts:
+        // its signal is already aborted, so the endpoint sees a single request.
+        expect(hangingToken).toHaveLength(1);
       } finally {
         for (const r of hangingToken.splice(0)) r.end();
       }

--- a/packages/http/tests/streamable_http_communication_protocol.test.ts
+++ b/packages/http/tests/streamable_http_communication_protocol.test.ts
@@ -239,6 +239,15 @@ describe("StreamableHttpCommunicationProtocol", () => {
       await expect(gen.next()).rejects.toThrow(/http_method is GET/);
     });
 
+    test("GET with a body_field supplied as undefined is still rejected, not silently dropped", async () => {
+      const gen = protocol.callToolStreaming(mockClient, "stream_server.t", { payload: undefined }, template({
+        url: `http://localhost:${serverPort}/ndjson`,
+        http_method: "GET",
+        body_field: "payload",
+      }));
+      await expect(gen.next()).rejects.toThrow(/http_method is GET/);
+    });
+
     test("OAuth2 tokens are cached per token endpoint, not per client_id", async () => {
       tokenHits.a = 0;
       tokenHits.b = 0;
@@ -257,16 +266,18 @@ describe("StreamableHttpCommunicationProtocol", () => {
       expect(tokenHits).toEqual({ a: 1, b: 1 });
     });
 
-    test("a stalled OAuth2 token endpoint is bounded by the call timeout", async () => {
+    test("a stalled OAuth2 token endpoint is bounded by the call timeout, once, not per credential method", async () => {
       const started = Date.now();
       const call = protocol.callTool(mockClient, "stream_server.t", {}, template({
         url: `http://localhost:${serverPort}/whoami`,
-        timeout: 300,
+        timeout: 800,
         auth: { auth_type: "oauth2", token_url: `http://localhost:${serverPort}/token-hang`, client_id: "c", client_secret: "s" } as any,
       }));
       try {
         await expect(call).rejects.toThrow(/Failed to fetch OAuth2 token/);
-        expect(Date.now() - started).toBeLessThan(3000);
+        // Two credential methods with a fresh 800 ms budget each would take
+        // about 1600 ms; a single shared deadline finishes just after 800 ms.
+        expect(Date.now() - started).toBeLessThan(1300);
       } finally {
         for (const r of hangingToken.splice(0)) r.end();
       }

--- a/packages/http/tests/streamable_http_communication_protocol.test.ts
+++ b/packages/http/tests/streamable_http_communication_protocol.test.ts
@@ -1,0 +1,206 @@
+// packages/http/tests/streamable_http_communication_protocol.test.ts
+import { test, expect, describe, beforeAll, afterAll } from "bun:test";
+import express, { Express } from 'express';
+import { Server } from 'http';
+// Import from package index to trigger auto-registration
+import { StreamableHttpCommunicationProtocol, StreamableHttpCallTemplate } from "@utcp/http";
+import { IUtcpClient } from "@utcp/sdk";
+
+// --- Test Server Setup ---
+let app: Express;
+let server: Server;
+let serverPort: number;
+
+const mockClient = {} as IUtcpClient;
+
+const BINARY_PAYLOAD = Buffer.alloc(10_000, 7); // 10,000 bytes of 0x07
+
+beforeAll(async () => {
+  app = express();
+  app.use(express.json());
+
+  app.get("/utcp", (req, res) => {
+    res.json({
+      utcp_version: "1.0.1",
+      manual_version: "1.0.0",
+      tools: [{
+        name: "stream_tool",
+        description: "A streaming test tool",
+        tool_call_template: {
+          name: "stream_server",
+          call_template_type: 'streamable_http',
+          url: `http://localhost:${serverPort}/ndjson`,
+          http_method: 'GET',
+        }
+      }]
+    });
+  });
+
+  app.get("/ndjson", (req, res) => {
+    res.setHeader('Content-Type', 'application/x-ndjson');
+    res.setHeader('Transfer-Encoding', 'chunked');
+    res.write(JSON.stringify({ seq: 1, query: req.query }) + "\n");
+    setTimeout(() => {
+      res.write(JSON.stringify({ seq: 2 }) + "\n");
+      setTimeout(() => {
+        res.write(JSON.stringify({ seq: 3 }) + "\n");
+        res.end();
+      }, 10);
+    }, 10);
+  });
+
+  app.post("/ndjson-echo", (req, res) => {
+    res.setHeader('Content-Type', 'application/x-ndjson');
+    res.write(JSON.stringify({ body: req.body, header: req.headers['x-custom'] ?? null }) + "\n");
+    res.end();
+  });
+
+  app.get("/json", (req, res) => {
+    res.json({ hello: "world", query: req.query });
+  });
+
+  app.get("/binary", (req, res) => {
+    res.setHeader('Content-Type', 'application/octet-stream');
+    // Write in a few pieces to exercise re-chunking.
+    res.write(BINARY_PAYLOAD.subarray(0, 3000));
+    res.write(BINARY_PAYLOAD.subarray(3000, 7500));
+    res.write(BINARY_PAYLOAD.subarray(7500));
+    res.end();
+  });
+
+  app.get("/items/:id/detail", (req, res) => {
+    res.setHeader('Content-Type', 'application/x-ndjson');
+    res.write(JSON.stringify({ id: req.params.id, query: req.query }) + "\n");
+    res.end();
+  });
+
+  app.get("/auth", (req, res) => {
+    if (req.headers['x-api-key'] !== 'secret') {
+      return res.status(401).json({ error: "unauthorized" });
+    }
+    res.setHeader('Content-Type', 'application/x-ndjson');
+    res.write(JSON.stringify({ ok: true }) + "\n");
+    res.end();
+  });
+
+  app.get("/error", (req, res) => {
+    res.status(500).json({ error: "Internal Server Error" });
+  });
+
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, () => {
+      serverPort = (server.address() as any).port;
+      resolve();
+    });
+  });
+});
+
+afterAll(() => {
+  return new Promise<void>((resolve) => {
+    server.close(() => resolve());
+  });
+});
+
+const template = (overrides: Partial<StreamableHttpCallTemplate> & { url: string }): StreamableHttpCallTemplate => ({
+  name: "stream_server",
+  call_template_type: "streamable_http",
+  http_method: "GET",
+  content_type: "application/json",
+  chunk_size: 4096,
+  timeout: 5000,
+  ...overrides,
+});
+
+describe("StreamableHttpCommunicationProtocol", () => {
+  const protocol = new StreamableHttpCommunicationProtocol();
+
+  test("registerManual discovers tools from a manual endpoint", async () => {
+    const result = await protocol.registerManual(mockClient, template({ url: `http://localhost:${serverPort}/utcp` }));
+    expect(result.success).toBe(true);
+    expect(result.manual.tools).toHaveLength(1);
+    expect(result.manual.tools[0]?.name).toBe("stream_tool");
+  });
+
+  test("callToolStreaming yields one parsed object per NDJSON line", async () => {
+    const chunks: any[] = [];
+    for await (const chunk of protocol.callToolStreaming(mockClient, "stream_server.stream_tool", { q: "x" }, template({ url: `http://localhost:${serverPort}/ndjson` }))) {
+      chunks.push(chunk);
+    }
+    expect(chunks).toHaveLength(3);
+    expect(chunks[0]).toEqual({ seq: 1, query: { q: "x" } });
+    expect(chunks[1]).toEqual({ seq: 2 });
+    expect(chunks[2]).toEqual({ seq: 3 });
+  });
+
+  test("callTool collects NDJSON chunks into an array", async () => {
+    const result = await protocol.callTool(mockClient, "stream_server.stream_tool", {}, template({ url: `http://localhost:${serverPort}/ndjson` }));
+    expect(Array.isArray(result)).toBe(true);
+    expect(result.map((c: any) => c.seq)).toEqual([1, 2, 3]);
+  });
+
+  test("application/json responses are yielded as a single parsed value", async () => {
+    const chunks: any[] = [];
+    for await (const chunk of protocol.callToolStreaming(mockClient, "stream_server.json_tool", { a: "1" }, template({ url: `http://localhost:${serverPort}/json` }))) {
+      chunks.push(chunk);
+    }
+    expect(chunks).toEqual([{ hello: "world", query: { a: "1" } }]);
+  });
+
+  test("binary responses are re-chunked to chunk_size and concatenated by callTool", async () => {
+    const chunks: Buffer[] = [];
+    for await (const chunk of protocol.callToolStreaming(mockClient, "stream_server.bin", {}, template({ url: `http://localhost:${serverPort}/binary`, chunk_size: 4096 }))) {
+      expect(Buffer.isBuffer(chunk)).toBe(true);
+      expect(chunk.length).toBeLessThanOrEqual(4096);
+      chunks.push(chunk);
+    }
+    expect(Buffer.concat(chunks).equals(BINARY_PAYLOAD)).toBe(true);
+    // 10,000 bytes at 4096 per chunk -> 4096, 4096, 1808
+    expect(chunks.map(c => c.length)).toEqual([4096, 4096, 1808]);
+
+    const full = await protocol.callTool(mockClient, "stream_server.bin", {}, template({ url: `http://localhost:${serverPort}/binary` }));
+    expect(Buffer.isBuffer(full)).toBe(true);
+    expect((full as Buffer).equals(BINARY_PAYLOAD)).toBe(true);
+  });
+
+  test("POST sends body_field as JSON body and header_fields as headers", async () => {
+    const result = await protocol.callTool(mockClient, "stream_server.echo", { payload: { n: 42 }, "x-custom": "hdr" }, template({
+      url: `http://localhost:${serverPort}/ndjson-echo`,
+      http_method: "POST",
+      body_field: "payload",
+      header_fields: ["x-custom"],
+    }));
+    expect(result).toEqual([{ body: { n: 42 }, header: "hdr" }]);
+  });
+
+  test("path parameters are substituted and the rest become query params", async () => {
+    const result = await protocol.callTool(mockClient, "stream_server.detail", { id: "abc/1", limit: 5 }, template({
+      url: `http://localhost:${serverPort}/items/{id}/detail`,
+    }));
+    expect(result).toEqual([{ id: "abc/1", query: { limit: "5" } }]);
+  });
+
+  test("missing path parameters throw", async () => {
+    const gen = protocol.callToolStreaming(mockClient, "stream_server.detail", {}, template({
+      url: `http://localhost:${serverPort}/items/{id}/detail`,
+    }));
+    await expect(gen.next()).rejects.toThrow(/Missing required path parameter/);
+  });
+
+  test("API key auth in header is applied", async () => {
+    const result = await protocol.callTool(mockClient, "stream_server.auth", {}, template({
+      url: `http://localhost:${serverPort}/auth`,
+      auth: { auth_type: "api_key", api_key: "secret", var_name: "x-api-key", location: "header" } as any,
+    }));
+    expect(result).toEqual([{ ok: true }]);
+  });
+
+  test("non-2xx responses reject", async () => {
+    const gen = protocol.callToolStreaming(mockClient, "stream_server.err", {}, template({ url: `http://localhost:${serverPort}/error` }));
+    await expect(gen.next()).rejects.toThrow(/HTTP 500/);
+  });
+
+  test("wrong call template type is rejected", async () => {
+    const gen = protocol.callToolStreaming(mockClient, "x", {}, { name: "x", call_template_type: "http" } as any);
+    await expect(gen.next()).rejects.toThrow(/StreamableHttpCallTemplate/);
+  });
+});

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -18,7 +18,7 @@ The `@utcp/mcp` package enables the `UtcpClient` to interact with tools defined 
     *   **Tool Execution**: Invokes tools on MCP servers using the MCP SDK's `callTool()`, translating arguments and processing raw MCP results into a unified format.
     *   **Transport Support**: Seamlessly handles both `stdio` (spawning a local process) and `http` (connecting to a remote streamable HTTP MCP server) via the `@modelcontextprotocol/sdk` client.
     *   **Authentication Support**: Supports `OAuth2Auth` for HTTP-based MCP servers, including token caching and automatic refresh.
-    *   **Result Processing**: Intelligently adapts raw MCP tool results (which can contain `structured_output`, `text` content, or `json` content) into a more usable format for the UTCP client.
+    *   **Result Processing**: Intelligently adapts raw MCP tool results (`structuredContent` when the server sends it, otherwise `text` or `json` content; the legacy non-standard `structured_output` field is still accepted) into a more usable format for the UTCP client.
 
 ## Installation
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -155,6 +155,16 @@ const client = await UtcpClient.create(process.cwd(), {
 });
 ```
 
+### Child Process stderr
+
+Stdio MCP servers often write banners, telemetry notices and auth chatter to stderr, multiplied by every server you federate. `@utcp/mcp` therefore discards the child's stderr by default. To see it while debugging a server that fails to start, opt back in for the host process:
+
+```bash
+UTCP_MCP_CHILD_STDERR=inherit node your-app.js
+```
+
+Any other value, or leaving the variable unset, keeps stderr suppressed. When a stdio server fails to connect, the error log reminds you of this switch.
+
 ### HTTP Server Configuration
 
 HTTP-based MCP servers support additional configuration options:

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@utcp/mcp",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "Model Context Protocol integration for UTCP",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/packages/mcp/src/mcp_communication_protocol.ts
+++ b/packages/mcp/src/mcp_communication_protocol.ts
@@ -240,18 +240,36 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
    */
   private _invalidateOAuthToken(auth: Auth | undefined): void {
     if (!auth || auth.auth_type === 'oauth2_user') return;
-    const clientId = (auth as OAuth2Auth).client_id;
+    const oauth = auth as OAuth2Auth;
+    const clientId = oauth.client_id;
     if (!clientId) return;
+    const cacheKey = this._oauthCacheKey(oauth);
     // Bump the generation whether or not a token was cached: a fetch may be
     // in flight right now, and it must not cache what it brings back.
-    this._oauthGenerations.set(clientId, this._oauthGeneration(clientId) + 1);
-    if (this._oauthTokens.delete(clientId)) {
+    this._oauthGenerations.set(cacheKey, this._oauthGeneration(cacheKey) + 1);
+    // Drop any pending shared fetch too, so a caller arriving after the
+    // rejection starts a fresh fetch instead of joining the pre-invalidation
+    // one and receiving its now-rejected token.
+    this._oauthInflight.delete(cacheKey);
+    if (this._oauthTokens.delete(cacheKey)) {
       this._logInfo(`Dropped cached OAuth token for client '${clientId}' after an auth rejection.`);
     }
   }
 
-  private _oauthGeneration(clientId: string): number {
-    return this._oauthGenerations.get(clientId) ?? 0;
+  /**
+   * Key for every per-credential OAuth structure (token cache, in-flight
+   * fetch, invalidation generation). Keyed by the FULL configuration, not
+   * `client_id` alone: two templates may share a client_id but point at
+   * different issuers, scopes or secrets, and must not receive each other's
+   * tokens. Matches the HTTP plugin's cache key. Carries the secret, so it is
+   * used only as a map key and never logged.
+   */
+  private _oauthCacheKey(auth: OAuth2Auth): string {
+    return JSON.stringify([auth.token_url, auth.client_id, auth.client_secret, auth.scope || '']);
+  }
+
+  private _oauthGeneration(cacheKey: string): number {
+    return this._oauthGenerations.get(cacheKey) ?? 0;
   }
 
   /**
@@ -742,6 +760,12 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
       // and JS promises can't be cancelled, so this only avoids a brief dangling
       // entry after a drain.
       this._oauthInflight.clear();
+      // Likewise drop pending session creations. A dial that began before this
+      // drain will reject with the shutdown error on its own; without this, a
+      // call arriving after the drain could join that doomed promise instead of
+      // dialing fresh. The settle handler's identity guard means the old
+      // promise cannot clobber a newer entry.
+      this._sessionCreations.clear();
     } finally {
       // Drain complete — the shared registry instance stays usable. This
       // instance serves every UtcpClient in the process (see the field
@@ -831,25 +855,25 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
     // disable redirects (maxRedirects: 0) — a 307/308 would otherwise let axios
     // replay the client secret to an unvalidated redirect target.
     ensureSecureMcpUrl(authDetails.token_url, 'MCP OAuth2 token URL');
-    const clientId = authDetails.client_id;
-    const cachedToken = this._oauthTokens.get(clientId);
+    const cacheKey = this._oauthCacheKey(authDetails);
+    const cachedToken = this._oauthTokens.get(cacheKey);
     if (cachedToken && cachedToken.expiresAt > Date.now()) {
       return cachedToken.accessToken;
     }
 
     // Coalesce concurrent first-time fetches: share one in-flight request per
-    // client so a burst of callers issues a single token request. The
-    // check-and-set is synchronous, so exactly one fetch is started.
-    let inflight = this._oauthInflight.get(clientId);
+    // credential configuration so a burst of callers issues a single token
+    // request. The check-and-set is synchronous, so exactly one fetch is started.
+    let inflight = this._oauthInflight.get(cacheKey);
     if (!inflight) {
       inflight = this._fetchOAuth2Token(authDetails);
-      this._oauthInflight.set(clientId, inflight);
+      this._oauthInflight.set(cacheKey, inflight);
       // Clear the slot once settled so a later miss re-fetches. The handler
       // never rethrows, so it does not create an unhandled rejection; callers
       // still observe the original promise's rejection via `await inflight`.
       const forget = () => {
-        if (this._oauthInflight.get(clientId) === inflight) {
-          this._oauthInflight.delete(clientId);
+        if (this._oauthInflight.get(cacheKey) === inflight) {
+          this._oauthInflight.delete(cacheKey);
         }
       };
       inflight.then(forget, forget);
@@ -860,8 +884,9 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
 
   private async _fetchOAuth2Token(authDetails: OAuth2Auth): Promise<{ accessToken: string; expiresAt: number }> {
     const clientId = authDetails.client_id;
+    const cacheKey = this._oauthCacheKey(authDetails);
     this._logInfo(`Fetching new OAuth2 token for client: '${clientId}'`);
-    const generation = this._oauthGeneration(clientId);
+    const generation = this._oauthGeneration(cacheKey);
 
     try {
       // Only the WINNER of the race caches — previously each variant wrote
@@ -892,8 +917,8 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
           return { accessToken: response.data.access_token as string, expiresAt };
         })()
       ]);
-      if (this._oauthGeneration(clientId) === generation) {
-        this._oauthTokens.set(clientId, token);
+      if (this._oauthGeneration(cacheKey) === generation) {
+        this._oauthTokens.set(cacheKey, token);
       } else {
         this._logInfo(`OAuth token for client '${clientId}' was invalidated while a fetch was in flight; not caching the stale result.`);
       }

--- a/packages/mcp/src/mcp_communication_protocol.ts
+++ b/packages/mcp/src/mcp_communication_protocol.ts
@@ -252,17 +252,21 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
   }
 
   /**
-   * The one rule for what may enter the token cache: a successful HTTP
-   * response is not a successful token fetch unless it carries a USABLE
-   * access token, i.e. a non-empty string. The transport formats whatever it
-   * is given into `Bearer <token>`, so a truthy non-string (a number, `true`,
-   * an object) would be injected as an invalid credential on every reuse.
+   * The one rule for what may enter the token cache. Defined POSITIVELY from
+   * the contract the token must satisfy, not as a list of bad shapes: it is
+   * placed verbatim into `Authorization: Bearer <token>`, and an HTTP header
+   * value may contain only visible ASCII (RFC 9110 VCHAR, 0x21–0x7E), with a
+   * space ending the token. So a usable token is a non-empty string of VCHAR.
+   * That single rule makes every unusable shape inexpressible at once — a
+   * non-string, empty, whitespace, CR/LF header injection, NUL/control
+   * characters, non-ASCII — without over-fitting to RFC 6750's narrower
+   * b64token alphabet, which would reject legitimate opaque tokens.
    * Both fetch variants go through this, so the rule lives in one place.
    */
   private _requireAccessToken(data: any): string {
     const token = data?.access_token;
-    if (typeof token !== 'string' || token.length === 0) {
-      throw new Error("Access token not found in response, or not a usable string.");
+    if (typeof token !== 'string' || !/^[\x21-\x7E]+$/.test(token)) {
+      throw new Error("Access token missing, or not a usable bearer token (must be a non-empty string of visible ASCII).");
     }
     return token;
   }

--- a/packages/mcp/src/mcp_communication_protocol.ts
+++ b/packages/mcp/src/mcp_communication_protocol.ts
@@ -768,6 +768,9 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
   private async _handleOAuth2(authDetails: OAuth2Auth): Promise<string> {
     // Validate the token endpoint before sending credentials to it, so a
     // manual cannot direct the operator's client secret at an arbitrary host.
+    // Validation covers only this URL, so the credential-bearing POSTs below
+    // disable redirects (maxRedirects: 0) — a 307/308 would otherwise let axios
+    // replay the client secret to an unvalidated redirect target.
     ensureSecureMcpUrl(authDetails.token_url, 'MCP OAuth2 token URL');
     const clientId = authDetails.client_id;
     const cachedToken = this._oauthTokens.get(clientId);
@@ -790,7 +793,7 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
             'grant_type': 'client_credentials', 'client_id': authDetails.client_id,
             'client_secret': authDetails.client_secret, 'scope': authDetails.scope || ''
           });
-          const response = await this._axiosInstance.post(authDetails.token_url, bodyData.toString(), { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } });
+          const response = await this._axiosInstance.post(authDetails.token_url, bodyData.toString(), { headers: { 'Content-Type': 'application/x-www-form-urlencoded' }, maxRedirects: 0 });
           if (!response.data.access_token) throw new Error("Access token not found in response.");
           const expiresAt = Date.now() + ((response.data.expires_in || 3600) * 1000);
           return { accessToken: response.data.access_token as string, expiresAt };
@@ -799,7 +802,8 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
           const bodyData = new URLSearchParams({ 'grant_type': 'client_credentials', 'scope': authDetails.scope || '' });
           const response = await this._axiosInstance.post(authDetails.token_url, bodyData.toString(), {
             auth: { username: authDetails.client_id, password: authDetails.client_secret },
-            headers: { 'Content-Type': 'application/x-www-form-urlencoded' }
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            maxRedirects: 0
           });
           if (!response.data.access_token) throw new Error("Access token not found in response.");
           const expiresAt = Date.now() + ((response.data.expires_in || 3600) * 1000);

--- a/packages/mcp/src/mcp_communication_protocol.ts
+++ b/packages/mcp/src/mcp_communication_protocol.ts
@@ -109,22 +109,17 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
   private _oauthTokens: Map<string, { accessToken: string; expiresAt: number }> = new Map();
   /**
    * In-flight token fetches, keyed like the token cache (by the full OAuth
-   * configuration). A burst of concurrent first-time callers shares one request
-   * instead of each POSTing to the token endpoint. Each entry is tagged with the
-   * invalidation generation it started under, and an entry is removed ONLY
-   * when its fetch settles — so "entry present" reliably means "a fetch is
-   * running", which `_invalidateOAuthToken` relies on. (Promises are not
+   * configuration). At most one entry per key, and that entry is the SOLE
+   * authority for who may write the cache: a fetch caches its result only if
+   * it is still the current entry when it completes, and removes itself only
+   * if still current. Invalidation and close() simply delete the entry, so a
+   * fetch that was already running finds it is no longer current and declines
+   * to cache — there is no version counter to coordinate or leak, and nothing
+   * keyed by the secret outlives an actual in-flight fetch. A burst of
+   * concurrent first-time callers shares the one entry. (Promises are not
    * cancellable in JS, so unlike the Python plugin no shielding is needed.)
    */
-  private _oauthInflight: Map<string, { promise: Promise<{ accessToken: string; expiresAt: number }>; generation: number }> = new Map();
-  /**
-   * Per-client invalidation counter. A token fetch captures the generation
-   * when it starts and only caches its result if nothing invalidated the
-   * client in the meantime — otherwise an in-flight fetch that began before
-   * a 401 would repopulate the cache right after `_invalidateOAuthToken`
-   * cleared it.
-   */
-  private _oauthGenerations: Map<string, number> = new Map();
+  private _oauthInflight: Map<string, { promise: Promise<{ accessToken: string; expiresAt: number }> }> = new Map();
   private _axiosInstance: AxiosInstance;
   private _mcpSessions: Map<string, McpClient> = new Map();
   /**
@@ -247,37 +242,25 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
     const clientId = oauth.client_id;
     if (!clientId) return;
     const cacheKey = this._oauthCacheKey(oauth);
+    // Drop the in-flight entry: a fetch running under it is no longer current,
+    // so by the caching rule (see _oauthInflight) it will not write its
+    // pre-invalidation result, and callers from now on dial fresh.
+    this._oauthInflight.delete(cacheKey);
     if (this._oauthTokens.delete(cacheKey)) {
       this._logInfo(`Dropped cached OAuth token for client '${clientId}' after an auth rejection.`);
-    }
-    if (this._oauthInflight.has(cacheKey)) {
-      // A fetch is running (entries are only removed on settle, so this is a
-      // reliable signal). Bump the generation: the fetch's captured value no
-      // longer matches, so it won't cache its result, and callers arriving
-      // from now on see a stale tag and dial fresh instead of joining it. The
-      // counter is pruned when that fetch settles.
-      this._oauthGenerations.set(cacheKey, this._oauthGeneration(cacheKey) + 1);
-    } else {
-      // Nothing in flight, so there is no stale result to guard against; don't
-      // leave a counter (whose key carries the secret) behind.
-      this._oauthGenerations.delete(cacheKey);
     }
   }
 
   /**
    * Key for every per-credential OAuth structure (token cache, in-flight
-   * fetch, invalidation generation). Keyed by the FULL configuration, not
-   * `client_id` alone: two templates may share a client_id but point at
-   * different issuers, scopes or secrets, and must not receive each other's
-   * tokens. Matches the HTTP plugin's cache key. Carries the secret, so it is
-   * used only as a map key and never logged.
+   * fetch). Keyed by the FULL configuration, not `client_id` alone: two
+   * templates may share a client_id but point at different issuers, scopes or
+   * secrets, and must not receive each other's tokens. Matches the HTTP
+   * plugin's cache key. Carries the secret, so it is used only as a map key
+   * and never logged.
    */
   private _oauthCacheKey(auth: OAuth2Auth): string {
     return JSON.stringify([auth.token_url, auth.client_id, auth.client_secret, auth.scope || '']);
-  }
-
-  private _oauthGeneration(cacheKey: string): number {
-    return this._oauthGenerations.get(cacheKey) ?? 0;
   }
 
   /**
@@ -764,17 +747,17 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
       const cleanupPromises = Array.from(this._mcpSessions.keys()).map(key => this._cleanupSession(key));
       await Promise.all(cleanupPromises);
       this._oauthTokens.clear();
-      // In-flight OAuth fetches and their generation counters are deliberately
-      // NOT cleared here: an entry is the signal that a fetch is still running
-      // (see _oauthInflight), and both self-prune when it settles. Clearing them
-      // would let a post-drain invalidation misjudge a still-running fetch as
-      // absent and prune the counter it depends on.
-      //
-      // Pending session creations ARE dropped. A dial that began before this
-      // drain will reject with the shutdown error on its own; without this, a
-      // call arriving after the drain could join that doomed promise instead of
-      // dialing fresh. The settle handler's identity guard means the old
-      // promise cannot clobber a newer entry.
+      // Drop in-flight OAuth entries too. A fetch still running is then no
+      // longer current, so by the caching rule (see _oauthInflight) it will
+      // not repopulate the cache when it lands — the drain leaves no
+      // credential behind. (JS promises can't be cancelled; correctness comes
+      // from the identity gate, not from stopping the request.)
+      this._oauthInflight.clear();
+      // Pending session creations are dropped for the same reason. A dial that
+      // began before this drain will reject with the shutdown error on its own;
+      // without this, a call arriving after the drain could join that doomed
+      // promise instead of dialing fresh. The settle handler's identity guard
+      // means the old promise cannot clobber a newer entry.
       this._sessionCreations.clear();
     } finally {
       // Drain complete — the shared registry instance stays usable. This
@@ -871,33 +854,33 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
       return cachedToken.accessToken;
     }
 
-    // Coalesce concurrent first-time fetches: share one in-flight request per
-    // credential configuration. A caller only joins an entry from the CURRENT
-    // generation; a fetch invalidated mid-flight keeps running (its result is
-    // simply not cached) while later callers dial fresh. The check-and-set is
-    // synchronous, so exactly one fetch is started per generation.
-    const generation = this._oauthGeneration(cacheKey);
+    // Coalesce concurrent first-time fetches: share one in-flight entry per
+    // credential configuration. The entry is the sole authority for caching
+    // (see _oauthInflight): the fetch below writes the cache only if it is
+    // STILL the current entry when it lands, and removes itself only if still
+    // current. The check-and-set is synchronous, so exactly one fetch starts.
     let entry = this._oauthInflight.get(cacheKey);
-    if (!entry || entry.generation !== generation) {
-      const promise = this._fetchOAuth2Token(authDetails);
-      entry = { promise, generation };
-      this._oauthInflight.set(cacheKey, entry);
-      // Clear the slot once settled so a later miss re-fetches. The handler
-      // never rethrows, so it does not create an unhandled rejection; callers
-      // still observe the original promise's rejection via `await`.
-      const forget = () => {
-        if (this._oauthInflight.get(cacheKey) === entry) {
-          this._oauthInflight.delete(cacheKey);
+    if (!entry) {
+      const created: { promise: Promise<{ accessToken: string; expiresAt: number }> } = { promise: undefined as any };
+      created.promise = (async () => {
+        try {
+          const token = await this._fetchOAuth2Token(authDetails);
+          if (this._oauthInflight.get(cacheKey) === created) {
+            this._oauthTokens.set(cacheKey, token);
+          } else {
+            this._logInfo(`OAuth token for client '${authDetails.client_id}' was invalidated or drained while its fetch was in flight; not caching the stale result.`);
+          }
+          return token;
+        } finally {
+          // Only a still-current entry removes itself; a superseded one must
+          // not delete its successor's slot.
+          if (this._oauthInflight.get(cacheKey) === created) {
+            this._oauthInflight.delete(cacheKey);
+          }
         }
-        // With no fetch left in flight for this key the generation counter has
-        // nothing to protect — drop it, so rotating credentials don't
-        // accumulate counters (whose keys carry the secret) for the lifetime
-        // of this shared instance.
-        if (!this._oauthInflight.has(cacheKey)) {
-          this._oauthGenerations.delete(cacheKey);
-        }
-      };
-      promise.then(forget, forget);
+      })();
+      entry = created;
+      this._oauthInflight.set(cacheKey, created);
     }
     const token = await entry.promise;
     return token.accessToken;
@@ -905,16 +888,13 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
 
   private async _fetchOAuth2Token(authDetails: OAuth2Auth): Promise<{ accessToken: string; expiresAt: number }> {
     const clientId = authDetails.client_id;
-    const cacheKey = this._oauthCacheKey(authDetails);
     this._logInfo(`Fetching new OAuth2 token for client: '${clientId}'`);
-    const generation = this._oauthGeneration(cacheKey);
 
     try {
-      // Only the WINNER of the race caches — previously each variant wrote
-      // the cache on its own success, so the slower one landed later and
-      // overwrote whatever was there, including an invalidation that
-      // happened in between. And even the winner only caches if nothing
-      // invalidated this client while the fetch was in flight.
+      // Pure fetch: race the two request shapes and return the winner. This
+      // never writes the cache — whether the result may be cached is decided
+      // by _handleOAuth2, which knows whether this fetch is still the current
+      // in-flight entry when it lands.
       const token = await Promise.any([
         (async () => {
           const bodyData = new URLSearchParams({
@@ -938,11 +918,6 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
           return { accessToken: response.data.access_token as string, expiresAt };
         })()
       ]);
-      if (this._oauthGeneration(cacheKey) === generation) {
-        this._oauthTokens.set(cacheKey, token);
-      } else {
-        this._logInfo(`OAuth token for client '${clientId}' was invalidated while a fetch was in flight; not caching the stale result.`);
-      }
       return token;
     } catch (aggregateError: any) {
       const errorMessages = aggregateError.errors?.map((e: Error) => e.message).join('; ') || String(aggregateError);

--- a/packages/mcp/src/mcp_communication_protocol.ts
+++ b/packages/mcp/src/mcp_communication_protocol.ts
@@ -374,8 +374,8 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
         this._closeGeneration === closeGenerationAtStart
       ) {
         this._logError(
-          `The child's stderr was suppressed. Re-run with UTCP_MCP_CHILD_STDERR=inherit ` +
-          `to see what '${sessionKey}' printed while starting.`,
+          `The child's stderr was suppressed. If startup output may explain this, re-run with ` +
+          `UTCP_MCP_CHILD_STDERR=inherit to see what '${sessionKey}' printed while starting.`,
         );
       }
       throw e;
@@ -706,6 +706,11 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
       // which previously collapsed to []. Matches the Python SDK.
       if (result.structuredContent != null) {
         return this._unwrapStructuredContent(result.structuredContent);
+      }
+      // Legacy, non-standard field this client accepted before 1.2; kept so a
+      // server relying on it does not silently regress.
+      if (result.structured_output != null) {
+        return result.structured_output;
       }
       if (Array.isArray(result.content)) {
         const processedList = result.content.map((item: any) => {

--- a/packages/mcp/src/mcp_communication_protocol.ts
+++ b/packages/mcp/src/mcp_communication_protocol.ts
@@ -364,7 +364,15 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
     } catch (e: any) {
       // If connection fails, don't cache the broken client
       this._logError(`Failed to connect MCP client for '${sessionKey}':`, e.message);
-      if (serverConfig.transport === 'stdio' && process.env.UTCP_MCP_CHILD_STDERR !== 'inherit') {
+      // Only hint when the child actually failed to start. A close() that
+      // raced with this connect throws our own shutdown error above, and
+      // that is not something stderr would explain.
+      if (
+        serverConfig.transport === 'stdio' &&
+        process.env.UTCP_MCP_CHILD_STDERR !== 'inherit' &&
+        this._activeDrains === 0 &&
+        this._closeGeneration === closeGenerationAtStart
+      ) {
         this._logError(
           `The child's stderr was suppressed. Re-run with UTCP_MCP_CHILD_STDERR=inherit ` +
           `to see what '${sessionKey}' printed while starting.`,
@@ -713,10 +721,15 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
   }
 
   /**
-   * FastMCP-style servers wrap non-object tool returns as `{ result: value }`
-   * so that `structuredContent` is always an object. Unwrap exactly that
-   * single-key shape; an object that merely has a `result` key among others
-   * is a genuine object return and is passed through untouched.
+   * FastMCP-style servers wrap NON-OBJECT tool returns (primitives, arrays,
+   * null) as `{ result: value }` so that `structuredContent` is always an
+   * object; object returns are sent as-is. Unwrap exactly that shape: a
+   * single `result` key whose value is not a plain object. A single-key
+   * `{ result: { ... } }` is therefore a genuine object return and passes
+   * through untouched, as does any object with other keys. A genuine
+   * `{ result: <primitive or array> }` return is indistinguishable from the
+   * wrapper on the wire and is unwrapped too; that ambiguity is inherent to
+   * the FastMCP convention.
    */
   private _unwrapStructuredContent(structured: any): any {
     if (
@@ -726,7 +739,11 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
       Object.keys(structured).length === 1 &&
       'result' in structured
     ) {
-      return structured.result;
+      const inner = structured.result;
+      const innerIsPlainObject = inner !== null && typeof inner === 'object' && !Array.isArray(inner);
+      if (!innerIsPlainObject) {
+        return inner;
+      }
     }
     return structured;
   }

--- a/packages/mcp/src/mcp_communication_protocol.ts
+++ b/packages/mcp/src/mcp_communication_protocol.ts
@@ -364,6 +364,12 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
     } catch (e: any) {
       // If connection fails, don't cache the broken client
       this._logError(`Failed to connect MCP client for '${sessionKey}':`, e.message);
+      if (serverConfig.transport === 'stdio' && process.env.UTCP_MCP_CHILD_STDERR !== 'inherit') {
+        this._logError(
+          `The child's stderr was suppressed. Re-run with UTCP_MCP_CHILD_STDERR=inherit ` +
+          `to see what '${sessionKey}' printed while starting.`,
+        );
+      }
       throw e;
     }
     
@@ -683,15 +689,15 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
   
   private _processMcpToolResult(result: any): any {
     if (result && typeof result === 'object') {
-      if ('structured_output' in result) {
-        return result.structured_output;
-      }
-      // MCP servers may return only `structuredContent` (spec field) with an
-      // empty `content` array — without this fallback such results collapse
-      // to [] and the payload is silently lost.
-      const hasContent = Array.isArray(result.content) && result.content.length > 0;
-      if (!hasContent && result.structuredContent != null) {
-        return result.structuredContent;
+      // Prefer `structuredContent` (MCP spec field) whenever the server sent
+      // it. Spec-compliant servers also mirror it as a serialized text block
+      // in `content` for older clients, and re-parsing that text is lossy: a
+      // numeric-looking string becomes a number, unparsable JSON stays a
+      // string. Using the structured payload directly also covers servers
+      // that return an empty `content` array with only `structuredContent`,
+      // which previously collapsed to []. Matches the Python SDK.
+      if (result.structuredContent != null) {
+        return this._unwrapStructuredContent(result.structuredContent);
       }
       if (Array.isArray(result.content)) {
         const processedList = result.content.map((item: any) => {
@@ -704,6 +710,25 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
       }
     }
     return result;
+  }
+
+  /**
+   * FastMCP-style servers wrap non-object tool returns as `{ result: value }`
+   * so that `structuredContent` is always an object. Unwrap exactly that
+   * single-key shape; an object that merely has a `result` key among others
+   * is a genuine object return and is passed through untouched.
+   */
+  private _unwrapStructuredContent(structured: any): any {
+    if (
+      structured &&
+      typeof structured === 'object' &&
+      !Array.isArray(structured) &&
+      Object.keys(structured).length === 1 &&
+      'result' in structured
+    ) {
+      return structured.result;
+    }
+    return structured;
   }
 
   private _parseTextContent(text: string): any {

--- a/packages/mcp/src/mcp_communication_protocol.ts
+++ b/packages/mcp/src/mcp_communication_protocol.ts
@@ -124,6 +124,12 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
   private _axiosInstance: AxiosInstance;
   private _mcpSessions: Map<string, McpClient> = new Map();
   /**
+   * In-flight session creations, keyed by sessionKey. Concurrent first calls
+   * for the same server share one dial instead of each spawning a transport and
+   * orphaning all but the last (which `_mcpSessions.set` would silently drop).
+   */
+  private _sessionCreations: Map<string, Promise<McpClient>> = new Map();
+  /**
    * `close()` is a DRAIN, not a terminal state. This instance is registered
    * once at module load (`index.ts`) into the process-wide
    * `CommunicationProtocol.communicationProtocols` registry, and EVERY
@@ -261,6 +267,29 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
       return existingSession;
     }
 
+    // Coalesce concurrent creations for the same key: without this, a burst of
+    // first calls each dials a transport and all but the last are orphaned
+    // (never closed). Cleared on settle so a later miss — including a retry
+    // after eviction — dials fresh.
+    const inflight = this._sessionCreations.get(sessionKey);
+    if (inflight) return inflight;
+    const creation = this._createSession(serverName, serverConfig, auth, sessionKey);
+    this._sessionCreations.set(sessionKey, creation);
+    const forget = () => {
+      if (this._sessionCreations.get(sessionKey) === creation) {
+        this._sessionCreations.delete(sessionKey);
+      }
+    };
+    creation.then(forget, forget);
+    return creation;
+  }
+
+  private async _createSession(
+    serverName: string,
+    serverConfig: McpServerConfig,
+    auth: Auth | undefined,
+    sessionKey: string,
+  ): Promise<McpClient> {
     // Worded without the transient markers ("closed", "disconnected") on
     // purpose, so `_withSession` does not classify shutdown as a transport
     // hiccup and spend a retry on it.

--- a/packages/mcp/src/mcp_communication_protocol.ts
+++ b/packages/mcp/src/mcp_communication_protocol.ts
@@ -107,6 +107,13 @@ function isMcpToolsResponse(data: unknown): data is { tools: McpToolResponse[] }
 export class McpCommunicationProtocol implements CommunicationProtocol {
   private _oauthTokens: Map<string, { accessToken: string; expiresAt: number }> = new Map();
   /**
+   * In-flight token fetches, keyed like the token cache (by client_id). A burst
+   * of concurrent first-time callers shares one request instead of each POSTing
+   * to the token endpoint. (Promises are not cancellable in JS, so unlike the
+   * Python plugin no shielding is needed — extra awaiters cannot abort the fetch.)
+   */
+  private _oauthInflight: Map<string, Promise<{ accessToken: string; expiresAt: number }>> = new Map();
+  /**
    * Per-client invalidation counter. A token fetch captures the generation
    * when it starts and only caches its result if nothing invalidated the
    * client in the meantime — otherwise an in-flight fetch that began before
@@ -683,6 +690,10 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
       const cleanupPromises = Array.from(this._mcpSessions.keys()).map(key => this._cleanupSession(key));
       await Promise.all(cleanupPromises);
       this._oauthTokens.clear();
+      // Drop references to any in-flight fetches; they self-remove on settle,
+      // and JS promises can't be cancelled, so this only avoids a brief dangling
+      // entry after a drain.
+      this._oauthInflight.clear();
     } finally {
       // Drain complete — the shared registry instance stays usable. This
       // instance serves every UtcpClient in the process (see the field
@@ -778,6 +789,29 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
       return cachedToken.accessToken;
     }
 
+    // Coalesce concurrent first-time fetches: share one in-flight request per
+    // client so a burst of callers issues a single token request. The
+    // check-and-set is synchronous, so exactly one fetch is started.
+    let inflight = this._oauthInflight.get(clientId);
+    if (!inflight) {
+      inflight = this._fetchOAuth2Token(authDetails);
+      this._oauthInflight.set(clientId, inflight);
+      // Clear the slot once settled so a later miss re-fetches. The handler
+      // never rethrows, so it does not create an unhandled rejection; callers
+      // still observe the original promise's rejection via `await inflight`.
+      const forget = () => {
+        if (this._oauthInflight.get(clientId) === inflight) {
+          this._oauthInflight.delete(clientId);
+        }
+      };
+      inflight.then(forget, forget);
+    }
+    const token = await inflight;
+    return token.accessToken;
+  }
+
+  private async _fetchOAuth2Token(authDetails: OAuth2Auth): Promise<{ accessToken: string; expiresAt: number }> {
+    const clientId = authDetails.client_id;
     this._logInfo(`Fetching new OAuth2 token for client: '${clientId}'`);
     const generation = this._oauthGeneration(clientId);
 
@@ -815,7 +849,7 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
       } else {
         this._logInfo(`OAuth token for client '${clientId}' was invalidated while a fetch was in flight; not caching the stale result.`);
       }
-      return token.accessToken;
+      return token;
     } catch (aggregateError: any) {
       const errorMessages = aggregateError.errors?.map((e: Error) => e.message).join('; ') || String(aggregateError);
       throw new Error(`Failed to fetch OAuth2 token for client '${clientId}': ${errorMessages}`);

--- a/packages/mcp/src/mcp_communication_protocol.ts
+++ b/packages/mcp/src/mcp_communication_protocol.ts
@@ -252,6 +252,22 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
   }
 
   /**
+   * The one rule for what may enter the token cache: a successful HTTP
+   * response is not a successful token fetch unless it carries a USABLE
+   * access token, i.e. a non-empty string. The transport formats whatever it
+   * is given into `Bearer <token>`, so a truthy non-string (a number, `true`,
+   * an object) would be injected as an invalid credential on every reuse.
+   * Both fetch variants go through this, so the rule lives in one place.
+   */
+  private _requireAccessToken(data: any): string {
+    const token = data?.access_token;
+    if (typeof token !== 'string' || token.length === 0) {
+      throw new Error("Access token not found in response, or not a usable string.");
+    }
+    return token;
+  }
+
+  /**
    * Key for every per-credential OAuth structure (token cache, in-flight
    * fetch). Keyed by the FULL configuration, not `client_id` alone: two
    * templates may share a client_id but point at different issuers, scopes or
@@ -902,9 +918,9 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
             'client_secret': authDetails.client_secret, 'scope': authDetails.scope || ''
           });
           const response = await this._axiosInstance.post(authDetails.token_url, bodyData.toString(), { headers: { 'Content-Type': 'application/x-www-form-urlencoded' }, maxRedirects: 0 });
-          if (!response.data.access_token) throw new Error("Access token not found in response.");
+          const accessToken = this._requireAccessToken(response.data);
           const expiresAt = Date.now() + ((response.data.expires_in || 3600) * 1000);
-          return { accessToken: response.data.access_token as string, expiresAt };
+          return { accessToken, expiresAt };
         })(),
         (async () => {
           const bodyData = new URLSearchParams({ 'grant_type': 'client_credentials', 'scope': authDetails.scope || '' });
@@ -913,9 +929,9 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
             headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
             maxRedirects: 0
           });
-          if (!response.data.access_token) throw new Error("Access token not found in response.");
+          const accessToken = this._requireAccessToken(response.data);
           const expiresAt = Date.now() + ((response.data.expires_in || 3600) * 1000);
-          return { accessToken: response.data.access_token as string, expiresAt };
+          return { accessToken, expiresAt };
         })()
       ]);
       return token;

--- a/packages/mcp/src/mcp_communication_protocol.ts
+++ b/packages/mcp/src/mcp_communication_protocol.ts
@@ -173,8 +173,13 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
         return schema as JsonSchema;
       }
       
-      // Dereference the schema (inlines all $refs and $defs)
-      const dereferenced = await $RefParser.dereference(schema as any);
+      // Dereference the schema (inlines all $refs and $defs). `circular:
+      // 'ignore'` keeps recursive schemas (e.g. self-referencing filter
+      // grammars) from throwing — the cycle is left as a live reference
+      // instead of failing the whole tool discovery.
+      const dereferenced = await $RefParser.dereference(schema as any, {
+        dereference: { circular: 'ignore' },
+      });
       return dereferenced as JsonSchema;
     } catch (error: any) {
       // If dereferencing fails, log a warning and return the original schema
@@ -273,6 +278,12 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
         args: stdioConfig.args || [],
         cwd: stdioConfig.cwd,
         env: combinedEnv,
+        // Default the child's stderr to 'ignore' so a chatty MCP server does
+        // not flood the host terminal during discovery. NOT 'pipe': with no
+        // reader attached the OS pipe buffer fills and a verbose child
+        // deadlocks. Set UTCP_MCP_CHILD_STDERR=inherit to see child stderr
+        // when debugging.
+        stderr: process.env.UTCP_MCP_CHILD_STDERR === 'inherit' ? 'inherit' : 'ignore',
       });
 
     } else if (serverConfig.transport === 'http') {
@@ -674,6 +685,13 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
     if (result && typeof result === 'object') {
       if ('structured_output' in result) {
         return result.structured_output;
+      }
+      // MCP servers may return only `structuredContent` (spec field) with an
+      // empty `content` array — without this fallback such results collapse
+      // to [] and the payload is silently lost.
+      const hasContent = Array.isArray(result.content) && result.content.length > 0;
+      if (!hasContent && result.structuredContent != null) {
+        return result.structuredContent;
       }
       if (Array.isArray(result.content)) {
         const processedList = result.content.map((item: any) => {

--- a/packages/mcp/src/mcp_communication_protocol.ts
+++ b/packages/mcp/src/mcp_communication_protocol.ts
@@ -1,4 +1,5 @@
 // packages/mcp/src/mcp_communication_protocol.ts
+import { createHash } from 'crypto';
 import { Client as McpClient } from '@modelcontextprotocol/sdk/client/index.js';
 import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
@@ -253,12 +254,30 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
     return this._oauthGenerations.get(clientId) ?? 0;
   }
 
+  /**
+   * Identity of a cached session. This protocol instance is shared
+   * process-wide, so keying by server name alone would let two manuals that
+   * name a server the same (e.g. "github") share a session even when their
+   * configs or credentials differ — one manual's calls would then run against
+   * the other's server or token. Include the config and auth so distinct
+   * connections get distinct sessions (mirrors python-utcp keying clients by
+   * config + auth). The config and auth are HASHED, not embedded, so the key
+   * stays log-safe and never exposes a secret.
+   */
+  private _sessionKey(serverName: string, serverConfig: McpServerConfig, auth?: Auth): string {
+    const fingerprint = createHash('sha256')
+      .update(JSON.stringify({ config: serverConfig, auth: auth ?? null }))
+      .digest('hex')
+      .slice(0, 16);
+    return `${serverName}:${serverConfig.transport}:${fingerprint}`;
+  }
+
   private async _getOrCreateSession(
     serverName: string,
     serverConfig: McpServerConfig,
     auth?: Auth
   ): Promise<McpClient> {
-    const sessionKey = `${serverName}:${serverConfig.transport}`;
+    const sessionKey = this._sessionKey(serverName, serverConfig, auth);
 
     // Check if we have an existing session
     if (this._mcpSessions.has(sessionKey)) {
@@ -548,7 +567,7 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
     auth: Auth | undefined,
     operation: (client: McpClient) => Promise<T>
   ): Promise<T> {
-    const sessionKey = `${serverName}:${serverConfig.transport}`;
+    const sessionKey = this._sessionKey(serverName, serverConfig, auth);
     const timeoutMs = this._getTimeoutMs(serverConfig);
     // Hoisted so the catch arms can hand the SPECIFIC client that failed to
     // `_cleanupSession` — a key-only eviction would close whatever a

--- a/packages/mcp/src/mcp_communication_protocol.ts
+++ b/packages/mcp/src/mcp_communication_protocol.ts
@@ -766,6 +766,9 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
   }
   
   private async _handleOAuth2(authDetails: OAuth2Auth): Promise<string> {
+    // Validate the token endpoint before sending credentials to it, so a
+    // manual cannot direct the operator's client secret at an arbitrary host.
+    ensureSecureMcpUrl(authDetails.token_url, 'MCP OAuth2 token URL');
     const clientId = authDetails.client_id;
     const cachedToken = this._oauthTokens.get(clientId);
     if (cachedToken && cachedToken.expiresAt > Date.now()) {

--- a/packages/mcp/src/mcp_communication_protocol.ts
+++ b/packages/mcp/src/mcp_communication_protocol.ts
@@ -108,12 +108,15 @@ function isMcpToolsResponse(data: unknown): data is { tools: McpToolResponse[] }
 export class McpCommunicationProtocol implements CommunicationProtocol {
   private _oauthTokens: Map<string, { accessToken: string; expiresAt: number }> = new Map();
   /**
-   * In-flight token fetches, keyed like the token cache (by client_id). A burst
-   * of concurrent first-time callers shares one request instead of each POSTing
-   * to the token endpoint. (Promises are not cancellable in JS, so unlike the
-   * Python plugin no shielding is needed — extra awaiters cannot abort the fetch.)
+   * In-flight token fetches, keyed like the token cache (by the full OAuth
+   * configuration). A burst of concurrent first-time callers shares one request
+   * instead of each POSTing to the token endpoint. Each entry is tagged with the
+   * invalidation generation it started under, and an entry is removed ONLY
+   * when its fetch settles — so "entry present" reliably means "a fetch is
+   * running", which `_invalidateOAuthToken` relies on. (Promises are not
+   * cancellable in JS, so unlike the Python plugin no shielding is needed.)
    */
-  private _oauthInflight: Map<string, Promise<{ accessToken: string; expiresAt: number }>> = new Map();
+  private _oauthInflight: Map<string, { promise: Promise<{ accessToken: string; expiresAt: number }>; generation: number }> = new Map();
   /**
    * Per-client invalidation counter. A token fetch captures the generation
    * when it starts and only caches its result if nothing invalidated the
@@ -244,15 +247,20 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
     const clientId = oauth.client_id;
     if (!clientId) return;
     const cacheKey = this._oauthCacheKey(oauth);
-    // Bump the generation whether or not a token was cached: a fetch may be
-    // in flight right now, and it must not cache what it brings back.
-    this._oauthGenerations.set(cacheKey, this._oauthGeneration(cacheKey) + 1);
-    // Drop any pending shared fetch too, so a caller arriving after the
-    // rejection starts a fresh fetch instead of joining the pre-invalidation
-    // one and receiving its now-rejected token.
-    this._oauthInflight.delete(cacheKey);
     if (this._oauthTokens.delete(cacheKey)) {
       this._logInfo(`Dropped cached OAuth token for client '${clientId}' after an auth rejection.`);
+    }
+    if (this._oauthInflight.has(cacheKey)) {
+      // A fetch is running (entries are only removed on settle, so this is a
+      // reliable signal). Bump the generation: the fetch's captured value no
+      // longer matches, so it won't cache its result, and callers arriving
+      // from now on see a stale tag and dial fresh instead of joining it. The
+      // counter is pruned when that fetch settles.
+      this._oauthGenerations.set(cacheKey, this._oauthGeneration(cacheKey) + 1);
+    } else {
+      // Nothing in flight, so there is no stale result to guard against; don't
+      // leave a counter (whose key carries the secret) behind.
+      this._oauthGenerations.delete(cacheKey);
     }
   }
 
@@ -756,11 +764,13 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
       const cleanupPromises = Array.from(this._mcpSessions.keys()).map(key => this._cleanupSession(key));
       await Promise.all(cleanupPromises);
       this._oauthTokens.clear();
-      // Drop references to any in-flight fetches; they self-remove on settle,
-      // and JS promises can't be cancelled, so this only avoids a brief dangling
-      // entry after a drain.
-      this._oauthInflight.clear();
-      // Likewise drop pending session creations. A dial that began before this
+      // In-flight OAuth fetches and their generation counters are deliberately
+      // NOT cleared here: an entry is the signal that a fetch is still running
+      // (see _oauthInflight), and both self-prune when it settles. Clearing them
+      // would let a post-drain invalidation misjudge a still-running fetch as
+      // absent and prune the counter it depends on.
+      //
+      // Pending session creations ARE dropped. A dial that began before this
       // drain will reject with the shutdown error on its own; without this, a
       // call arriving after the drain could join that doomed promise instead of
       // dialing fresh. The settle handler's identity guard means the old
@@ -862,23 +872,34 @@ export class McpCommunicationProtocol implements CommunicationProtocol {
     }
 
     // Coalesce concurrent first-time fetches: share one in-flight request per
-    // credential configuration so a burst of callers issues a single token
-    // request. The check-and-set is synchronous, so exactly one fetch is started.
-    let inflight = this._oauthInflight.get(cacheKey);
-    if (!inflight) {
-      inflight = this._fetchOAuth2Token(authDetails);
-      this._oauthInflight.set(cacheKey, inflight);
+    // credential configuration. A caller only joins an entry from the CURRENT
+    // generation; a fetch invalidated mid-flight keeps running (its result is
+    // simply not cached) while later callers dial fresh. The check-and-set is
+    // synchronous, so exactly one fetch is started per generation.
+    const generation = this._oauthGeneration(cacheKey);
+    let entry = this._oauthInflight.get(cacheKey);
+    if (!entry || entry.generation !== generation) {
+      const promise = this._fetchOAuth2Token(authDetails);
+      entry = { promise, generation };
+      this._oauthInflight.set(cacheKey, entry);
       // Clear the slot once settled so a later miss re-fetches. The handler
       // never rethrows, so it does not create an unhandled rejection; callers
-      // still observe the original promise's rejection via `await inflight`.
+      // still observe the original promise's rejection via `await`.
       const forget = () => {
-        if (this._oauthInflight.get(cacheKey) === inflight) {
+        if (this._oauthInflight.get(cacheKey) === entry) {
           this._oauthInflight.delete(cacheKey);
         }
+        // With no fetch left in flight for this key the generation counter has
+        // nothing to protect — drop it, so rotating credentials don't
+        // accumulate counters (whose keys carry the secret) for the lifetime
+        // of this shared instance.
+        if (!this._oauthInflight.has(cacheKey)) {
+          this._oauthGenerations.delete(cacheKey);
+        }
       };
-      inflight.then(forget, forget);
+      promise.then(forget, forget);
     }
-    const token = await inflight;
+    const token = await entry.promise;
     return token.accessToken;
   }
 

--- a/packages/mcp/tests/mcp_communication_protocol.test.ts
+++ b/packages/mcp/tests/mcp_communication_protocol.test.ts
@@ -301,7 +301,10 @@ describe("McpCommunicationProtocol", () => {
 
   describe("Session eviction on session-class failures (issue #34)", () => {
     const CONFIG = { transport: "stdio" as const, command: "true", timeout: 60 };
-    const KEY = "s:stdio";
+    // The session key now includes a config+auth fingerprint; compute it the
+    // same way the protocol does. This is the key for (CONFIG, no-auth), which
+    // the run()-based tests below exercise.
+    const KEY = (new McpCommunicationProtocol() as any)._sessionKey("s", CONFIG, undefined);
 
     /** A fake cached session whose close() we can observe, wired into the
      * protocol's private session map the way _getOrCreateSession would. */
@@ -312,9 +315,10 @@ describe("McpCommunicationProtocol", () => {
         close() { this.closed += 1; return Promise.resolve(); },
         op: () => behavior((calls += 1)),
       };
-      (protocol as any)._mcpSessions.set(KEY, client);
-      (protocol as any)._getOrCreateSession = () => {
-        (protocol as any)._mcpSessions.set(KEY, client);
+      // Cache under the SAME key the real _getOrCreateSession would for these
+      // args, so _withSession's cleanup (which recomputes the key) targets it.
+      (protocol as any)._getOrCreateSession = (sn: any, sc: any, a: any) => {
+        (protocol as any)._mcpSessions.set((protocol as any)._sessionKey(sn, sc, a), client);
         return Promise.resolve(client);
       };
       return client;
@@ -383,7 +387,8 @@ describe("McpCommunicationProtocol", () => {
         (protocol as any)._withSession("s", config, undefined, () => client.op())
       ).rejects.toThrow("timed out");
       expect(client.closed).toBe(1);
-      expect((protocol as any)._mcpSessions.has(KEY)).toBe(false);
+      // This test uses a modified config (timeout: 1), so its session key differs.
+      expect((protocol as any)._mcpSessions.has((protocol as any)._sessionKey("s", config, undefined))).toBe(false);
     });
 
     test("an auth failure dressed in connection vocabulary is not retried", async () => {
@@ -582,7 +587,8 @@ describe("McpCommunicationProtocol", () => {
         (protocol as any)._withSession("s", CONFIG, auth, () => client.op())
       ).rejects.toThrow("Authorization");
       expect(client.closed).toBe(0);
-      expect((protocol as any)._mcpSessions.get(KEY)).toBe(client);
+      // Called with auth, so the session is cached under the auth-inclusive key.
+      expect((protocol as any)._mcpSessions.get((protocol as any)._sessionKey("s", CONFIG, auth))).toBe(client);
       expect((protocol as any)._oauthTokens.has("cid")).toBe(true);
     });
 
@@ -839,5 +845,35 @@ describe("McpCommunicationProtocol session-creation coalescing", () => {
     await protocol._getOrCreateSession("s", CONFIG);
 
     expect(creations).toBe(2);
+  });
+});
+
+describe("McpCommunicationProtocol session isolation by config + auth", () => {
+  test("same server name but different config yields different session keys", () => {
+    const protocol: any = new McpCommunicationProtocol();
+    const a = protocol._sessionKey("srv", { transport: "stdio", command: "serverA" }, undefined);
+    const b = protocol._sessionKey("srv", { transport: "stdio", command: "serverB" }, undefined);
+    expect(a).not.toBe(b);
+  });
+
+  test("same server name + config but different auth yields different session keys", () => {
+    const protocol: any = new McpCommunicationProtocol();
+    const cfg = { transport: "http", url: "https://x/mcp" };
+    const a = protocol._sessionKey("srv", cfg, { auth_type: "oauth2", client_id: "a", client_secret: "s", token_url: "https://x/t" });
+    const b = protocol._sessionKey("srv", cfg, { auth_type: "oauth2", client_id: "b", client_secret: "s", token_url: "https://x/t" });
+    expect(a).not.toBe(b);
+  });
+
+  test("identical name + config + auth yields the same key (sessions still shared)", () => {
+    const protocol: any = new McpCommunicationProtocol();
+    const cfg = { transport: "stdio", command: "node" };
+    expect(protocol._sessionKey("srv", cfg, undefined)).toBe(protocol._sessionKey("srv", cfg, undefined));
+  });
+
+  test("the session key never embeds the raw secret (log-safe)", () => {
+    const protocol: any = new McpCommunicationProtocol();
+    const cfg = { transport: "http", url: "https://x/mcp" };
+    const key = protocol._sessionKey("srv", cfg, { auth_type: "oauth2", client_id: "a", client_secret: "TOPSECRET", token_url: "https://x/t" });
+    expect(key).not.toContain("TOPSECRET");
   });
 });

--- a/packages/mcp/tests/mcp_communication_protocol.test.ts
+++ b/packages/mcp/tests/mcp_communication_protocol.test.ts
@@ -713,4 +713,77 @@ describe("McpCommunicationProtocol", () => {
       expect(capturedOpts[1]).toEqual({ method: "callTool", opts: { timeout: 90_000 } });
     });
   });
+
+  describe("Tool result processing", () => {
+    const protocol = new McpCommunicationProtocol();
+    const processResult = (r: any) => (protocol as any)._processMcpToolResult(r);
+
+    test("prefers structuredContent over the mirrored text block", () => {
+      const result = {
+        content: [{ type: "text", text: '{"answer": 42}' }],
+        structuredContent: { answer: 42 },
+      };
+      expect(processResult(result)).toEqual({ answer: 42 });
+    });
+
+    test("returns structuredContent when content is empty instead of collapsing to []", () => {
+      expect(processResult({ content: [], structuredContent: { answer: 42 } })).toEqual({ answer: 42 });
+    });
+
+    test("unwraps a FastMCP-style single-key {result} wrapper", () => {
+      expect(processResult({ content: [{ type: "text", text: "42" }], structuredContent: { result: 42 } })).toBe(42);
+    });
+
+    test("does not unwrap an object that merely has a result key among others", () => {
+      const structured = { result: 1, extra: 2 };
+      expect(processResult({ content: [], structuredContent: structured })).toEqual(structured);
+    });
+
+    test("falls back to parsing text content when structuredContent is absent", () => {
+      expect(processResult({ content: [{ type: "text", text: '{"a": 1}' }] })).toEqual({ a: 1 });
+      expect(processResult({ content: [{ type: "text", text: "7" }] })).toBe(7);
+      expect(processResult({ content: [] })).toEqual([]);
+    });
+  });
+
+  describe("Schema dereferencing", () => {
+    const protocol = new McpCommunicationProtocol();
+    const deref = (s: any) => (protocol as any)._dereferenceSchema(s);
+
+    test("a circular schema dereferences into something JSON-serializable", async () => {
+      const schema = {
+        type: "object",
+        properties: { root: { $ref: "#/$defs/node" } },
+        $defs: {
+          node: {
+            type: "object",
+            properties: {
+              value: { type: "string" },
+              next: { $ref: "#/$defs/node" },
+            },
+          },
+        },
+      };
+      const out = await deref(schema);
+      // With the default `circular: true` this is a live object cycle and
+      // stringify throws; with `circular: 'ignore'` every $ref on the cycle
+      // stays a $ref string, which serializes fine.
+      expect(() => JSON.stringify(out)).not.toThrow();
+      expect(out.properties.root).toEqual({ $ref: "#/$defs/node" });
+      // The definitions the leftover $refs point at must survive so the
+      // schema remains resolvable by whoever consumes it.
+      expect(out.$defs.node.properties.value).toEqual({ type: "string" });
+      expect(out.$defs.node.properties.next).toEqual({ $ref: "#/$defs/node" });
+    });
+
+    test("acyclic refs are still inlined", async () => {
+      const schema = {
+        type: "object",
+        properties: { a: { $ref: "#/$defs/s" } },
+        $defs: { s: { type: "string" } },
+      };
+      const out = await deref(schema);
+      expect(out.properties.a).toEqual({ type: "string" });
+    });
+  });
 });

--- a/packages/mcp/tests/mcp_communication_protocol.test.ts
+++ b/packages/mcp/tests/mcp_communication_protocol.test.ts
@@ -798,3 +798,46 @@ describe("McpCommunicationProtocol", () => {
     });
   });
 });
+describe("McpCommunicationProtocol session-creation coalescing", () => {
+  const CONFIG = { transport: "stdio" as const, command: "true", timeout: 60 };
+
+  test("concurrent first calls for the same server dial exactly once", async () => {
+    const protocol: any = new McpCommunicationProtocol();
+    let creations = 0;
+    let release!: () => void;
+    const gate = new Promise<void>((r) => { release = r; });
+    const fakeClient = { close: () => Promise.resolve() };
+    protocol._createSession = async () => {
+      creations += 1;
+      await gate;
+      protocol._mcpSessions.set("s:stdio", fakeClient);
+      return fakeClient;
+    };
+
+    const pending = Promise.all([
+      protocol._getOrCreateSession("s", CONFIG),
+      protocol._getOrCreateSession("s", CONFIG),
+      protocol._getOrCreateSession("s", CONFIG),
+    ]);
+    release();
+    const clients = await pending;
+
+    expect(creations).toBe(1);
+    expect(clients.every((c: any) => c === fakeClient)).toBe(true);
+    expect(protocol._sessionCreations.size).toBe(0); // slot cleared on settle
+  });
+
+  test("a later call after the creation settles dials again", async () => {
+    const protocol: any = new McpCommunicationProtocol();
+    let creations = 0;
+    protocol._createSession = async () => {
+      creations += 1;
+      return { close: () => Promise.resolve() }; // not cached, so the next call misses
+    };
+
+    await protocol._getOrCreateSession("s", CONFIG);
+    await protocol._getOrCreateSession("s", CONFIG);
+
+    expect(creations).toBe(2);
+  });
+});

--- a/packages/mcp/tests/mcp_communication_protocol.test.ts
+++ b/packages/mcp/tests/mcp_communication_protocol.test.ts
@@ -734,8 +734,19 @@ describe("McpCommunicationProtocol", () => {
       expect(processResult({ content: [{ type: "text", text: "42" }], structuredContent: { result: 42 } })).toBe(42);
     });
 
+    test("unwraps a FastMCP-style {result} wrapper around an array", () => {
+      expect(processResult({ content: [], structuredContent: { result: ["a", "b"] } })).toEqual(["a", "b"]);
+    });
+
     test("does not unwrap an object that merely has a result key among others", () => {
       const structured = { result: 1, extra: 2 };
+      expect(processResult({ content: [], structuredContent: structured })).toEqual(structured);
+    });
+
+    test("does not unwrap a genuine single-key object return whose result is itself an object", () => {
+      // FastMCP only wraps non-object returns, so { result: { ... } } is a
+      // real object return from the tool and must keep its shape.
+      const structured = { result: { nested: true } };
       expect(processResult({ content: [], structuredContent: structured })).toEqual(structured);
     });
 

--- a/packages/mcp/tests/mcp_communication_protocol.test.ts
+++ b/packages/mcp/tests/mcp_communication_protocol.test.ts
@@ -440,15 +440,16 @@ describe("McpCommunicationProtocol", () => {
       // its local expiry — evicting only the session would resend the same
       // rejected token on every redial until the TTL ran out.
       const protocol = new McpCommunicationProtocol();
-      (protocol as any)._oauthTokens.set("cid", { accessToken: "revoked", expiresAt: Date.now() + 3600_000 });
       const auth = { auth_type: "oauth2", client_id: "cid", client_secret: "s", token_url: "https://x/token" };
+      const tokenKey = (protocol as any)._oauthCacheKey(auth);
+      (protocol as any)._oauthTokens.set(tokenKey, { accessToken: "revoked", expiresAt: Date.now() + 3600_000 });
       const client = seed(protocol, () =>
         Promise.reject(new Error("HTTP 401 Unauthorized")));
 
       await expect(
         (protocol as any)._withSession("s", CONFIG, auth, () => client.op())
       ).rejects.toThrow("401");
-      expect((protocol as any)._oauthTokens.has("cid")).toBe(false);
+      expect((protocol as any)._oauthTokens.has(tokenKey)).toBe(false);
     });
 
     test("a slower token-fetch variant cannot repopulate the cache after invalidation", async () => {
@@ -466,14 +467,15 @@ describe("McpCommunicationProtocol", () => {
       };
       const auth = { auth_type: "oauth2", client_id: "cid", client_secret: "s", token_url: "https://x/token" };
 
+      const tokenKey = (protocol as any)._oauthCacheKey(auth);
       await expect((protocol as any)._handleOAuth2(auth)).resolves.toBe("fast");
-      expect((protocol as any)._oauthTokens.get("cid")?.accessToken).toBe("fast");
+      expect((protocol as any)._oauthTokens.get(tokenKey)?.accessToken).toBe("fast");
 
       (protocol as any)._invalidateOAuthToken(auth);
       resolveSlow({ data: { access_token: "slow", expires_in: 3600 } });
       await slow;
       await new Promise((r) => setTimeout(r, 0));
-      expect((protocol as any)._oauthTokens.has("cid")).toBe(false);
+      expect((protocol as any)._oauthTokens.has(tokenKey)).toBe(false);
     });
 
     test("a fetch already in flight when the token is invalidated does not cache its result", async () => {
@@ -489,7 +491,7 @@ describe("McpCommunicationProtocol", () => {
 
       // The in-flight attempt still gets its token — only the CACHE is guarded.
       await expect(fetching).resolves.toBe("stale");
-      expect((protocol as any)._oauthTokens.has("cid")).toBe(false);
+      expect((protocol as any)._oauthTokens.has((protocol as any)._oauthCacheKey(auth))).toBe(false);
     });
 
     test("a session whose connect resolves after close() began is closed, not cached", async () => {
@@ -578,8 +580,9 @@ describe("McpCommunicationProtocol", () => {
       // valid OAuth token. An McpError is a well-formed response from a live
       // session; only its -32001 timeout code says anything about health.
       const protocol = new McpCommunicationProtocol();
-      (protocol as any)._oauthTokens.set("cid", { accessToken: "valid", expiresAt: Date.now() + 3600_000 });
       const auth = { auth_type: "oauth2", client_id: "cid", client_secret: "s", token_url: "https://x/token" };
+      const tokenKey = (protocol as any)._oauthCacheKey(auth);
+      (protocol as any)._oauthTokens.set(tokenKey, { accessToken: "valid", expiresAt: Date.now() + 3600_000 });
       const client = seed(protocol, () =>
         Promise.reject(new McpError(-32602, "Authorization header missing for downstream API")));
 
@@ -589,7 +592,7 @@ describe("McpCommunicationProtocol", () => {
       expect(client.closed).toBe(0);
       // Called with auth, so the session is cached under the auth-inclusive key.
       expect((protocol as any)._mcpSessions.get((protocol as any)._sessionKey("s", CONFIG, auth))).toBe(client);
-      expect((protocol as any)._oauthTokens.has("cid")).toBe(true);
+      expect((protocol as any)._oauthTokens.has(tokenKey)).toBe(true);
     });
 
     test("a structured HTTP 401 classifies as auth without relying on message text", async () => {

--- a/packages/mcp/tests/oauth_token_url_security.test.ts
+++ b/packages/mcp/tests/oauth_token_url_security.test.ts
@@ -95,6 +95,18 @@ describe("McpCommunicationProtocol OAuth2 token URL guard", () => {
     expect(results).toEqual(["tok", "tok", "tok", "tok", "tok"]);
     expect(calls).toBe(1);
   });
+
+  test("an access_token that is not a non-empty string is a failed fetch and is never cached", async () => {
+    // A truthy non-string would be formatted into `Bearer 12345` and injected as
+    // an invalid credential on every reuse. A bare `!x` check lets it through,
+    // so this test fails if the string requirement is removed.
+    const protocol: any = new McpCommunicationProtocol();
+    protocol._axiosInstance = { post: async () => ({ data: { access_token: 12345, expires_in: 3600 } }) };
+
+    await expect(protocol._handleOAuth2(auth("https://auth.example.com/token"))).rejects.toThrow("usable");
+    expect(protocol._oauthTokens.size).toBe(0);
+    expect(protocol._oauthInflight.size).toBe(0); // the failed fetch released its slot
+  });
 });
 
 describe("McpCommunicationProtocol OAuth2 in-flight identity lifecycle", () => {

--- a/packages/mcp/tests/oauth_token_url_security.test.ts
+++ b/packages/mcp/tests/oauth_token_url_security.test.ts
@@ -97,29 +97,31 @@ describe("McpCommunicationProtocol OAuth2 token URL guard", () => {
   });
 });
 
-describe("McpCommunicationProtocol OAuth2 generation lifecycle", () => {
+describe("McpCommunicationProtocol OAuth2 in-flight identity lifecycle", () => {
+  // The in-flight entry is the sole authority for who may write the cache. A
+  // fetch caches only if it is still the current entry when it lands, and
+  // removes itself only if still current. There is no version counter.
   const auth = { auth_type: "oauth2", token_url: "https://x/token", client_id: "cid", client_secret: "s", scope: "" };
   const tick = () => new Promise((r) => setTimeout(r, 0));
+  const tok = (v: string) => ({ accessToken: v, expiresAt: Date.now() + 3_600_000 });
+  const cached = (protocol: any) => protocol._oauthTokens.get(protocol._oauthCacheKey(auth))?.accessToken;
 
-  test("invalidating with nothing in flight leaves no generation entry", () => {
+  test("invalidating with nothing in flight leaves no state behind", () => {
     const protocol: any = new McpCommunicationProtocol();
     protocol._invalidateOAuthToken(auth);
-    expect(protocol._oauthGenerations.size).toBe(0);
+    expect(protocol._oauthInflight.size).toBe(0);
+    expect(protocol._oauthTokens.size).toBe(0);
   });
 
-  test("a settled fetch prunes its in-flight entry and generation", async () => {
+  test("a settled fetch caches and removes its own in-flight entry", async () => {
     const protocol: any = new McpCommunicationProtocol();
     protocol._axiosInstance = { post: async () => ({ data: { access_token: "tok", expires_in: 3600 } }) };
-    await protocol._handleOAuth2(auth);
-    await tick(); // let the settle handler run
+    expect(await protocol._handleOAuth2(auth)).toBe("tok");
     expect(protocol._oauthInflight.size).toBe(0);
-    expect(protocol._oauthGenerations.size).toBe(0);
+    expect(cached(protocol)).toBe("tok");
   });
 
-  test("invalidated twice mid-flight still never caches the stale token, then prunes", async () => {
-    // The obvious approach (bump only if an in-flight map entry exists) breaks
-    // here: after the first invalidation removed the entry, a second one would
-    // see nothing in flight, prune the counter, and let the stale fetch cache.
+  test("a fetch invalidated mid-flight (even twice) never caches its stale result", async () => {
     const protocol: any = new McpCommunicationProtocol();
     let resolveFetch!: (v: any) => void;
     const pending = new Promise<any>((res) => { resolveFetch = res; });
@@ -130,26 +132,47 @@ describe("McpCommunicationProtocol OAuth2 generation lifecycle", () => {
     protocol._invalidateOAuthToken(auth); // a second rejection before the fetch lands
     resolveFetch({ data: { access_token: "stale", expires_in: 3600 } });
 
-    await expect(fetching).resolves.toBe("stale");
-    await tick();
-    expect(protocol._oauthTokens.size).toBe(0);
-    expect(protocol._oauthGenerations.size).toBe(0);
+    await expect(fetching).resolves.toBe("stale"); // the caller still gets a token...
+    expect(protocol._oauthTokens.size).toBe(0);     // ...but nothing is cached
     expect(protocol._oauthInflight.size).toBe(0);
   });
 
-  test("a caller arriving after a mid-flight invalidation dials fresh instead of joining", async () => {
+  test("a superseded fetch settling AFTER its replacement cannot repopulate the cache", async () => {
+    // The generation-counter design broke exactly here: the replacement
+    // settling first pruned the counter while the older fetch was still
+    // running, and that older fetch then cached its stale token.
     const protocol: any = new McpCommunicationProtocol();
-    let fetches = 0;
     const gates: Array<(v: any) => void> = [];
-    protocol._fetchOAuth2Token = () => { fetches += 1; return new Promise((res) => gates.push(res)); };
+    protocol._fetchOAuth2Token = () => new Promise((res) => gates.push(res));
 
-    const first = protocol._handleOAuth2(auth);   // fetch #1 in flight
-    protocol._invalidateOAuthToken(auth);          // its generation is now stale
-    const second = protocol._handleOAuth2(auth);  // must NOT join fetch #1
-    expect(fetches).toBe(2);
+    const first = protocol._handleOAuth2(auth);   // fetch #1 is the current entry
+    protocol._invalidateOAuthToken(auth);          // entry dropped; fetch #1 keeps running
+    const second = protocol._handleOAuth2(auth);  // fetch #2 becomes the current entry
+    expect(gates.length).toBe(2);
 
-    const tok = { accessToken: "tok", expiresAt: Date.now() + 3_600_000 };
-    gates.forEach((g) => g(tok));
-    expect(await Promise.all([first, second])).toEqual(["tok", "tok"]);
+    gates[1](tok("fresh"));                        // the replacement settles FIRST
+    expect(await second).toBe("fresh");
+    expect(cached(protocol)).toBe("fresh");
+
+    gates[0](tok("stale"));                        // the superseded fetch settles LAST
+    expect(await first).toBe("stale");             // its caller still receives a token...
+    await tick();
+    expect(cached(protocol)).toBe("fresh");        // ...but it was not current, so the cache kept "fresh"
+    expect(protocol._oauthInflight.size).toBe(0);
+  });
+
+  test("close() drops in-flight entries so a fetch landing afterwards does not cache", async () => {
+    const protocol: any = new McpCommunicationProtocol();
+    let resolveFetch!: (v: any) => void;
+    const pending = new Promise<any>((res) => { resolveFetch = res; });
+    protocol._axiosInstance = { post: () => pending };
+
+    const fetching = protocol._handleOAuth2(auth);
+    await protocol.close();                        // entry dropped mid-fetch
+    resolveFetch({ data: { access_token: "late", expires_in: 3600 } });
+
+    await expect(fetching).resolves.toBe("late");
+    expect(protocol._oauthTokens.size).toBe(0);    // the drain left no credential behind
+    expect(protocol._oauthInflight.size).toBe(0);
   });
 });

--- a/packages/mcp/tests/oauth_token_url_security.test.ts
+++ b/packages/mcp/tests/oauth_token_url_security.test.ts
@@ -70,4 +70,29 @@ describe("McpCommunicationProtocol OAuth2 token URL guard", () => {
       expect(post).toHaveBeenCalled();
     });
   }
+
+  test("concurrent first-time token fetches are coalesced into one request", async () => {
+    const protocol: any = new McpCommunicationProtocol();
+    let calls = 0;
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => { release = resolve; });
+    protocol._fetchOAuth2Token = async (a: any) => {
+      calls += 1;
+      await gate;
+      const token = { accessToken: "tok", expiresAt: Date.now() + 3_600_000 };
+      protocol._oauthTokens.set(a.client_id, token);
+      return token;
+    };
+
+    // All five callers are started synchronously and attach to the shared fetch
+    // before it is released.
+    const pending = Promise.all(
+      [0, 1, 2, 3, 4].map(() => protocol._handleOAuth2(auth("https://auth.example.com/token")))
+    );
+    release();
+    const results = await pending;
+
+    expect(results).toEqual(["tok", "tok", "tok", "tok", "tok"]);
+    expect(calls).toBe(1);
+  });
 });

--- a/packages/mcp/tests/oauth_token_url_security.test.ts
+++ b/packages/mcp/tests/oauth_token_url_security.test.ts
@@ -1,12 +1,11 @@
 // Security: the MCP OAuth2 token endpoint must be validated before the
 // operator's client secret is posted to it, so a manual cannot direct
 // credentials at an arbitrary host. Mirrors the guard the HTTP plugin applies.
-import { test, expect, describe } from "bun:test";
+// The HTTP session is stubbed so the guard is exercised without network I/O.
+import { test, expect, describe, mock } from "bun:test";
 import { McpCommunicationProtocol } from "../src/index";
 
 describe("McpCommunicationProtocol OAuth2 token URL guard", () => {
-  const protocol: any = new McpCommunicationProtocol();
-
   const auth = (tokenUrl: string) => ({
     auth_type: "oauth2",
     token_url: tokenUrl,
@@ -15,16 +14,30 @@ describe("McpCommunicationProtocol OAuth2 token URL guard", () => {
     scope: "",
   });
 
-  test("rejects a non-loopback plain-HTTP token URL before sending credentials", async () => {
+  test("rejects a non-loopback plain-HTTP token URL without ever posting credentials", async () => {
+    const protocol: any = new McpCommunicationProtocol();
+    const post = mock(async () => ({ data: { access_token: "tok", expires_in: 3600 } }));
+    protocol._axiosInstance = { post };
+
     await expect(protocol._handleOAuth2(auth("http://attacker.example/token"))).rejects.toThrow(
       "Security error",
     );
+    // The guard must run before any request: the credential POST is never made.
+    expect(post).toHaveBeenCalledTimes(0);
   });
 
-  test("a loopback token URL passes the guard (then fails on connection, not the guard)", async () => {
-    // Port 1 refuses immediately; the resulting error must not be the guard's.
-    await expect(protocol._handleOAuth2(auth("http://127.0.0.1:1/token"))).rejects.not.toThrow(
-      "Security error",
-    );
+  test("a secure token URL passes the guard and fetches the token", async () => {
+    const protocol: any = new McpCommunicationProtocol();
+    const post = mock(async () => ({ data: { access_token: "tok", expires_in: 3600 } }));
+    protocol._axiosInstance = { post };
+
+    const token = await protocol._handleOAuth2(auth("https://auth.example.com/token"));
+    expect(token).toBe("tok");
+    expect(post).toHaveBeenCalled();
+    // Credential POSTs must disable redirects so a 307/308 can't replay the
+    // client secret to an unvalidated target.
+    for (const call of post.mock.calls) {
+      expect(call[2]).toMatchObject({ maxRedirects: 0 });
+    }
   });
 });

--- a/packages/mcp/tests/oauth_token_url_security.test.ts
+++ b/packages/mcp/tests/oauth_token_url_security.test.ts
@@ -96,16 +96,36 @@ describe("McpCommunicationProtocol OAuth2 token URL guard", () => {
     expect(calls).toBe(1);
   });
 
-  test("an access_token that is not a non-empty string is a failed fetch and is never cached", async () => {
-    // A truthy non-string would be formatted into `Bearer 12345` and injected as
-    // an invalid credential on every reuse. A bare `!x` check lets it through,
-    // so this test fails if the string requirement is removed.
-    const protocol: any = new McpCommunicationProtocol();
-    protocol._axiosInstance = { post: async () => ({ data: { access_token: 12345, expires_in: 3600 } }) };
+  // The usability rule is positive (non-empty visible ASCII), so every shape
+  // that cannot be a valid `Authorization: Bearer <token>` header is rejected
+  // by one rule. Each case here fails if the VCHAR requirement is removed.
+  const unusableTokens: Array<[string, unknown]> = [
+    ["a number", 12345],
+    ["an empty string", ""],
+    ["an embedded space", "tok en"],
+    ["a CR/LF (header injection)", "tok\r\nen"],
+    ["a NUL/control character", "tok\u0000en"],
+    ["non-ASCII", "tok\u00e9n"],
+  ];
+  for (const [label, value] of unusableTokens) {
+    test(`an access_token that is ${label} is a failed fetch and is never cached`, async () => {
+      const protocol: any = new McpCommunicationProtocol();
+      protocol._axiosInstance = { post: async () => ({ data: { access_token: value, expires_in: 3600 } }) };
 
-    await expect(protocol._handleOAuth2(auth("https://auth.example.com/token"))).rejects.toThrow("usable");
-    expect(protocol._oauthTokens.size).toBe(0);
-    expect(protocol._oauthInflight.size).toBe(0); // the failed fetch released its slot
+      await expect(protocol._handleOAuth2(auth("https://auth.example.com/token"))).rejects.toThrow("usable");
+      expect(protocol._oauthTokens.size).toBe(0);
+      expect(protocol._oauthInflight.size).toBe(0); // the failed fetch released its slot
+    });
+  }
+
+  test("a token of printable punctuation is accepted (the rule must not over-reject real tokens)", async () => {
+    // Guards the opposite failure: tightening to RFC 6750's b64token alphabet
+    // would reject legitimate opaque tokens containing e.g. ':'.
+    const protocol: any = new McpCommunicationProtocol();
+    const value = "a.b-c_d~e+f/g=:h";
+    protocol._axiosInstance = { post: async () => ({ data: { access_token: value, expires_in: 3600 } }) };
+
+    expect(await protocol._handleOAuth2(auth("https://auth.example.com/token"))).toBe(value);
   });
 });
 

--- a/packages/mcp/tests/oauth_token_url_security.test.ts
+++ b/packages/mcp/tests/oauth_token_url_security.test.ts
@@ -40,4 +40,16 @@ describe("McpCommunicationProtocol OAuth2 token URL guard", () => {
       expect(call[2]).toMatchObject({ maxRedirects: 0 });
     }
   });
+
+  test("a loopback plain-HTTP token URL passes the guard (local dev)", async () => {
+    // Covers the loopback accept branch of ensureSecureMcpUrl (localhost /
+    // 127.0.0.0/8 / 0.0.0.0 / ::ffff:127.x), which HTTPS alone doesn't exercise.
+    const protocol: any = new McpCommunicationProtocol();
+    const post = mock(async () => ({ data: { access_token: "tok", expires_in: 3600 } }));
+    protocol._axiosInstance = { post };
+
+    const token = await protocol._handleOAuth2(auth("http://127.0.0.1/token"));
+    expect(token).toBe("tok");
+    expect(post).toHaveBeenCalled();
+  });
 });

--- a/packages/mcp/tests/oauth_token_url_security.test.ts
+++ b/packages/mcp/tests/oauth_token_url_security.test.ts
@@ -14,23 +14,32 @@ describe("McpCommunicationProtocol OAuth2 token URL guard", () => {
     scope: "",
   });
 
-  test("rejects a non-loopback plain-HTTP token URL without ever posting credentials", async () => {
+  const freshProtocol = () => {
     const protocol: any = new McpCommunicationProtocol();
     const post = mock(async () => ({ data: { access_token: "tok", expires_in: 3600 } }));
     protocol._axiosInstance = { post };
+    return { protocol, post };
+  };
 
-    await expect(protocol._handleOAuth2(auth("http://attacker.example/token"))).rejects.toThrow(
-      "Security error",
-    );
-    // The guard must run before any request: the credential POST is never made.
-    expect(post).toHaveBeenCalledTimes(0);
-  });
+  // Each form is rejected by a different branch of the guard: a remote
+  // plain-HTTP host, a host that only looks loopback by prefix, and a
+  // non-HTTP(S)/WS scheme.
+  const insecureForms = [
+    "http://attacker.example/token",
+    "http://127.0.0.1.attacker.example/token",
+    "ftp://127.0.0.1/token",
+  ];
+  for (const url of insecureForms) {
+    test(`rejects ${url} without ever posting credentials`, async () => {
+      const { protocol, post } = freshProtocol();
+      await expect(protocol._handleOAuth2(auth(url))).rejects.toThrow("Security error");
+      // The guard must run before any request: the credential POST is never made.
+      expect(post).toHaveBeenCalledTimes(0);
+    });
+  }
 
-  test("a secure token URL passes the guard and fetches the token", async () => {
-    const protocol: any = new McpCommunicationProtocol();
-    const post = mock(async () => ({ data: { access_token: "tok", expires_in: 3600 } }));
-    protocol._axiosInstance = { post };
-
+  test("a secure HTTPS token URL passes the guard and fetches the token", async () => {
+    const { protocol, post } = freshProtocol();
     const token = await protocol._handleOAuth2(auth("https://auth.example.com/token"));
     expect(token).toBe("tok");
     expect(post).toHaveBeenCalled();
@@ -41,15 +50,24 @@ describe("McpCommunicationProtocol OAuth2 token URL guard", () => {
     }
   });
 
-  test("a loopback plain-HTTP token URL passes the guard (local dev)", async () => {
-    // Covers the loopback accept branch of ensureSecureMcpUrl (localhost /
-    // 127.0.0.0/8 / 0.0.0.0 / ::ffff:127.x), which HTTPS alone doesn't exercise.
-    const protocol: any = new McpCommunicationProtocol();
-    const post = mock(async () => ({ data: { access_token: "tok", expires_in: 3600 } }));
-    protocol._axiosInstance = { post };
-
-    const token = await protocol._handleOAuth2(auth("http://127.0.0.1/token"));
-    expect(token).toBe("tok");
-    expect(post).toHaveBeenCalled();
-  });
+  // Each loopback form exercises a different accept branch of the guard:
+  //   localhost / 127.0.0.1  -> the hostname set
+  //   127.0.0.2              -> the 127.0.0.0/8 IPv4 range
+  //   0.0.0.0                -> the wildcard address
+  //   [::ffff:127.0.0.1]     -> IPv4-mapped IPv6 loopback
+  const loopbackForms = [
+    "http://localhost/token",
+    "http://127.0.0.1/token",
+    "http://127.0.0.2/token",
+    "http://0.0.0.0/token",
+    "http://[::ffff:127.0.0.1]/token",
+  ];
+  for (const url of loopbackForms) {
+    test(`loopback token URL passes the guard (local dev): ${url}`, async () => {
+      const { protocol, post } = freshProtocol();
+      const token = await protocol._handleOAuth2(auth(url));
+      expect(token).toBe("tok");
+      expect(post).toHaveBeenCalled();
+    });
+  }
 });

--- a/packages/mcp/tests/oauth_token_url_security.test.ts
+++ b/packages/mcp/tests/oauth_token_url_security.test.ts
@@ -80,7 +80,7 @@ describe("McpCommunicationProtocol OAuth2 token URL guard", () => {
       calls += 1;
       await gate;
       const token = { accessToken: "tok", expiresAt: Date.now() + 3_600_000 };
-      protocol._oauthTokens.set(a.client_id, token);
+      protocol._oauthTokens.set(protocol._oauthCacheKey(a), token);
       return token;
     };
 

--- a/packages/mcp/tests/oauth_token_url_security.test.ts
+++ b/packages/mcp/tests/oauth_token_url_security.test.ts
@@ -1,0 +1,30 @@
+// Security: the MCP OAuth2 token endpoint must be validated before the
+// operator's client secret is posted to it, so a manual cannot direct
+// credentials at an arbitrary host. Mirrors the guard the HTTP plugin applies.
+import { test, expect, describe } from "bun:test";
+import { McpCommunicationProtocol } from "../src/index";
+
+describe("McpCommunicationProtocol OAuth2 token URL guard", () => {
+  const protocol: any = new McpCommunicationProtocol();
+
+  const auth = (tokenUrl: string) => ({
+    auth_type: "oauth2",
+    token_url: tokenUrl,
+    client_id: "id",
+    client_secret: "secret",
+    scope: "",
+  });
+
+  test("rejects a non-loopback plain-HTTP token URL before sending credentials", async () => {
+    await expect(protocol._handleOAuth2(auth("http://attacker.example/token"))).rejects.toThrow(
+      "Security error",
+    );
+  });
+
+  test("a loopback token URL passes the guard (then fails on connection, not the guard)", async () => {
+    // Port 1 refuses immediately; the resulting error must not be the guard's.
+    await expect(protocol._handleOAuth2(auth("http://127.0.0.1:1/token"))).rejects.not.toThrow(
+      "Security error",
+    );
+  });
+});

--- a/packages/mcp/tests/oauth_token_url_security.test.ts
+++ b/packages/mcp/tests/oauth_token_url_security.test.ts
@@ -96,3 +96,60 @@ describe("McpCommunicationProtocol OAuth2 token URL guard", () => {
     expect(calls).toBe(1);
   });
 });
+
+describe("McpCommunicationProtocol OAuth2 generation lifecycle", () => {
+  const auth = { auth_type: "oauth2", token_url: "https://x/token", client_id: "cid", client_secret: "s", scope: "" };
+  const tick = () => new Promise((r) => setTimeout(r, 0));
+
+  test("invalidating with nothing in flight leaves no generation entry", () => {
+    const protocol: any = new McpCommunicationProtocol();
+    protocol._invalidateOAuthToken(auth);
+    expect(protocol._oauthGenerations.size).toBe(0);
+  });
+
+  test("a settled fetch prunes its in-flight entry and generation", async () => {
+    const protocol: any = new McpCommunicationProtocol();
+    protocol._axiosInstance = { post: async () => ({ data: { access_token: "tok", expires_in: 3600 } }) };
+    await protocol._handleOAuth2(auth);
+    await tick(); // let the settle handler run
+    expect(protocol._oauthInflight.size).toBe(0);
+    expect(protocol._oauthGenerations.size).toBe(0);
+  });
+
+  test("invalidated twice mid-flight still never caches the stale token, then prunes", async () => {
+    // The obvious approach (bump only if an in-flight map entry exists) breaks
+    // here: after the first invalidation removed the entry, a second one would
+    // see nothing in flight, prune the counter, and let the stale fetch cache.
+    const protocol: any = new McpCommunicationProtocol();
+    let resolveFetch!: (v: any) => void;
+    const pending = new Promise<any>((res) => { resolveFetch = res; });
+    protocol._axiosInstance = { post: () => pending };
+
+    const fetching = protocol._handleOAuth2(auth);
+    protocol._invalidateOAuthToken(auth);
+    protocol._invalidateOAuthToken(auth); // a second rejection before the fetch lands
+    resolveFetch({ data: { access_token: "stale", expires_in: 3600 } });
+
+    await expect(fetching).resolves.toBe("stale");
+    await tick();
+    expect(protocol._oauthTokens.size).toBe(0);
+    expect(protocol._oauthGenerations.size).toBe(0);
+    expect(protocol._oauthInflight.size).toBe(0);
+  });
+
+  test("a caller arriving after a mid-flight invalidation dials fresh instead of joining", async () => {
+    const protocol: any = new McpCommunicationProtocol();
+    let fetches = 0;
+    const gates: Array<(v: any) => void> = [];
+    protocol._fetchOAuth2Token = () => { fetches += 1; return new Promise((res) => gates.push(res)); };
+
+    const first = protocol._handleOAuth2(auth);   // fetch #1 in flight
+    protocol._invalidateOAuthToken(auth);          // its generation is now stale
+    const second = protocol._handleOAuth2(auth);  // must NOT join fetch #1
+    expect(fetches).toBe(2);
+
+    const tok = { accessToken: "tok", expiresAt: Date.now() + 3_600_000 };
+    gates.forEach((g) => g(tok));
+    expect(await Promise.all([first, second])).toEqual(["tok", "tok"]);
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Replaces the SSE and Streamable HTTP placeholder stubs with working transports, makes CLI `callToolStreaming` yield the completed result as a single chunk, and hardens discovery, authentication, reconnection, session isolation, and error reporting across `@utcp/http` and `@utcp/mcp`, including protections for remote manuals and MCP token endpoints. `@utcp/cli`, `@utcp/http`, and `@utcp/mcp` each get a patch version bump; every change is backward-compatible.

**HTTP**

- HTTP, SSE, and Streamable HTTP map path, header, body, and query arguments and support API-key, Basic, and OAuth2 authentication.
- SSE parses events incrementally, filters by event type, and reconnects dropped GET streams up to five times with `Last-Event-ID`; body-bearing calls are not retried.
- Streamable HTTP parses NDJSON and JSON, re-chunks binary responses, and applies one timeout across token fetch, request, and streaming; GET calls with `body_field` are rejected.
- Failed calls and discovery preserve status and bounded server response bodies on errors, while query strings stay out of logs.
- Manuals discovered from remote origins cannot point tools at loopback URLs; local discovery remains allowed.

**MCP**

- Tool results prefer `structuredContent`, keep the legacy `structured_output` fallback, and unwrap non-object FastMCP `{result}` wrappers.
- Recursive JSON Schema references no longer prevent tool discovery.
- Stdio child stderr is suppressed by default; set `UTCP_MCP_CHILD_STDERR=inherit` to show it.
- MCP validates OAuth2 token URLs before sending client credentials and disables redirects on token POSTs; loopback token URLs remain accepted for local development.
- OAuth state is keyed by the full credential config, so templates sharing a `client_id` but different token URLs, secrets, or scopes don't receive each other's tokens; concurrent fetches for the same config coalesce, and invalidation removes the in-flight entry so a stale fetch never caches while later callers dial fresh.
- OAuth2 responses are usable only when `access_token` is a non-empty visible-ASCII string (RFC 9110 VCHAR); any other shape — including whitespace and control characters — fails the fetch and never reaches the cache.
- Sessions are keyed by a hashed config+auth fingerprint, so manuals with matching server names but different config or credentials no longer share a session; concurrent first-time dials share one transport, and `close()` clears pending dials.

<sup>Written for commit 06d7e38c30375226c6993483894b735fdad909aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/universal-tool-calling-protocol/typescript-utcp/pull/43?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

