### PR TITLE
Dev

### DIFF
--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@utcp/http",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "description": "HTTP utilities for UTCP",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/packages/http/src/_url.ts
+++ b/packages/http/src/_url.ts
@@ -10,6 +10,24 @@
  * not also sent as query parameters. Throws when a parameter is missing.
  */
 export function buildUrlWithPathParams(urlTemplate: string, args: Record<string, any>): string {
+  // A template that IS a single placeholder — `{url}` / `${url}` — names the
+  // WHOLE URL, not a path segment of one. Percent-encoding it corrupts the
+  // scheme (`https://` becomes `https%3A%2F%2F`), after which no request can
+  // ever be made: the security validation downstream rejects the mangled
+  // string. Substitute raw instead — that same validation then sees a real
+  // URL and gets to police it properly. Templates that EMBED placeholders
+  // keep per-segment encoding below, which is what prevents path injection.
+  const wholeUrl = urlTemplate.match(/^\$?\{([^}]+)\}$/);
+  if (wholeUrl) {
+    const paramName = wholeUrl[1];
+    if (!Object.prototype.hasOwnProperty.call(args, paramName)) {
+      throw new Error(`Missing required path parameter: ${paramName}`);
+    }
+    const value = String(args[paramName]);
+    delete args[paramName];
+    return value;
+  }
+
   let url = urlTemplate;
   const placeholders = urlTemplate.match(/\$?\{([^}]+)\}/g) || [];
   const paramNames = Array.from(new Set(

--- a/packages/http/src/_url.ts
+++ b/packages/http/src/_url.ts
@@ -8,23 +8,26 @@
  * replaced (a template may repeat one), values are URL-encoded to prevent
  * path injection, and consumed parameters are removed from `args` so they are
  * not also sent as query parameters. Throws when a parameter is missing.
+ *
+ * ONE exception to the encoding rule: a template that is exactly `{url}` (or
+ * `${url}`) declares that the caller's argument IS the whole URL, and that
+ * argument is substituted raw — encoding it would corrupt the scheme
+ * (`https://` → `https%3A%2F%2F`) and no request could ever be made. The raw
+ * value still passes through the same request-time security validation as an
+ * author-written URL. The exception is deliberately keyed to the placeholder
+ * NAME, not the template's shape: writing `{url}` as the entire template is
+ * an explicit opt-in to a caller-controlled destination, and any other
+ * single-placeholder template (`{endpoint}`, `{path}`) keeps today's encoded
+ * behavior rather than silently gaining that power on a library upgrade.
  */
 export function buildUrlWithPathParams(urlTemplate: string, args: Record<string, any>): string {
-  // A template that IS a single placeholder — `{url}` / `${url}` — names the
-  // WHOLE URL, not a path segment of one. Percent-encoding it corrupts the
-  // scheme (`https://` becomes `https%3A%2F%2F`), after which no request can
-  // ever be made: the security validation downstream rejects the mangled
-  // string. Substitute raw instead — that same validation then sees a real
-  // URL and gets to police it properly. Templates that EMBED placeholders
-  // keep per-segment encoding below, which is what prevents path injection.
-  const wholeUrl = urlTemplate.match(/^\$?\{([^}]+)\}$/);
-  if (wholeUrl) {
-    const paramName = wholeUrl[1];
-    if (!Object.prototype.hasOwnProperty.call(args, paramName)) {
-      throw new Error(`Missing required path parameter: ${paramName}`);
+  // The whole-URL opt-in described above: exactly `{url}` / `${url}`.
+  if (/^\$?\{url\}$/.test(urlTemplate)) {
+    if (!Object.prototype.hasOwnProperty.call(args, 'url')) {
+      throw new Error('Missing required path parameter: url');
     }
-    const value = String(args[paramName]);
-    delete args[paramName];
+    const value = String(args['url']);
+    delete args['url'];
     return value;
   }
 

--- a/packages/http/src/_url.ts
+++ b/packages/http/src/_url.ts
@@ -9,20 +9,26 @@
  * path injection, and consumed parameters are removed from `args` so they are
  * not also sent as query parameters. Throws when a parameter is missing.
  *
- * ONE exception to the encoding rule: a template that is exactly `{url}` (or
- * `${url}`) declares that the caller's argument IS the whole URL, and that
- * argument is substituted raw — encoding it would corrupt the scheme
- * (`https://` → `https%3A%2F%2F`) and no request could ever be made. The raw
- * value still passes through the same request-time security validation as an
+ * ONE exception to the encoding rule: a template that is exactly `{url}`
+ * declares that the caller's argument IS the whole URL, and that argument is
+ * substituted raw — encoding it would corrupt the scheme (`https://` →
+ * `https%3A%2F%2F`) and no request could ever be made. The raw value still
+ * passes through the same request-time security validation as an
  * author-written URL. The exception is deliberately keyed to the placeholder
  * NAME, not the template's shape: writing `{url}` as the entire template is
  * an explicit opt-in to a caller-controlled destination, and any other
  * single-placeholder template (`{endpoint}`, `{path}`) keeps today's encoded
  * behavior rather than silently gaining that power on a library upgrade.
+ *
+ * The `{url}` form only — never `${url}`. The `${...}` syntax belongs to the
+ * client's VARIABLE layer: `DefaultVariableSubstitutor` resolves `${name}`
+ * (and `$name`) against configured variables before any protocol sees the
+ * template, so a `${url}` written in a call template is consumed there and
+ * cannot reach this function through the default client.
  */
 export function buildUrlWithPathParams(urlTemplate: string, args: Record<string, any>): string {
-  // The whole-URL opt-in described above: exactly `{url}` / `${url}`.
-  if (/^\$?\{url\}$/.test(urlTemplate)) {
+  // The whole-URL opt-in described above: exactly `{url}`.
+  if (urlTemplate === '{url}') {
     if (!Object.prototype.hasOwnProperty.call(args, 'url')) {
       throw new Error('Missing required path parameter: url');
     }

--- a/packages/http/tests/url_template.test.ts
+++ b/packages/http/tests/url_template.test.ts
@@ -1,0 +1,50 @@
+// packages/http/tests/url_template.test.ts
+import { test, expect, describe } from "bun:test";
+import { buildUrlWithPathParams } from "../src/_url";
+
+describe("buildUrlWithPathParams", () => {
+  test("encodes embedded path parameters", () => {
+    const args: Record<string, any> = { owner: "a/b", repo: "x y" };
+    const url = buildUrlWithPathParams("https://api.example.com/repos/{owner}/{repo}", args);
+    expect(url).toBe("https://api.example.com/repos/a%2Fb/x%20y");
+    expect(args).toEqual({}); // consumed, so they are not re-sent as query params
+  });
+
+  test("supports the ${param} form and repeated parameters", () => {
+    const args: Record<string, any> = { v: "1" };
+    expect(buildUrlWithPathParams("https://h/${v}/{v}", args)).toBe("https://h/1/1");
+  });
+
+  test("a whole-URL template substitutes raw", () => {
+    // The tool that motivated this: `url: "{url}"` with the full URL as the
+    // argument. Encoding turned `https://` into `https%3A%2F%2F`, and the
+    // scheme check downstream rejected every request the tool could make.
+    const args: Record<string, any> = { url: "https://staging.example.com/api/health?x=1" };
+    const url = buildUrlWithPathParams("{url}", args);
+    expect(url).toBe("https://staging.example.com/api/health?x=1");
+    expect(args).toEqual({});
+  });
+
+  test("a whole-URL template in the ${...} form substitutes raw too", () => {
+    const args: Record<string, any> = { target: "https://h/a b" };
+    expect(buildUrlWithPathParams("${target}", args)).toBe("https://h/a b");
+  });
+
+  test("whole-URL substitution still requires the argument", () => {
+    expect(() => buildUrlWithPathParams("{url}", {})).toThrow("Missing required path parameter: url");
+  });
+
+  test("a template with surrounding text is NOT whole-URL: encoding stays", () => {
+    const args: Record<string, any> = { url: "https://h/x" };
+    // Anything around the placeholder means it is a segment, not the URL.
+    expect(buildUrlWithPathParams("https://proxy/{url}", args)).toBe(
+      "https://proxy/https%3A%2F%2Fh%2Fx",
+    );
+  });
+
+  test("missing embedded parameters still throw", () => {
+    expect(() => buildUrlWithPathParams("https://h/{a}/{b}", { a: "1" } as Record<string, any>)).toThrow(
+      "Missing required path parameter: b",
+    );
+  });
+});

--- a/packages/http/tests/url_template.test.ts
+++ b/packages/http/tests/url_template.test.ts
@@ -26,8 +26,16 @@ describe("buildUrlWithPathParams", () => {
   });
 
   test("a whole-URL template in the ${...} form substitutes raw too", () => {
-    const args: Record<string, any> = { target: "https://h/a b" };
-    expect(buildUrlWithPathParams("${target}", args)).toBe("https://h/a b");
+    const args: Record<string, any> = { url: "https://h/a b" };
+    expect(buildUrlWithPathParams("${url}", args)).toBe("https://h/a b");
+  });
+
+  test("the opt-in is the NAME `url`: other single-placeholder templates keep encoding", () => {
+    // A legacy template like `{endpoint}` must not silently become a
+    // caller-controlled destination on a library upgrade — raw substitution
+    // is only for the explicit `{url}` contract.
+    const args: Record<string, any> = { endpoint: "https://h/x" };
+    expect(buildUrlWithPathParams("{endpoint}", args)).toBe("https%3A%2F%2Fh%2Fx");
   });
 
   test("whole-URL substitution still requires the argument", () => {

--- a/packages/http/tests/url_template.test.ts
+++ b/packages/http/tests/url_template.test.ts
@@ -1,6 +1,8 @@
 // packages/http/tests/url_template.test.ts
 import { test, expect, describe } from "bun:test";
 import { buildUrlWithPathParams } from "../src/_url";
+import { DefaultVariableSubstitutor } from "@utcp/sdk";
+import type { UtcpClientConfig } from "@utcp/sdk";
 
 describe("buildUrlWithPathParams", () => {
   test("encodes embedded path parameters", () => {
@@ -25,9 +27,12 @@ describe("buildUrlWithPathParams", () => {
     expect(args).toEqual({});
   });
 
-  test("a whole-URL template in the ${...} form substitutes raw too", () => {
-    const args: Record<string, any> = { url: "https://h/a b" };
-    expect(buildUrlWithPathParams("${url}", args)).toBe("https://h/a b");
+  test("the ${url} form is NOT the opt-in — that syntax belongs to the variable layer", () => {
+    // Through the default client, `${url}` never reaches this function: the
+    // variable substitutor consumes `${...}` first. If a protocol is driven
+    // directly, the generic (encoding) path applies — no raw substitution.
+    const args: Record<string, any> = { url: "https://h/x" };
+    expect(buildUrlWithPathParams("${url}", args)).toBe("https%3A%2F%2Fh%2Fx");
   });
 
   test("the opt-in is the NAME `url`: other single-placeholder templates keep encoding", () => {
@@ -54,5 +59,34 @@ describe("buildUrlWithPathParams", () => {
     expect(() => buildUrlWithPathParams("https://h/{a}/{b}", { a: "1" } as Record<string, any>)).toThrow(
       "Missing required path parameter: b",
     );
+  });
+});
+
+describe("layering with the client's variable substitutor", () => {
+  // The client substitutes `${...}` (config variables) into call templates
+  // BEFORE any protocol expands `{...}` (path params). These two tests pin
+  // that seam: the `{url}` opt-in survives the variable pass untouched and
+  // reaches buildUrlWithPathParams, while a `${url}` written in a template
+  // is consumed by the variable layer and never gets there.
+  const config = {
+    variables: { url: "https://from-config-vars.example" },
+    load_variables_from: null,
+  } as unknown as UtcpClientConfig;
+
+  test("`{url}` passes through variable substitution untouched", async () => {
+    const substitutor = new DefaultVariableSubstitutor();
+    const template = { url: "{url}", http_method: "GET" };
+    const substituted = await substitutor.substitute(template, config);
+    expect(substituted.url).toBe("{url}");
+    // ...and then the protocol's expansion applies the raw opt-in.
+    const args: Record<string, any> = { url: "https://caller.example/health" };
+    expect(buildUrlWithPathParams(substituted.url, args)).toBe("https://caller.example/health");
+  });
+
+  test("`${url}` is consumed by the variable layer, not the protocol", async () => {
+    const substitutor = new DefaultVariableSubstitutor();
+    const template = { url: "${url}", http_method: "GET" };
+    const substituted = await substitutor.substitute(template, config);
+    expect(substituted.url).toBe("https://from-config-vars.example");
   });
 });


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes URL substitution for templates that are exactly `{url}` so the full URL argument is used as-is instead of being percent-encoded, which previously corrupted the scheme (e.g. `https://` became `https%3A%2F%2F`) and made every request fail downstream validation.

- The raw substitution is opted into only by the placeholder name `{url}`; other single-placeholder templates like `{endpoint}` keep encoding.
- `${url}` is resolved by the client's variable layer before path-param expansion, so it never reaches this branch.

<sup>Written for commit 80d9b9cf5bfe854bd6ed79bc82f22c01276b0956. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/universal-tool-calling-protocol/typescript-utcp/pull/47?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

