### PR TITLE
http: surface the server's error body on failed calls and discovery (lands #26)

### DIFF
--- a/packages/http/src/_text.ts
+++ b/packages/http/src/_text.ts
@@ -1,0 +1,29 @@
+// packages/http/src/_text.ts
+
+/**
+ * Truncate `text` to at most `maxCodePoints` Unicode code points, appending
+ * an ellipsis when anything was cut.
+ *
+ * Works by code point rather than UTF-16 unit so a surrogate pair on the
+ * boundary is dropped whole instead of leaving a lone surrogate. Walks the
+ * string with an iterator and stops at the cap, so a multi-megabyte error
+ * body costs O(cap) work and allocation rather than an array of every
+ * character in the body.
+ */
+export function truncateByCodePoint(text: string, maxCodePoints: number): string {
+  // A string of N UTF-16 units has at most N code points, so short strings
+  // need no walk at all.
+  if (text.length <= maxCodePoints) {
+    return text;
+  }
+  let kept = '';
+  let count = 0;
+  for (const codePoint of text) {
+    if (count === maxCodePoints) {
+      return `${kept}…`;
+    }
+    kept += codePoint;
+    count += 1;
+  }
+  return kept;
+}

--- a/packages/http/src/http_communication_protocol.ts
+++ b/packages/http/src/http_communication_protocol.ts
@@ -247,12 +247,18 @@ export class HttpCommunicationProtocol implements CommunicationProtocol {
     }
     const status = error.response.status;
     const data = error.response.data;
+    // Prefer a string `error` / `message` / `detail` field from the body; some
+    // APIs nest an OBJECT there (e.g. { error: { code, reason } }), so only use
+    // the candidate when it's actually a string — otherwise fall through to the
+    // full JSON so the real structure shows instead of "[object Object]".
+    const stringField = (...candidates: unknown[]): string | undefined =>
+      candidates.find((c): c is string => typeof c === 'string');
     const detail =
       typeof data === 'string'
         ? data
         : data == null
           ? error.message
-          : (data.error ?? data.message ?? data.detail ?? JSON.stringify(data));
+          : (stringField(data.error, data.message, data.detail) ?? JSON.stringify(data));
     const normalized = new Error(
       `HTTP ${status} calling tool '${toolName}': ${detail}`,
     ) as Error & { status: number; data: unknown };

--- a/packages/http/src/http_communication_protocol.ts
+++ b/packages/http/src/http_communication_protocol.ts
@@ -222,8 +222,44 @@ export class HttpCommunicationProtocol implements CommunicationProtocol {
       return response.data;
     } catch (error: any) {
       this._logError(`Error calling HTTP tool '${toolName}':`, error);
-      throw error;
+      throw this._normalizeToolError(toolName, error);
     }
+  }
+
+  /**
+   * Turn a raw axios error into one that actually carries the server's response.
+   *
+   * On a non-2xx, axios throws an `AxiosError` whose `.message` is the generic
+   * `"Request failed with status code 403"` — the response BODY (where servers
+   * put the real reason, e.g. `{ "error": "..." }`) sits on `error.response.data`
+   * and is otherwise lost to every caller that only reads `.message`. That body
+   * is also dropped entirely when the error is serialized across a boundary
+   * (e.g. JSON.stringify in an isolated-vm tool runner), because `Error.message`
+   * is non-enumerable and `AxiosError` doesn't serialize its `response`.
+   *
+   * This folds the status + body into the message AND attaches enumerable
+   * `status` / `data` fields, so the reason survives both `.message` readers and
+   * structured serialization. Non-HTTP errors (network, timeout) pass through.
+   */
+  private _normalizeToolError(toolName: string, error: any): Error {
+    if (!axios.isAxiosError(error) || !error.response) {
+      return error instanceof Error ? error : new Error(String(error));
+    }
+    const status = error.response.status;
+    const data = error.response.data;
+    const detail =
+      typeof data === 'string'
+        ? data
+        : data == null
+          ? error.message
+          : (data.error ?? data.message ?? data.detail ?? JSON.stringify(data));
+    const normalized = new Error(
+      `HTTP ${status} calling tool '${toolName}': ${detail}`,
+    ) as Error & { status: number; data: unknown };
+    // Enumerable so they survive JSON.stringify out of an isolated-vm runner.
+    normalized.status = status;
+    normalized.data = data;
+    return normalized;
   }
 
   /**

--- a/packages/http/src/http_communication_protocol.ts
+++ b/packages/http/src/http_communication_protocol.ts
@@ -14,6 +14,7 @@ import { IUtcpClient } from '@utcp/sdk';
 import { HttpCallTemplateSchema, HttpCallTemplate } from './http_call_template';
 import { OpenApiConverter } from './openapi_converter';
 import { ensureSecureUrl, safeRequestWithRedirects, assertNoCrlf } from './_security';
+import { truncateByCodePoint } from './_text';
 
 /**
  * HTTP communication protocol implementation for UTCP client.
@@ -279,8 +280,7 @@ export class HttpCommunicationProtocol implements CommunicationProtocol {
           : (stringField(data.error, data.message, data.detail) ?? JSON.stringify(data));
     // Truncate by code point, not UTF-16 unit, so a multi-byte character on
     // the boundary is dropped whole rather than leaving a lone surrogate.
-    const codePoints = Array.from(rawDetail);
-    const detail = codePoints.length > MAX_DETAIL_CHARS ? `${codePoints.slice(0, MAX_DETAIL_CHARS).join('')}…` : rawDetail;
+    const detail = truncateByCodePoint(rawDetail, MAX_DETAIL_CHARS);
     const normalized = new Error(
       `HTTP ${status} calling tool '${toolName}': ${detail}`,
     ) as Error & { status: number; data: unknown };

--- a/packages/http/src/http_communication_protocol.ts
+++ b/packages/http/src/http_communication_protocol.ts
@@ -253,12 +253,18 @@ export class HttpCommunicationProtocol implements CommunicationProtocol {
     // full JSON so the real structure shows instead of "[object Object]".
     const stringField = (...candidates: unknown[]): string | undefined =>
       candidates.find((c): c is string => typeof c === 'string');
-    const detail =
+    // A blank body carries no reason: fall back to the status text (then
+    // axios's own message) rather than emitting a message that ends in a
+    // bare colon. Bound the detail so a multi-megabyte error page (an HTML
+    // stack trace, say) does not end up in messages and logs in full.
+    const MAX_DETAIL_CHARS = 2000;
+    const rawDetail =
       typeof data === 'string'
-        ? data
+        ? data.trim() || error.response.statusText || error.message
         : data == null
           ? error.message
           : (stringField(data.error, data.message, data.detail) ?? JSON.stringify(data));
+    const detail = rawDetail.length > MAX_DETAIL_CHARS ? `${rawDetail.slice(0, MAX_DETAIL_CHARS)}…` : rawDetail;
     const normalized = new Error(
       `HTTP ${status} calling tool '${toolName}': ${detail}`,
     ) as Error & { status: number; data: unknown };

--- a/packages/http/src/http_communication_protocol.ts
+++ b/packages/http/src/http_communication_protocol.ts
@@ -277,7 +277,10 @@ export class HttpCommunicationProtocol implements CommunicationProtocol {
         : data == null
           ? error.message
           : (stringField(data.error, data.message, data.detail) ?? JSON.stringify(data));
-    const detail = rawDetail.length > MAX_DETAIL_CHARS ? `${rawDetail.slice(0, MAX_DETAIL_CHARS)}…` : rawDetail;
+    // Truncate by code point, not UTF-16 unit, so a multi-byte character on
+    // the boundary is dropped whole rather than leaving a lone surrogate.
+    const codePoints = Array.from(rawDetail);
+    const detail = codePoints.length > MAX_DETAIL_CHARS ? `${codePoints.slice(0, MAX_DETAIL_CHARS).join('')}…` : rawDetail;
     const normalized = new Error(
       `HTTP ${status} calling tool '${toolName}': ${detail}`,
     ) as Error & { status: number; data: unknown };

--- a/packages/http/src/http_communication_protocol.ts
+++ b/packages/http/src/http_communication_protocol.ts
@@ -251,8 +251,21 @@ export class HttpCommunicationProtocol implements CommunicationProtocol {
     // APIs nest an OBJECT there (e.g. { error: { code, reason } }), so only use
     // the candidate when it's actually a string — otherwise fall through to the
     // full JSON so the real structure shows instead of "[object Object]".
-    const stringField = (...candidates: unknown[]): string | undefined =>
-      candidates.find((c): c is string => typeof c === 'string');
+    // The first of `error` / `message` / `detail` that is present decides: a
+    // non-blank string is the reason; anything else (an object, say) is a
+    // structured error, so return undefined to fall through to the full JSON
+    // rather than skipping ahead to a lower-priority generic string.
+    const stringField = (...candidates: unknown[]): string | undefined => {
+      for (const c of candidates) {
+        if (c === undefined || c === null) continue;
+        if (typeof c === 'string') {
+          if (c.trim()) return c;
+          continue;
+        }
+        return undefined;
+      }
+      return undefined;
+    };
     // A blank body carries no reason: fall back to the status text (then
     // axios's own message) rather than emitting a message that ends in a
     // bare colon. Bound the detail so a multi-megabyte error page (an HTML

--- a/packages/http/src/sse_communication_protocol.ts
+++ b/packages/http/src/sse_communication_protocol.ts
@@ -219,7 +219,9 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
         // (e.g. { "error": "..." }); discarding it leaves callers with only a
         // status code. Fall back to statusText when the body is empty.
         const body = await response.text().catch(() => '');
-        const detail = body.trim() || response.statusText;
+        // Truncate like the streaming path does, so a huge error page does
+        // not land in errors[] and logs in full.
+        const detail = body.trim().slice(0, 200) || response.statusText;
         throw new Error(`HTTP ${response.status}: ${detail}`);
       }
 

--- a/packages/http/src/sse_communication_protocol.ts
+++ b/packages/http/src/sse_communication_protocol.ts
@@ -215,7 +215,12 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
       });
 
       if (!response.ok) {
-        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+        // Read the body before throwing — servers put the real reason there
+        // (e.g. { "error": "..." }); discarding it leaves callers with only a
+        // status code. Fall back to statusText when the body is empty.
+        const body = await response.text().catch(() => '');
+        const detail = body.trim() || response.statusText;
+        throw new Error(`HTTP ${response.status}: ${detail}`);
       }
 
       // Discovery returns the manual as a plain JSON document.

--- a/packages/http/src/sse_communication_protocol.ts
+++ b/packages/http/src/sse_communication_protocol.ts
@@ -220,8 +220,9 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
         // status code. Fall back to statusText when the body is empty.
         const body = await response.text().catch(() => '');
         // Truncate like the streaming path does, so a huge error page does
-        // not land in errors[] and logs in full.
-        const detail = body.trim().slice(0, 200) || response.statusText;
+        // not land in errors[] and logs in full. By code point, so a
+        // multi-byte character on the boundary cannot leave a lone surrogate.
+        const detail = Array.from(body.trim()).slice(0, 200).join('') || response.statusText;
         throw new Error(`HTTP ${response.status}: ${detail}`);
       }
 

--- a/packages/http/src/sse_communication_protocol.ts
+++ b/packages/http/src/sse_communication_protocol.ts
@@ -15,6 +15,7 @@ import { OAuth2UserAuth } from '@utcp/sdk';
 import { IUtcpClient } from '@utcp/sdk';
 import { SseCallTemplate, SseCallTemplateSchema } from './sse_call_template';
 import { ensureSecureUrl, assertNoCrlf } from './_security';
+import { truncateByCodePoint } from './_text';
 
 /**
  * A single parsed Server-Sent Event.
@@ -222,7 +223,7 @@ export class SseCommunicationProtocol implements CommunicationProtocol {
         // Truncate like the streaming path does, so a huge error page does
         // not land in errors[] and logs in full. By code point, so a
         // multi-byte character on the boundary cannot leave a lone surrogate.
-        const detail = Array.from(body.trim()).slice(0, 200).join('') || response.statusText;
+        const detail = truncateByCodePoint(body.trim(), 200) || response.statusText;
         throw new Error(`HTTP ${response.status}: ${detail}`);
       }
 

--- a/packages/http/src/streamable_http_communication_protocol.ts
+++ b/packages/http/src/streamable_http_communication_protocol.ts
@@ -15,6 +15,7 @@ import { OAuth2UserAuth } from '@utcp/sdk';
 import { IUtcpClient } from '@utcp/sdk';
 import { StreamableHttpCallTemplate, StreamableHttpCallTemplateSchema } from './streamable_http_call_template';
 import { ensureSecureUrl, assertNoCrlf } from './_security';
+import { truncateByCodePoint } from './_text';
 
 /**
  * REQUIRED
@@ -175,7 +176,7 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
           // Truncate like the streaming path does, so a huge error page does
           // not land in errors[] and logs in full. By code point, so a
           // multi-byte character on the boundary cannot leave a lone surrogate.
-          const detail = Array.from(body.trim()).slice(0, 200).join('') || response.statusText;
+          const detail = truncateByCodePoint(body.trim(), 200) || response.statusText;
           throw new Error(`HTTP ${response.status}: ${detail}`);
         }
 

--- a/packages/http/src/streamable_http_communication_protocol.ts
+++ b/packages/http/src/streamable_http_communication_protocol.ts
@@ -168,7 +168,12 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
         });
 
         if (!response.ok) {
-          throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+          // Read the body before throwing: servers put the real reason there
+          // (e.g. { "error": "..." }); discarding it leaves callers with only a
+          // status code. Fall back to statusText when the body is empty.
+          const body = await response.text().catch(() => '');
+          const detail = body.trim() || response.statusText;
+          throw new Error(`HTTP ${response.status}: ${detail}`);
         }
 
         const responseText = await response.text();

--- a/packages/http/src/streamable_http_communication_protocol.ts
+++ b/packages/http/src/streamable_http_communication_protocol.ts
@@ -172,7 +172,9 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
           // (e.g. { "error": "..." }); discarding it leaves callers with only a
           // status code. Fall back to statusText when the body is empty.
           const body = await response.text().catch(() => '');
-          const detail = body.trim() || response.statusText;
+          // Truncate like the streaming path does, so a huge error page does
+          // not land in errors[] and logs in full.
+          const detail = body.trim().slice(0, 200) || response.statusText;
           throw new Error(`HTTP ${response.status}: ${detail}`);
         }
 

--- a/packages/http/src/streamable_http_communication_protocol.ts
+++ b/packages/http/src/streamable_http_communication_protocol.ts
@@ -173,8 +173,9 @@ export class StreamableHttpCommunicationProtocol implements CommunicationProtoco
           // status code. Fall back to statusText when the body is empty.
           const body = await response.text().catch(() => '');
           // Truncate like the streaming path does, so a huge error page does
-          // not land in errors[] and logs in full.
-          const detail = body.trim().slice(0, 200) || response.statusText;
+          // not land in errors[] and logs in full. By code point, so a
+          // multi-byte character on the boundary cannot leave a lone surrogate.
+          const detail = Array.from(body.trim()).slice(0, 200).join('') || response.statusText;
           throw new Error(`HTTP ${response.status}: ${detail}`);
         }
 

--- a/packages/http/tests/http_communication_protocol.test.ts
+++ b/packages/http/tests/http_communication_protocol.test.ts
@@ -3,7 +3,12 @@ import { test, expect, describe, beforeAll, afterAll } from "bun:test";
 import express, { Express } from 'express';
 import { Server } from 'http';
 // Import from package index to trigger auto-registration
-import { HttpCommunicationProtocol, HttpCallTemplate } from "@utcp/http";
+import {
+  HttpCommunicationProtocol,
+  HttpCallTemplate,
+  StreamableHttpCommunicationProtocol,
+  SseCommunicationProtocol,
+} from "@utcp/http";
 import { ApiKeyAuth, BasicAuth, OAuth2Auth } from "@utcp/sdk";
 import { IUtcpClient } from "@utcp/sdk";
 
@@ -66,6 +71,11 @@ beforeAll(async () => {
   // refuses a call. Used to prove callTool surfaces that body, not just the status.
   app.post("/forbidden", (req, res) => {
     res.status(403).json({ error: "You are not allowed to do that, and here is exactly why." });
+  });
+
+  // GET variant for the streamable/sse discovery (registerManual) error-body test.
+  app.get("/forbidden-discovery", (req, res) => {
+    res.status(403).send("discovery refused: tenant is not provisioned for streaming");
   });
 
   await new Promise<void>((resolve) => {
@@ -221,5 +231,39 @@ describe("HttpCommunicationProtocol", () => {
       expect(roundTripped.status).toBe(403);
       expect(roundTripped.data).toEqual({ error: "You are not allowed to do that, and here is exactly why." });
     });
+  });
+});
+
+// The streamable/sse protocols' callTool paths are stubs; the only real fetch
+// that can fail with a body is in registerManual (discovery). These prove that
+// failure surfaces the server's body, not just "HTTP 403: Forbidden".
+describe("discovery error body (streamable_http + sse)", () => {
+  test("StreamableHttpCommunicationProtocol.registerManual surfaces the server body", async () => {
+    const protocol = new StreamableHttpCommunicationProtocol();
+    const result = await protocol.registerManual(mockClient, {
+      name: "forbidden_stream",
+      call_template_type: "streamable_http",
+      url: `http://localhost:${serverPort}/forbidden-discovery`,
+      http_method: "GET",
+    } as any);
+
+    expect(result.success).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+    expect(result.errors[0]).toContain("discovery refused: tenant is not provisioned for streaming");
+    expect(result.errors[0]).toContain("403");
+  });
+
+  test("SseCommunicationProtocol.registerManual surfaces the server body", async () => {
+    const protocol = new SseCommunicationProtocol();
+    const result = await protocol.registerManual(mockClient, {
+      name: "forbidden_sse",
+      call_template_type: "sse",
+      url: `http://localhost:${serverPort}/forbidden-discovery`,
+    } as any);
+
+    expect(result.success).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+    expect(result.errors[0]).toContain("discovery refused: tenant is not provisioned for streaming");
+    expect(result.errors[0]).toContain("403");
   });
 });

--- a/packages/http/tests/http_communication_protocol.test.ts
+++ b/packages/http/tests/http_communication_protocol.test.ts
@@ -62,6 +62,12 @@ beforeAll(async () => {
     res.status(500).json({ error: "Internal Server Error" });
   });
 
+  // Returns a non-2xx with a descriptive JSON body, like a real API does when it
+  // refuses a call. Used to prove callTool surfaces that body, not just the status.
+  app.post("/forbidden", (req, res) => {
+    res.status(403).json({ error: "You are not allowed to do that, and here is exactly why." });
+  });
+
   await new Promise<void>((resolve) => {
     server = app.listen(0, () => {
       serverPort = (server.address() as any).port;
@@ -187,6 +193,33 @@ describe("HttpCommunicationProtocol", () => {
       };
       const result = await protocol.callTool(mockClient, "test.tool", {}, callTemplate);
       expect(result.result).toBe("success");
+    });
+
+    test("should surface the server's error body, not just the status code", async () => {
+      const callTemplate: HttpCallTemplate = {
+        name: "forbidden_server",
+        call_template_type: "http",
+        url: `http://localhost:${serverPort}/forbidden`,
+        http_method: "POST",
+      };
+
+      let thrown: any;
+      try {
+        await protocol.callTool(mockClient, "test.forbidden", {}, callTemplate);
+      } catch (e) {
+        thrown = e;
+      }
+
+      expect(thrown).toBeInstanceOf(Error);
+      // The reason the server sent (not just "status code 403") must be present.
+      expect(thrown.message).toContain("You are not allowed to do that, and here is exactly why.");
+      expect(thrown.message).toContain("403");
+      // Enumerable status/data survive structured serialization out of a sandbox.
+      expect(thrown.status).toBe(403);
+      expect(thrown.data).toEqual({ error: "You are not allowed to do that, and here is exactly why." });
+      const roundTripped = JSON.parse(JSON.stringify(thrown));
+      expect(roundTripped.status).toBe(403);
+      expect(roundTripped.data).toEqual({ error: "You are not allowed to do that, and here is exactly why." });
     });
   });
 });

--- a/packages/http/tests/http_communication_protocol.test.ts
+++ b/packages/http/tests/http_communication_protocol.test.ts
@@ -78,6 +78,12 @@ beforeAll(async () => {
     res.status(403).send("discovery refused: tenant is not provisioned for streaming");
   });
 
+  // Some APIs nest an OBJECT under `error` — the message must show its JSON,
+  // not "[object Object]".
+  app.post("/forbidden-object", (req, res) => {
+    res.status(422).json({ error: { code: "INVALID_FIELD", reason: "value out of range" } });
+  });
+
   await new Promise<void>((resolve) => {
     server = app.listen(0, () => {
       serverPort = (server.address() as any).port;
@@ -230,6 +236,31 @@ describe("HttpCommunicationProtocol", () => {
       const roundTripped = JSON.parse(JSON.stringify(thrown));
       expect(roundTripped.status).toBe(403);
       expect(roundTripped.data).toEqual({ error: "You are not allowed to do that, and here is exactly why." });
+    });
+
+    test("should JSON-stringify an object-valued error field, not '[object Object]'", async () => {
+      const callTemplate: HttpCallTemplate = {
+        name: "forbidden_object_server",
+        call_template_type: "http",
+        url: `http://localhost:${serverPort}/forbidden-object`,
+        http_method: "POST",
+      };
+
+      let thrown: any;
+      try {
+        await protocol.callTool(mockClient, "test.forbidden_object", {}, callTemplate);
+      } catch (e) {
+        thrown = e;
+      }
+
+      expect(thrown).toBeInstanceOf(Error);
+      expect(thrown.message).not.toContain("[object Object]");
+      // The structured detail survives in the message...
+      expect(thrown.message).toContain("INVALID_FIELD");
+      expect(thrown.message).toContain("value out of range");
+      // ...and the raw object is preserved on `data`.
+      expect(thrown.status).toBe(422);
+      expect(thrown.data).toEqual({ error: { code: "INVALID_FIELD", reason: "value out of range" } });
     });
   });
 });

--- a/packages/http/tests/http_communication_protocol.test.ts
+++ b/packages/http/tests/http_communication_protocol.test.ts
@@ -97,6 +97,11 @@ beforeAll(async () => {
     res.status(403).type("text/plain").send("x".repeat(5000));
   });
 
+  // A structured `error` next to a generic `message`: the structure must win.
+  app.post("/forbidden-object-then-message", (req, res) => {
+    res.status(422).json({ error: { code: "INVALID_FIELD", reason: "value out of range" }, message: "Request failed" });
+  });
+
   await new Promise<void>((resolve) => {
     server = app.listen(0, () => {
       serverPort = (server.address() as any).port;
@@ -335,6 +340,14 @@ describe("error body edge cases", () => {
     expect(thrown.message).toContain("403");
     expect(thrown.message).toContain("Forbidden");
     expect(thrown.message.trimEnd().endsWith(":")).toBe(false);
+  });
+
+  test("a structured error field wins over a lower-priority generic message", async () => {
+    const thrown = await callForbidden("/forbidden-object-then-message");
+    expect(thrown.status).toBe(422);
+    expect(thrown.message).toContain("INVALID_FIELD");
+    expect(thrown.message).toContain("value out of range");
+    expect(thrown.message).not.toContain("[object Object]");
   });
 
   test("a huge error body is truncated in the message but kept in full on data", async () => {

--- a/packages/http/tests/http_communication_protocol.test.ts
+++ b/packages/http/tests/http_communication_protocol.test.ts
@@ -97,6 +97,11 @@ beforeAll(async () => {
     res.status(403).type("text/plain").send("x".repeat(5000));
   });
 
+  // An emoji sitting exactly on the truncation boundary of the message.
+  app.post("/forbidden-emoji-boundary", (req, res) => {
+    res.status(403).type("text/plain").send("x".repeat(1999) + "😀" + "y".repeat(50));
+  });
+
   // A structured `error` next to a generic `message`: the structure must win.
   app.post("/forbidden-object-then-message", (req, res) => {
     res.status(422).json({ error: { code: "INVALID_FIELD", reason: "value out of range" }, message: "Request failed" });
@@ -348,6 +353,15 @@ describe("error body edge cases", () => {
     expect(thrown.message).toContain("INVALID_FIELD");
     expect(thrown.message).toContain("value out of range");
     expect(thrown.message).not.toContain("[object Object]");
+  });
+
+  test("truncation never splits a surrogate pair", async () => {
+    const thrown = await callForbidden("/forbidden-emoji-boundary");
+    expect(thrown.status).toBe(403);
+    const loneSurrogate = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/;
+    expect(loneSurrogate.test(thrown.message)).toBe(false);
+    expect(thrown.message).toContain("😀");
+    expect(thrown.message).toContain("…");
   });
 
   test("a huge error body is truncated in the message but kept in full on data", async () => {

--- a/packages/http/tests/http_communication_protocol.test.ts
+++ b/packages/http/tests/http_communication_protocol.test.ts
@@ -84,6 +84,19 @@ beforeAll(async () => {
     res.status(422).json({ error: { code: "INVALID_FIELD", reason: "value out of range" } });
   });
 
+  // A refusal with no body at all: the message must still carry a reason.
+  app.post("/forbidden-empty", (req, res) => {
+    res.status(403).end();
+  });
+
+  // A refusal with a huge body (think an HTML stack trace): messages stay bounded.
+  app.post("/forbidden-huge", (req, res) => {
+    res.status(403).type("text/plain").send("x".repeat(5000));
+  });
+  app.get("/forbidden-huge", (req, res) => {
+    res.status(403).type("text/plain").send("x".repeat(5000));
+  });
+
   await new Promise<void>((resolve) => {
     server = app.listen(0, () => {
       serverPort = (server.address() as any).port;
@@ -296,5 +309,51 @@ describe("discovery error body (streamable_http + sse)", () => {
     expect(result.errors.length).toBeGreaterThan(0);
     expect(result.errors[0]).toContain("discovery refused: tenant is not provisioned for streaming");
     expect(result.errors[0]).toContain("403");
+  });
+});
+
+describe("error body edge cases", () => {
+  const callForbidden = async (path: string) => {
+    const protocol = new HttpCommunicationProtocol();
+    try {
+      await protocol.callTool(mockClient, "test.forbidden", {}, {
+        name: "forbidden_server",
+        call_template_type: "http",
+        url: `http://localhost:${serverPort}${path}`,
+        http_method: "POST",
+      } as any);
+    } catch (e) {
+      return e as any;
+    }
+    throw new Error("expected the call to fail");
+  };
+
+  test("a blank error body falls back to the status text instead of a bare colon", async () => {
+    const thrown = await callForbidden("/forbidden-empty");
+    expect(thrown).toBeInstanceOf(Error);
+    expect(thrown.status).toBe(403);
+    expect(thrown.message).toContain("403");
+    expect(thrown.message).toContain("Forbidden");
+    expect(thrown.message.trimEnd().endsWith(":")).toBe(false);
+  });
+
+  test("a huge error body is truncated in the message but kept in full on data", async () => {
+    const thrown = await callForbidden("/forbidden-huge");
+    expect(thrown.status).toBe(403);
+    expect(thrown.message.length).toBeLessThan(2500);
+    expect(thrown.data).toHaveLength(5000);
+  });
+
+  test("a huge discovery error body is truncated in errors[]", async () => {
+    const protocol = new StreamableHttpCommunicationProtocol();
+    const result = await protocol.registerManual(mockClient, {
+      name: "huge_stream",
+      call_template_type: "streamable_http",
+      url: `http://localhost:${serverPort}/forbidden-huge`,
+      http_method: "GET",
+    } as any);
+    expect(result.success).toBe(false);
+    expect(result.errors[0]).toContain("403");
+    expect(result.errors[0].length).toBeLessThan(400);
   });
 });


### PR DESCRIPTION
## Summary

Lands #26 by @edujuan, cherry-picked with authorship preserved, on top of #41 so it applies to the rewritten SSE and Streamable HTTP protocols. **Stacked on #41**: until #41 merges this diff shows its commits too; after that only the three commits from #26 remain.

**What #26 does**
- `HttpCommunicationProtocol.callTool` normalizes a failed call into an `Error` whose message carries the status and the server's body (a string `error` / `message` / `detail` field when the body is JSON, otherwise the JSON itself), with enumerable `status` and `data` fields so the reason survives `JSON.stringify` out of a sandboxed tool runner. Network and timeout errors pass through unchanged.
- SSE and Streamable HTTP discovery read the response body before throwing on a non-2xx, so a refused discovery no longer surfaces as just `HTTP 403: Forbidden` in `errors[]`.

**Conflict resolution**: only the Streamable HTTP discovery block conflicted with #41's rewrite; the body read was re-applied inside the new structure. The SSE hunk merged cleanly.

## Test plan
- [x] #26's four tests (body in message, object-valued error field, streamable and SSE discovery) pass on top of #41
- [x] `bun test packages/http`: 128 pass
- [x] `bun run build` in packages/http succeeds including DTS

Supersedes #26. Companion: universal-tool-calling-protocol/python-utcp#102.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Failed HTTP tool calls and discovery now surface the server's error body instead of a generic status code, so the real reason for a refusal shows up in messages and logs.

- `callTool` errors include the status and body in the message and carry enumerable `status` and `data` fields, so the reason survives `JSON.stringify` out of sandboxed tool runners.
- SSE and Streamable HTTP discovery errors include the response body, truncated to 200 characters, instead of `HTTP 403: Forbidden`.
- Object-valued error fields are JSON-stringified rather than shown as `[object Object]`, and a structured `error` field takes precedence over a generic `message` field.
- A blank body falls back to the status text; tool-call messages cap detail at 2000 characters while `data` keeps the full body.
- Truncation is an O(cap) code-point walk, so huge bodies are not fully materialized and multi-byte characters on the boundary are never split.
- Network and timeout errors pass through unchanged.

<sup>Written for commit 1bd01e5f8e7537634780cb890e95d4d511f751d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/universal-tool-calling-protocol/typescript-utcp/pull/44?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

